### PR TITLE
Pollution of a Composer's classmap and a record about usage of Composer

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -142,6 +142,12 @@ Autoload compatibility
     for you, which can collide with an autoloader that was added by *you*
     later.
 
+    If you use the Composer (a tool for dependency management in PHP) you
+    just should manually call HTMLPurifier_Bootstrap::registerAutoloader().
+    This call will register an additional autoloader for HTMLPurifier. You
+    don't need to include or require HTMLPurifier_Bootstrap class itself
+    because Composer will does it for you. See https://getcomposer.org/
+    for an additional information.
 
 For better performance
 ----------------------

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
         "php": ">=5.2"
     },
     "autoload": {
-        "classmap": ["library/"]
+        "files": ["library/HTMLPurifier/Bootstrap.php"]
     }
 }


### PR DESCRIPTION
It's very important to register the HTMLPurifier's autoloader. HTMLPurifier_Boostrap must be called because it defines HTMLPURIFIER_PREFIX constant and has specific rules for converting names of classes. HTMLPurifier loads all its classes and there is a no job for Composer's autoloader. Composer's autoloader must load only HTMLPurifier_Boostrap class. Also, previous code slows down autoloading because of a huge classmap array generated by Composer.

Typical usage with Composer:

``` php
var_dump(spl_autoload_functions());
HTMLPurifier_Bootstrap::registerAutoload();
echo '-----------------' . PHP_EOL;
var_dump(spl_autoload_functions())
$config = HTMLPurifier_Config::createDefault();
$purifier = new HTMLPurifier($config);
$clean_html = $purifier->purify($dirty_html);
```

This code will output:

``` php
array (size=1)
  0 => 
    array (size=2)
      0 => 
        object(Composer\Autoload\ClassLoader)[1]
          private 'prefixes' => 
            array (size=6)
              'Zend\Stdlib' => 
                array (size=1)
                  0 => string '/path/to/vendor/zendframework/zend-stdlib/' (length=56)
          private 'fallbackDirs' => 
            array (size=0)
              empty
          private 'useIncludePath' => boolean false
          private 'classMap' => 
            array (size=0)
              empty
      1 => string 'loadClass' (length=9)
-----------------
array (size=2)
  0 => 
    array (size=2)
      0 => string 'HTMLPurifier_Bootstrap' (length=22)
      1 => string 'autoload' (length=8)
  1 => 
    array (size=2)
      0 => 
        object(Composer\Autoload\ClassLoader)[1]
          private 'prefixes' => 
            array (size=6)
              'Zend\Stdlib' => 
                array (size=1)
                  0 => string '/path/to/vendor/zendframework/zend-stdlib/' (length=56)
          private 'fallbackDirs' => 
            array (size=0)
              empty
          private 'useIncludePath' => boolean false
          private 'classMap' => 
            array (size=0)
              empty
      1 => string 'loadClass' (length=9)
```
