### PR TITLE
RFC 1738

### DIFF
--- a/library/HTMLPurifier/URIParser.php
+++ b/library/HTMLPurifier/URIParser.php
@@ -30,7 +30,7 @@ class HTMLPurifier_URIParser
         // Note that ["<>] are an addition to the RFC's recommended
         // characters, because they represent external delimeters.
         $r_URI = '!'.
-            '(([^:/?#"<>]+):)?'. // 2. Scheme
+            '(([a-zA-Z0-9\.\+\-]+):)?'. // 2. Scheme
             '(//([^/?#"<>]*))?'. // 4. Authority
             '([^?#"<>]*)'.       // 5. Path
             '(\?([^#"<>]*))?'.   // 7. Query


### PR DESCRIPTION
`<a href="{::test::}" title="Test">test</a>` parsed as `<a title="Test">test</a>`
It happened because of wrong regexp for scheme.
I can write unit test if you can show me how to run it. I can't find test-settings.sample.php to run them.
