### PR TITLE
Update Composer autoloader to use PSR-0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "php": ">=5.2"
     },
     "autoload": {
-        "classmap": ["library/"]
+        "psr-0": { "HTMLPurifier": "library/" },
+        "files": ["library/HTMLPurifier.composer.php"]
     }
 }

--- a/library/HTMLPurifier.composer.php
+++ b/library/HTMLPurifier.composer.php
@@ -1,0 +1,4 @@
+<?php
+if (!defined('HTMLPURIFIER_PREFIX')) {
+    define('HTMLPURIFIER_PREFIX', __DIR__);
+}


### PR DESCRIPTION
Fixes the composer autoloading to use PSR-0.

Also adds a new include file for the `HTMLPURIFIER_PREFIX` named constant, normally found in Bootstrap.php

It would be better if this named constant could be eliminated, but for the moment this works with the least disturbance to the existing code.
