### PR TITLE
Composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+  "name": "ezyang/htmlpurifier",
+  "description": "Standards compliant HTML filter written in PHP",
+  "type": "library",
+  "keywords":  [ "html"],
+  "homepage": "http://htmlpurifier.org/",
+  "license": "LGPL",
+  "authors": [
+  {
+    "name": "Edward Z. Yang",
+    "email": "admin@htmlpurifier.org",
+    "homepage": "http://ezyang.com"
+  }
+  ],
+  "require": {
+    "php": ">=5.2"
+  }
+}


### PR DESCRIPTION
Composer.json to make htmlpurifier easily installable via composer.

Composer: http://getcomposer.org/

Since htmlpurifier ist not completely psr-0 compatible or a classmap would be enough for autoloading (defined constants and stuff) the package-description does not contain anything autoload-related, a user has to include htmlpurifiers autoloading himself.

If this PR gets accepted i would create an entry on packagist to allow installing htmlpurifier without the need to declare a repository in projects or other libraries which want to use htmlpurifier using composer.

Packagist: http://packagist.org/
