### PR TITLE
Include path in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,6 @@
   ],
   "require": {
     "php": ">=5.2"
-  }
+  },
+  "include-path": ["library/"]
 }


### PR DESCRIPTION
Added the htmlpurifier/libraries folder to include path in composer.json file so the htmlpurifier can be included and autoloaded easily when installed via composer.
