### PR TITLE
Fix name clash in Config loadArray

### DIFF
--- a/library/HTMLPurifier/Config.php
+++ b/library/HTMLPurifier/Config.php
@@ -532,8 +532,8 @@ class HTMLPurifier_Config
             } else {
                 $namespace = $key;
                 $namespace_values = $value;
-                foreach ($namespace_values as $directive => $value) {
-                    $this->set($namespace .'.'. $directive, $value);
+                foreach ($namespace_values as $directive => $value2) {
+                    $this->set($namespace .'.'. $directive, $value2);
                 }
             }
         }


### PR DESCRIPTION
The loadArray function in the Config class has a name clash; the inner loop's value variable (`$value`) has the same name as the one in the outer loop. This pull changes the name of the inner value property to avoid the clash.
