### PR TITLE
PSR-2 Reformatting and PHPDoc corrections

### DIFF
--- a/benchmarks/Lexer.php
+++ b/benchmarks/Lexer.php
@@ -23,15 +23,16 @@ if (version_compare(PHP_VERSION, '5', '>=')) {
 class RowTimer extends Benchmark_Timer
 {
 
-    var $name;
+    public $name;
 
-    function RowTimer($name, $auto = false) {
+    public function RowTimer($name, $auto = false)
+    {
         $this->name = htmlentities($name);
         $this->Benchmark_Timer($auto);
     }
 
-    function getOutput() {
-
+    public function getOutput()
+    {
         $total  = $this->TimeElapsed();
         $result = $this->getProfiling();
         $dashes = '';
@@ -68,7 +69,8 @@ class RowTimer extends Benchmark_Timer
     }
 }
 
-function print_lexers() {
+function print_lexers()
+{
     global $LEXERS;
     $first = true;
     foreach ($LEXERS as $key => $value) {
@@ -78,7 +80,8 @@ function print_lexers() {
     }
 }
 
-function do_benchmark($name, $document) {
+function do_benchmark($name, $document)
+{
     global $LEXERS, $RUNS;
 
     $config = HTMLPurifier_Config::createDefault();

--- a/extras/ConfigDoc/HTMLXSLTProcessor.php
+++ b/extras/ConfigDoc/HTMLXSLTProcessor.php
@@ -11,7 +11,8 @@ class ConfigDoc_HTMLXSLTProcessor
      */
     protected $xsltProcessor;
 
-    public function __construct($proc = false) {
+    public function __construct($proc = false)
+    {
         if ($proc === false) $proc = new XSLTProcessor();
         $this->xsltProcessor = $proc;
     }
@@ -19,7 +20,8 @@ class ConfigDoc_HTMLXSLTProcessor
     /**
      * @note Allows a string $xsl filename to be passed
      */
-    public function importStylesheet($xsl) {
+    public function importStylesheet($xsl)
+    {
         if (is_string($xsl)) {
             $xsl_file = $xsl;
             $xsl = new DOMDocument();
@@ -34,7 +36,8 @@ class ConfigDoc_HTMLXSLTProcessor
      * @return string HTML output
      * @todo Rename to transformToXHTML, as transformToHTML is misleading
      */
-    public function transformToHTML($xml) {
+    public function transformToHTML($xml)
+    {
         if (is_string($xml)) {
             $dom = new DOMDocument();
             $dom->load($xml);
@@ -68,7 +71,8 @@ class ConfigDoc_HTMLXSLTProcessor
      * Bulk sets parameters for the XSL stylesheet
      * @param array $options Associative array of options to set
      */
-    public function setParameters($options) {
+    public function setParameters($options)
+    {
         foreach ($options as $name => $value) {
             $this->xsltProcessor->setParameter('', $name, $value);
         }
@@ -77,7 +81,8 @@ class ConfigDoc_HTMLXSLTProcessor
     /**
      * Forward any other calls to the XSLT processor
      */
-    public function __call($name, $arguments) {
+    public function __call($name, $arguments)
+    {
         call_user_func_array(array($this->xsltProcessor, $name), $arguments);
     }
 

--- a/extras/FSTools.php
+++ b/extras/FSTools.php
@@ -15,7 +15,8 @@ class FSTools
     /**
      * Returns a global instance of FSTools
      */
-    static public function singleton() {
+    public static function singleton()
+    {
         if (empty(FSTools::$singleton)) FSTools::$singleton = new FSTools();
         return FSTools::$singleton;
     }
@@ -24,7 +25,8 @@ class FSTools
      * Sets our global singleton to something else; useful for overloading
      * functions.
      */
-    static public function setSingleton($singleton) {
+    public static function setSingleton($singleton)
+    {
         FSTools::$singleton = $singleton;
     }
 
@@ -33,7 +35,8 @@ class FSTools
      * @param string $folder Name of folder to create
      * @note Adapted from the PHP manual comment 76612
      */
-    public function mkdirr($folder) {
+    public function mkdirr($folder)
+    {
         $folders = preg_split("#[\\\\/]#", $folder);
         $base = '';
         for($i = 0, $c = count($folders); $i < $c; $i++) {
@@ -57,7 +60,8 @@ class FSTools
      * so that copied files, if PHP, have includes removed
      * @note Adapted from http://aidanlister.com/repos/v/function.copyr.php
      */
-    public function copyr($source, $dest) {
+    public function copyr($source, $dest)
+    {
         // Simple copy for a file
         if (is_file($source)) {
             return $this->copy($source, $dest);
@@ -92,7 +96,8 @@ class FSTools
      * ignore hidden files, unreadable files, etc. This function
      * applies to copyr().
      */
-    public function copyable($file) {
+    public function copyable($file)
+    {
         return true;
     }
 
@@ -131,7 +136,8 @@ class FSTools
     /**
      * Recursively globs a directory.
      */
-    public function globr($dir, $pattern, $flags = NULL) {
+    public function globr($dir, $pattern, $flags = NULL)
+    {
         $files = $this->glob("$dir/$pattern", $flags);
         if ($files === false) $files = array();
         $sub_dirs = $this->glob("$dir/*", GLOB_ONLYDIR);
@@ -148,7 +154,8 @@ class FSTools
      * @warning This function will not work for functions that need
      *      to pass references; manually define a stub function for those.
      */
-    public function __call($name, $args) {
+    public function __call($name, $args)
+    {
         return call_user_func_array($name, $args);
     }
 

--- a/extras/FSTools/File.php
+++ b/extras/FSTools/File.php
@@ -23,7 +23,8 @@ class FSTools_File
      * Filename of file you wish to instantiate.
      * @note This file need not exist
      */
-    public function __construct($name, $fs = false) {
+    public function __construct($name, $fs = false)
+    {
         $this->name = $name;
         $this->fs = $fs ? $fs : FSTools::singleton();
     }
@@ -38,27 +39,32 @@ class FSTools_File
      * Retrieves the contents of a file
      * @todo Throw an exception if file doesn't exist
      */
-    public function get() {
+    public function get()
+    {
         return $this->fs->file_get_contents($this->name);
     }
 
     /** Writes contents to a file, creates new file if necessary */
-    public function write($contents) {
+    public function write($contents)
+    {
         return $this->fs->file_put_contents($this->name, $contents);
     }
 
     /** Deletes the file */
-    public function delete() {
+    public function delete()
+    {
         return $this->fs->unlink($this->name);
     }
 
     /** Returns true if file exists and is a file. */
-    public function exists() {
+    public function exists()
+    {
         return $this->fs->is_file($this->name);
     }
 
     /** Returns last file modification time */
-    public function getMTime() {
+    public function getMTime()
+    {
         return $this->fs->filemtime($this->name);
     }
 
@@ -67,19 +73,22 @@ class FSTools_File
      * @note We ignore errors because of some weird owner trickery due
      *       to SVN duality
      */
-    public function chmod($octal_code) {
+    public function chmod($octal_code)
+    {
         return @$this->fs->chmod($this->name, $octal_code);
     }
 
     /** Opens file's handle */
-    public function open($mode) {
+    public function open($mode)
+    {
         if ($this->handle) $this->close();
         $this->handle = $this->fs->fopen($this->name, $mode);
         return true;
     }
 
     /** Closes file's handle */
-    public function close() {
+    public function close()
+    {
         if (!$this->handle) return false;
         $status = $this->fs->fclose($this->handle);
         $this->handle = false;
@@ -87,37 +96,43 @@ class FSTools_File
     }
 
     /** Retrieves a line from an open file, with optional max length $length */
-    public function getLine($length = null) {
+    public function getLine($length = null)
+    {
         if (!$this->handle) $this->open('r');
         if ($length === null) return $this->fs->fgets($this->handle);
         else return $this->fs->fgets($this->handle, $length);
     }
 
     /** Retrieves a character from an open file */
-    public function getChar() {
+    public function getChar()
+    {
         if (!$this->handle) $this->open('r');
         return $this->fs->fgetc($this->handle);
     }
 
     /** Retrieves an $length bytes of data from an open data */
-    public function read($length) {
+    public function read($length)
+    {
         if (!$this->handle) $this->open('r');
         return $this->fs->fread($this->handle, $length);
     }
 
     /** Writes to an open file */
-    public function put($string) {
+    public function put($string)
+    {
         if (!$this->handle) $this->open('a');
         return $this->fs->fwrite($this->handle, $string);
     }
 
     /** Returns TRUE if the end of the file has been reached */
-    public function eof() {
+    public function eof()
+    {
         if (!$this->handle) return true;
         return $this->fs->feof($this->handle);
     }
 
-    public function __destruct() {
+    public function __destruct()
+    {
         if ($this->handle) $this->close();
     }
 

--- a/extras/HTMLPurifierExtras.autoload.php
+++ b/extras/HTMLPurifierExtras.autoload.php
@@ -17,7 +17,8 @@ if (function_exists('spl_autoload_register')) {
         spl_autoload_register('__autoload');
     }
 } elseif (!function_exists('__autoload')) {
-    function __autoload($class) {
+    function __autoload($class)
+    {
         return HTMLPurifierExtras::autoload($class);
     }
 }

--- a/extras/HTMLPurifierExtras.php
+++ b/extras/HTMLPurifierExtras.php
@@ -7,14 +7,16 @@
 class HTMLPurifierExtras
 {
 
-    public static function autoload($class) {
+    public static function autoload($class)
+    {
         $path = HTMLPurifierExtras::getPath($class);
         if (!$path) return false;
         require $path;
         return true;
     }
 
-    public static function getPath($class) {
+    public static function getPath($class)
+    {
         if (
             strncmp('FSTools', $class, 7) !== 0 &&
             strncmp('ConfigDoc', $class, 9) !== 0

--- a/library/HTMLPurifier.autoload.php
+++ b/library/HTMLPurifier.autoload.php
@@ -14,7 +14,8 @@ if (function_exists('spl_autoload_register') && function_exists('spl_autoload_un
         spl_autoload_register('__autoload');
     }
 } elseif (!function_exists('__autoload')) {
-    function __autoload($class) {
+    function __autoload($class)
+    {
         return HTMLPurifier_Bootstrap::autoload($class);
     }
 }

--- a/library/HTMLPurifier.func.php
+++ b/library/HTMLPurifier.func.php
@@ -8,11 +8,13 @@
 
 /**
  * Purify HTML.
- * @param $html String HTML to purify
- * @param $config Configuration to use, can be any value accepted by
+ * @param string $html String HTML to purify
+ * @param mixed $config Configuration to use, can be any value accepted by
  *        HTMLPurifier_Config::create()
+ * @return string
  */
-function HTMLPurifier($html, $config = null) {
+function HTMLPurifier($html, $config = null)
+{
     static $purifier = false;
     if (!$purifier) {
         $purifier = new HTMLPurifier();

--- a/library/HTMLPurifier.kses.php
+++ b/library/HTMLPurifier.kses.php
@@ -7,7 +7,8 @@
 
 require_once dirname(__FILE__) . '/HTMLPurifier.auto.php';
 
-function kses($string, $allowed_html, $allowed_protocols = null) {
+function kses($string, $allowed_html, $allowed_protocols = null)
+{
     $config = HTMLPurifier_Config::createDefault();
     $allowed_elements = array();
     $allowed_attributes = array();
@@ -19,7 +20,6 @@ function kses($string, $allowed_html, $allowed_protocols = null) {
     }
     $config->set('HTML.AllowedElements', $allowed_elements);
     $config->set('HTML.AllowedAttributes', $allowed_attributes);
-    $allowed_schemes = array();
     if ($allowed_protocols !== null) {
         $config->set('URI.AllowedSchemes', $allowed_protocols);
     }

--- a/library/HTMLPurifier.php
+++ b/library/HTMLPurifier.php
@@ -55,36 +55,49 @@ class HTMLPurifier
 {
 
     /**
-     * @var string Version of HTML Purifier
+     * Version of HTML Purifier.
+     * @type string
      */
     public $version = '4.5.0';
 
     /**
-     * Constant with version of HTML Purifier
+     * Constant with version of HTML Purifier.
      */
     const VERSION = '4.5.0';
 
     /**
-     * @var HTMLPurifier_Config Global configuration object
+     * Global configuration object.
+     * @type HTMLPurifier_Config
      */
     public $config;
 
     /**
-     * @var HTMLPurifier_Filter[] Array of extra filter objects to run on HTML,
-     * for backwards compatibility
+     * Array of extra filter objects to run on HTML,
+     * for backwards compatibility.
+     * @type HTMLPurifier_Filter[]
      */
     private $filters = array();
 
     /**
-     * @var HTMLPurifier Single instance of HTML Purifier
+     * Single instance of HTML Purifier.
+     * @type HTMLPurifier
      */
     private static $instance;
 
-    protected $strategy, $generator;
+    /**
+     * @type HTMLPurifier_Strategy_Core
+     */
+    protected $strategy;
 
     /**
-     * @var HTMLPurifier_Context Resultant context of last run purification.
+     * @type HTMLPurifier_Generator
+     */
+    protected $generator;
+
+    /**
+     * Resultant context of last run purification.
      * Is an array of contexts if the last called method was purifyArray().
+     * @type HTMLPurifier_Context
      */
     public $context;
 
@@ -98,12 +111,10 @@ class HTMLPurifier
      *                The parameter can also be any type that
      *                HTMLPurifier_Config::create() supports.
      */
-    public function __construct($config = null) {
-
+    public function __construct($config = null)
+    {
         $this->config = HTMLPurifier_Config::create($config);
-
-        $this->strategy     = new HTMLPurifier_Strategy_Core();
-
+        $this->strategy = new HTMLPurifier_Strategy_Core();
     }
 
     /**
@@ -111,9 +122,10 @@ class HTMLPurifier
      *
      * @param HTMLPurifier_Filter $filter HTMLPurifier_Filter object
      */
-    public function addFilter($filter) {
+    public function addFilter($filter)
+    {
         trigger_error(
-            'HTMLPurifier->addFilter() is deprecated, use configuration directives'.
+            'HTMLPurifier->addFilter() is deprecated, use configuration directives' .
             ' in the Filter namespace or Filter.Custom',
             E_USER_WARNING
         );
@@ -131,8 +143,8 @@ class HTMLPurifier
      *
      * @return string Purified HTML
      */
-    public function purify($html, $config = null) {
-
+    public function purify($html, $config = null)
+    {
         // :TODO: make the config merge in, instead of replace
         $config = $config ? HTMLPurifier_Config::create($config) : $this->config;
 
@@ -170,8 +182,12 @@ class HTMLPurifier
         unset($filter_flags['Custom']);
         $filters = array();
         foreach ($filter_flags as $filter => $flag) {
-            if (!$flag) continue;
-            if (strpos($filter, '.') !== false) continue;
+            if (!$flag) {
+                continue;
+            }
+            if (strpos($filter, '.') !== false) {
+                continue;
+            }
             $class = "HTMLPurifier_Filter_$filter";
             $filters[] = new $class;
         }
@@ -194,9 +210,12 @@ class HTMLPurifier
                     // list of un-purified tokens
                     $lexer->tokenizeHTML(
                         // un-purified HTML
-                        $html, $config, $context
+                        $html,
+                        $config,
+                        $context
                     ),
-                    $config, $context
+                    $config,
+                    $context
                 )
             );
 
@@ -218,7 +237,8 @@ class HTMLPurifier
      *
      * @return string[] Array of purified HTML
      */
-    public function purifyArray($array_of_html, $config = null) {
+    public function purifyArray($array_of_html, $config = null)
+    {
         $context_array = array();
         foreach ($array_of_html as $key => $html) {
             $array_of_html[$key] = $this->purify($html, $config);
@@ -238,7 +258,8 @@ class HTMLPurifier
      *
      * @return HTMLPurifier
      */
-    public static function instance($prototype = null) {
+    public static function instance($prototype = null)
+    {
         if (!self::$instance || $prototype) {
             if ($prototype instanceof HTMLPurifier) {
                 self::$instance = $prototype;
@@ -262,10 +283,10 @@ class HTMLPurifier
      * @return HTMLPurifier
      * @note Backwards compatibility, see instance()
      */
-    public static function getInstance($prototype = null) {
+    public static function getInstance($prototype = null)
+    {
         return HTMLPurifier::instance($prototype);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrCollections.php
+++ b/library/HTMLPurifier/AttrCollections.php
@@ -8,7 +8,8 @@ class HTMLPurifier_AttrCollections
 {
 
     /**
-     * Associative array of attribute collections, indexed by name
+     * Associative array of attribute collections, indexed by name.
+     * @type array
      */
     public $info = array();
 
@@ -16,10 +17,11 @@ class HTMLPurifier_AttrCollections
      * Performs all expansions on internal data for use by other inclusions
      * It also collects all attribute collection extensions from
      * modules
-     * @param $attr_types HTMLPurifier_AttrTypes instance
-     * @param $modules Hash array of HTMLPurifier_HTMLModule members
+     * @param HTMLPurifier_AttrTypes $attr_types HTMLPurifier_AttrTypes instance
+     * @param HTMLPurifier_HTMLModule[] $modules Hash array of HTMLPurifier_HTMLModule members
      */
-    public function __construct($attr_types, $modules) {
+    public function __construct($attr_types, $modules)
+    {
         // load extensions from the modules
         foreach ($modules as $module) {
             foreach ($module->attr_collections as $coll_i => $coll) {
@@ -30,7 +32,9 @@ class HTMLPurifier_AttrCollections
                     if ($attr_i === 0 && isset($this->info[$coll_i][$attr_i])) {
                         // merge in includes
                         $this->info[$coll_i][$attr_i] = array_merge(
-                            $this->info[$coll_i][$attr_i], $attr);
+                            $this->info[$coll_i][$attr_i],
+                            $attr
+                        );
                         continue;
                     }
                     $this->info[$coll_i][$attr_i] = $attr;
@@ -49,20 +53,29 @@ class HTMLPurifier_AttrCollections
     /**
      * Takes a reference to an attribute associative array and performs
      * all inclusions specified by the zero index.
-     * @param &$attr Reference to attribute array
+     * @param array &$attr Reference to attribute array
      */
-    public function performInclusions(&$attr) {
-        if (!isset($attr[0])) return;
+    public function performInclusions(&$attr)
+    {
+        if (!isset($attr[0])) {
+            return;
+        }
         $merge = $attr[0];
         $seen  = array(); // recursion guard
         // loop through all the inclusions
         for ($i = 0; isset($merge[$i]); $i++) {
-            if (isset($seen[$merge[$i]])) continue;
+            if (isset($seen[$merge[$i]])) {
+                continue;
+            }
             $seen[$merge[$i]] = true;
             // foreach attribute of the inclusion, copy it over
-            if (!isset($this->info[$merge[$i]])) continue;
+            if (!isset($this->info[$merge[$i]])) {
+                continue;
+            }
             foreach ($this->info[$merge[$i]] as $key => $value) {
-                if (isset($attr[$key])) continue; // also catches more inclusions
+                if (isset($attr[$key])) {
+                    continue;
+                } // also catches more inclusions
                 $attr[$key] = $value;
             }
             if (isset($this->info[$merge[$i]][0])) {
@@ -76,20 +89,24 @@ class HTMLPurifier_AttrCollections
     /**
      * Expands all string identifiers in an attribute array by replacing
      * them with the appropriate values inside HTMLPurifier_AttrTypes
-     * @param &$attr Reference to attribute array
-     * @param $attr_types HTMLPurifier_AttrTypes instance
+     * @param array &$attr Reference to attribute array
+     * @param HTMLPurifier_AttrTypes $attr_types HTMLPurifier_AttrTypes instance
      */
-    public function expandIdentifiers(&$attr, $attr_types) {
-
+    public function expandIdentifiers(&$attr, $attr_types)
+    {
         // because foreach will process new elements we add, make sure we
         // skip duplicates
         $processed = array();
 
         foreach ($attr as $def_i => $def) {
             // skip inclusions
-            if ($def_i === 0) continue;
+            if ($def_i === 0) {
+                continue;
+            }
 
-            if (isset($processed[$def_i])) continue;
+            if (isset($processed[$def_i])) {
+                continue;
+            }
 
             // determine whether or not attribute is required
             if ($required = (strpos($def_i, '*') !== false)) {
@@ -120,9 +137,7 @@ class HTMLPurifier_AttrCollections
                 unset($attr[$def_i]);
             }
         }
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef.php
+++ b/library/HTMLPurifier/AttrDef.php
@@ -14,23 +14,25 @@ abstract class HTMLPurifier_AttrDef
 {
 
     /**
-     * Tells us whether or not an HTML attribute is minimized. Has no
-     * meaning in other contexts.
+     * Tells us whether or not an HTML attribute is minimized.
+     * Has no meaning in other contexts.
+     * @type bool
      */
     public $minimized = false;
 
     /**
-     * Tells us whether or not an HTML attribute is required. Has no
-     * meaning in other contexts
+     * Tells us whether or not an HTML attribute is required.
+     * Has no meaning in other contexts
+     * @type bool
      */
     public $required = false;
 
     /**
      * Validates and cleans passed string according to a definition.
      *
-     * @param $string String to be validated and cleaned.
-     * @param $config Mandatory HTMLPurifier_Config object.
-     * @param $context Mandatory HTMLPurifier_AttrContext object.
+     * @param string $string String to be validated and cleaned.
+     * @param HTMLPurifier_Config $config Mandatory HTMLPurifier_Config object.
+     * @param HTMLPurifier_Context $context Mandatory HTMLPurifier_Context object.
      */
     abstract public function validate($string, $config, $context);
 
@@ -55,7 +57,8 @@ abstract class HTMLPurifier_AttrDef
      *          parsing XML, thus, this behavior may still be correct. We
      *          assume that newlines have been normalized.
      */
-    public function parseCDATA($string) {
+    public function parseCDATA($string)
+    {
         $string = trim($string);
         $string = str_replace(array("\n", "\t", "\r"), ' ', $string);
         return $string;
@@ -63,10 +66,11 @@ abstract class HTMLPurifier_AttrDef
 
     /**
      * Factory method for creating this class from a string.
-     * @param $string String construction info
-     * @return Created AttrDef object corresponding to $string
+     * @param string $string String construction info
+     * @return HTMLPurifier_AttrDef Created AttrDef object corresponding to $string
      */
-    public function make($string) {
+    public function make($string)
+    {
         // default implementation, return a flyweight of this object.
         // If $string has an effect on the returned object (i.e. you
         // need to overload this method), it is best
@@ -77,16 +81,20 @@ abstract class HTMLPurifier_AttrDef
     /**
      * Removes spaces from rgb(0, 0, 0) so that shorthand CSS properties work
      * properly. THIS IS A HACK!
+     * @param string $string a CSS colour definition
+     * @return string
      */
-    protected function mungeRgb($string) {
+    protected function mungeRgb($string)
+    {
         return preg_replace('/rgb\((\d+)\s*,\s*(\d+)\s*,\s*(\d+)\)/', 'rgb(\1,\2,\3)', $string);
     }
 
     /**
-     * Parses a possibly escaped CSS string and returns the "pure" 
+     * Parses a possibly escaped CSS string and returns the "pure"
      * version of it.
      */
-    protected function expandCSSEscape($string) {
+    protected function expandCSSEscape($string)
+    {
         // flexibly parse it
         $ret = '';
         for ($i = 0, $c = strlen($string); $i < $c; $i++) {
@@ -99,25 +107,32 @@ abstract class HTMLPurifier_AttrDef
                 if (ctype_xdigit($string[$i])) {
                     $code = $string[$i];
                     for ($a = 1, $i++; $i < $c && $a < 6; $i++, $a++) {
-                        if (!ctype_xdigit($string[$i])) break;
+                        if (!ctype_xdigit($string[$i])) {
+                            break;
+                        }
                         $code .= $string[$i];
                     }
                     // We have to be extremely careful when adding
                     // new characters, to make sure we're not breaking
                     // the encoding.
                     $char = HTMLPurifier_Encoder::unichr(hexdec($code));
-                    if (HTMLPurifier_Encoder::cleanUTF8($char) === '') continue;
+                    if (HTMLPurifier_Encoder::cleanUTF8($char) === '') {
+                        continue;
+                    }
                     $ret .= $char;
-                    if ($i < $c && trim($string[$i]) !== '') $i--;
+                    if ($i < $c && trim($string[$i]) !== '') {
+                        $i--;
+                    }
                     continue;
                 }
-                if ($string[$i] === "\n") continue;
+                if ($string[$i] === "\n") {
+                    continue;
+                }
             }
             $ret .= $string[$i];
         }
         return $ret;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS.php
+++ b/library/HTMLPurifier/AttrDef/CSS.php
@@ -14,8 +14,14 @@
 class HTMLPurifier_AttrDef_CSS extends HTMLPurifier_AttrDef
 {
 
-    public function validate($css, $config, $context) {
-
+    /**
+     * @param string $css
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($css, $config, $context)
+    {
         $css = $this->parseCDATA($css);
 
         $definition = $config->getCSSDefinition();
@@ -36,34 +42,47 @@ class HTMLPurifier_AttrDef_CSS extends HTMLPurifier_AttrDef
         $context->register('CurrentCSSProperty', $property);
 
         foreach ($declarations as $declaration) {
-            if (!$declaration) continue;
-            if (!strpos($declaration, ':')) continue;
+            if (!$declaration) {
+                continue;
+            }
+            if (!strpos($declaration, ':')) {
+                continue;
+            }
             list($property, $value) = explode(':', $declaration, 2);
             $property = trim($property);
-            $value    = trim($value);
+            $value = trim($value);
             $ok = false;
             do {
                 if (isset($definition->info[$property])) {
                     $ok = true;
                     break;
                 }
-                if (ctype_lower($property)) break;
+                if (ctype_lower($property)) {
+                    break;
+                }
                 $property = strtolower($property);
                 if (isset($definition->info[$property])) {
                     $ok = true;
                     break;
                 }
-            } while(0);
-            if (!$ok) continue;
+            } while (0);
+            if (!$ok) {
+                continue;
+            }
             // inefficient call, since the validator will do this again
             if (strtolower(trim($value)) !== 'inherit') {
                 // inherit works for everything (but only on the base property)
                 $result = $definition->info[$property]->validate(
-                    $value, $config, $context );
+                    $value,
+                    $config,
+                    $context
+                );
             } else {
                 $result = 'inherit';
             }
-            if ($result === false) continue;
+            if ($result === false) {
+                continue;
+            }
             $propvalues[$property] = $result;
         }
 

--- a/library/HTMLPurifier/AttrDef/CSS/AlphaValue.php
+++ b/library/HTMLPurifier/AttrDef/CSS/AlphaValue.php
@@ -3,19 +3,32 @@
 class HTMLPurifier_AttrDef_CSS_AlphaValue extends HTMLPurifier_AttrDef_CSS_Number
 {
 
-    public function __construct() {
+    public function __construct()
+    {
         parent::__construct(false); // opacity is non-negative, but we will clamp it
     }
 
-    public function validate($number, $config, $context) {
+    /**
+     * @param string $number
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return string
+     */
+    public function validate($number, $config, $context)
+    {
         $result = parent::validate($number, $config, $context);
-        if ($result === false) return $result;
-        $float = (float) $result;
-        if ($float < 0.0) $result = '0';
-        if ($float > 1.0) $result = '1';
+        if ($result === false) {
+            return $result;
+        }
+        $float = (float)$result;
+        if ($float < 0.0) {
+            $result = '0';
+        }
+        if ($float > 1.0) {
+            $result = '1';
+        }
         return $result;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/Background.php
+++ b/library/HTMLPurifier/AttrDef/CSS/Background.php
@@ -9,11 +9,16 @@ class HTMLPurifier_AttrDef_CSS_Background extends HTMLPurifier_AttrDef
 
     /**
      * Local copy of component validators.
+     * @type HTMLPurifier_AttrDef[]
      * @note See HTMLPurifier_AttrDef_Font::$info for a similar impl.
      */
     protected $info;
 
-    public function __construct($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function __construct($config)
+    {
         $def = $config->getCSSDefinition();
         $this->info['background-color'] = $def->info['background-color'];
         $this->info['background-image'] = $def->info['background-image'];
@@ -22,11 +27,19 @@ class HTMLPurifier_AttrDef_CSS_Background extends HTMLPurifier_AttrDef
         $this->info['background-position'] = $def->info['background-position'];
     }
 
-    public function validate($string, $config, $context) {
-
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         // regular pre-processing
         $string = $this->parseCDATA($string);
-        if ($string === '') return false;
+        if ($string === '') {
+            return false;
+        }
 
         // munge rgb() decl if necessary
         $string = $this->mungeRgb($string);
@@ -35,27 +48,34 @@ class HTMLPurifier_AttrDef_CSS_Background extends HTMLPurifier_AttrDef
         $bits = explode(' ', $string); // bits to process
 
         $caught = array();
-        $caught['color']    = false;
-        $caught['image']    = false;
-        $caught['repeat']   = false;
+        $caught['color'] = false;
+        $caught['image'] = false;
+        $caught['repeat'] = false;
         $caught['attachment'] = false;
         $caught['position'] = false;
 
         $i = 0; // number of catches
-        $none = false;
 
         foreach ($bits as $bit) {
-            if ($bit === '') continue;
+            if ($bit === '') {
+                continue;
+            }
             foreach ($caught as $key => $status) {
                 if ($key != 'position') {
-                    if ($status !== false) continue;
+                    if ($status !== false) {
+                        continue;
+                    }
                     $r = $this->info['background-' . $key]->validate($bit, $config, $context);
                 } else {
                     $r = $bit;
                 }
-                if ($r === false) continue;
+                if ($r === false) {
+                    continue;
+                }
                 if ($key == 'position') {
-                    if ($caught[$key] === false) $caught[$key] = '';
+                    if ($caught[$key] === false) {
+                        $caught[$key] = '';
+                    }
                     $caught[$key] .= $r . ' ';
                 } else {
                     $caught[$key] = $r;
@@ -65,7 +85,9 @@ class HTMLPurifier_AttrDef_CSS_Background extends HTMLPurifier_AttrDef
             }
         }
 
-        if (!$i) return false;
+        if (!$i) {
+            return false;
+        }
         if ($caught['position'] !== false) {
             $caught['position'] = $this->info['background-position']->
                 validate($caught['position'], $config, $context);
@@ -73,15 +95,17 @@ class HTMLPurifier_AttrDef_CSS_Background extends HTMLPurifier_AttrDef
 
         $ret = array();
         foreach ($caught as $value) {
-            if ($value === false) continue;
+            if ($value === false) {
+                continue;
+            }
             $ret[] = $value;
         }
 
-        if (empty($ret)) return false;
+        if (empty($ret)) {
+            return false;
+        }
         return implode(' ', $ret);
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/BackgroundPosition.php
+++ b/library/HTMLPurifier/AttrDef/CSS/BackgroundPosition.php
@@ -44,15 +44,30 @@
 class HTMLPurifier_AttrDef_CSS_BackgroundPosition extends HTMLPurifier_AttrDef
 {
 
+    /**
+     * @type HTMLPurifier_AttrDef_CSS_Length
+     */
     protected $length;
+
+    /**
+     * @type HTMLPurifier_AttrDef_CSS_Percentage
+     */
     protected $percentage;
 
-    public function __construct() {
-        $this->length     = new HTMLPurifier_AttrDef_CSS_Length();
+    public function __construct()
+    {
+        $this->length = new HTMLPurifier_AttrDef_CSS_Length();
         $this->percentage = new HTMLPurifier_AttrDef_CSS_Percentage();
     }
 
-    public function validate($string, $config, $context) {
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $string = $this->parseCDATA($string);
         $bits = explode(' ', $string);
 
@@ -74,7 +89,9 @@ class HTMLPurifier_AttrDef_CSS_BackgroundPosition extends HTMLPurifier_AttrDef
         );
 
         foreach ($bits as $bit) {
-            if ($bit === '') continue;
+            if ($bit === '') {
+                continue;
+            }
 
             // test for keyword
             $lbit = ctype_lower($bit) ? $bit : strtolower($bit);
@@ -104,30 +121,37 @@ class HTMLPurifier_AttrDef_CSS_BackgroundPosition extends HTMLPurifier_AttrDef
                 $measures[] = $r;
                 $i++;
             }
-
         }
 
-        if (!$i) return false; // no valid values were caught
+        if (!$i) {
+            return false;
+        } // no valid values were caught
 
         $ret = array();
 
         // first keyword
-        if     ($keywords['h'])     $ret[] = $keywords['h'];
-        elseif ($keywords['ch']) {
+        if ($keywords['h']) {
+            $ret[] = $keywords['h'];
+        } elseif ($keywords['ch']) {
             $ret[] = $keywords['ch'];
             $keywords['cv'] = false; // prevent re-use: center = center center
+        } elseif (count($measures)) {
+            $ret[] = array_shift($measures);
         }
-        elseif (count($measures))   $ret[] = array_shift($measures);
 
-        if     ($keywords['v'])     $ret[] = $keywords['v'];
-        elseif ($keywords['cv'])    $ret[] = $keywords['cv'];
-        elseif (count($measures))   $ret[] = array_shift($measures);
+        if ($keywords['v']) {
+            $ret[] = $keywords['v'];
+        } elseif ($keywords['cv']) {
+            $ret[] = $keywords['cv'];
+        } elseif (count($measures)) {
+            $ret[] = array_shift($measures);
+        }
 
-        if (empty($ret)) return false;
+        if (empty($ret)) {
+            return false;
+        }
         return implode(' ', $ret);
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/Border.php
+++ b/library/HTMLPurifier/AttrDef/CSS/Border.php
@@ -8,17 +8,29 @@ class HTMLPurifier_AttrDef_CSS_Border extends HTMLPurifier_AttrDef
 
     /**
      * Local copy of properties this property is shorthand for.
+     * @type HTMLPurifier_AttrDef[]
      */
     protected $info = array();
 
-    public function __construct($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function __construct($config)
+    {
         $def = $config->getCSSDefinition();
         $this->info['border-width'] = $def->info['border-width'];
         $this->info['border-style'] = $def->info['border-style'];
         $this->info['border-top-color'] = $def->info['border-top-color'];
     }
 
-    public function validate($string, $config, $context) {
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $string = $this->parseCDATA($string);
         $string = $this->mungeRgb($string);
         $bits = explode(' ', $string);
@@ -26,7 +38,9 @@ class HTMLPurifier_AttrDef_CSS_Border extends HTMLPurifier_AttrDef
         $ret = ''; // return value
         foreach ($bits as $bit) {
             foreach ($this->info as $propname => $validator) {
-                if (isset($done[$propname])) continue;
+                if (isset($done[$propname])) {
+                    continue;
+                }
                 $r = $validator->validate($bit, $config, $context);
                 if ($r !== false) {
                     $ret .= $r . ' ';
@@ -37,7 +51,6 @@ class HTMLPurifier_AttrDef_CSS_Border extends HTMLPurifier_AttrDef
         }
         return rtrim($ret);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/Color.php
+++ b/library/HTMLPurifier/AttrDef/CSS/Color.php
@@ -6,29 +6,47 @@
 class HTMLPurifier_AttrDef_CSS_Color extends HTMLPurifier_AttrDef
 {
 
-    public function validate($color, $config, $context) {
-
+    /**
+     * @param string $color
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($color, $config, $context)
+    {
         static $colors = null;
-        if ($colors === null) $colors = $config->get('Core.ColorKeywords');
+        if ($colors === null) {
+            $colors = $config->get('Core.ColorKeywords');
+        }
 
         $color = trim($color);
-        if ($color === '') return false;
+        if ($color === '') {
+            return false;
+        }
 
         $lower = strtolower($color);
-        if (isset($colors[$lower])) return $colors[$lower];
+        if (isset($colors[$lower])) {
+            return $colors[$lower];
+        }
 
         if (strpos($color, 'rgb(') !== false) {
             // rgb literal handling
             $length = strlen($color);
-            if (strpos($color, ')') !== $length - 1) return false;
+            if (strpos($color, ')') !== $length - 1) {
+                return false;
+            }
             $triad = substr($color, 4, $length - 4 - 1);
             $parts = explode(',', $triad);
-            if (count($parts) !== 3) return false;
+            if (count($parts) !== 3) {
+                return false;
+            }
             $type = false; // to ensure that they're all the same type
             $new_parts = array();
             foreach ($parts as $part) {
                 $part = trim($part);
-                if ($part === '') return false;
+                if ($part === '') {
+                    return false;
+                }
                 $length = strlen($part);
                 if ($part[$length - 1] === '%') {
                     // handle percents
@@ -37,9 +55,13 @@ class HTMLPurifier_AttrDef_CSS_Color extends HTMLPurifier_AttrDef
                     } elseif ($type !== 'percentage') {
                         return false;
                     }
-                    $num = (float) substr($part, 0, $length - 1);
-                    if ($num < 0) $num = 0;
-                    if ($num > 100) $num = 100;
+                    $num = (float)substr($part, 0, $length - 1);
+                    if ($num < 0) {
+                        $num = 0;
+                    }
+                    if ($num > 100) {
+                        $num = 100;
+                    }
                     $new_parts[] = "$num%";
                 } else {
                     // handle integers
@@ -48,10 +70,14 @@ class HTMLPurifier_AttrDef_CSS_Color extends HTMLPurifier_AttrDef
                     } elseif ($type !== 'integer') {
                         return false;
                     }
-                    $num = (int) $part;
-                    if ($num < 0) $num = 0;
-                    if ($num > 255) $num = 255;
-                    $new_parts[] = (string) $num;
+                    $num = (int)$part;
+                    if ($num < 0) {
+                        $num = 0;
+                    }
+                    if ($num > 255) {
+                        $num = 255;
+                    }
+                    $new_parts[] = (string)$num;
                 }
             }
             $new_triad = implode(',', $new_parts);
@@ -65,14 +91,15 @@ class HTMLPurifier_AttrDef_CSS_Color extends HTMLPurifier_AttrDef
                 $color = '#' . $color;
             }
             $length = strlen($hex);
-            if ($length !== 3 && $length !== 6) return false;
-            if (!ctype_xdigit($hex)) return false;
+            if ($length !== 3 && $length !== 6) {
+                return false;
+            }
+            if (!ctype_xdigit($hex)) {
+                return false;
+            }
         }
-
         return $color;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/Composite.php
+++ b/library/HTMLPurifier/AttrDef/CSS/Composite.php
@@ -13,26 +13,36 @@ class HTMLPurifier_AttrDef_CSS_Composite extends HTMLPurifier_AttrDef
 {
 
     /**
-     * List of HTMLPurifier_AttrDef objects that may process strings
+     * List of objects that may process strings.
+     * @type HTMLPurifier_AttrDef[]
      * @todo Make protected
      */
     public $defs;
 
     /**
-     * @param $defs List of HTMLPurifier_AttrDef objects
+     * @param HTMLPurifier_AttrDef[] $defs List of HTMLPurifier_AttrDef objects
      */
-    public function __construct($defs) {
+    public function __construct($defs)
+    {
         $this->defs = $defs;
     }
 
-    public function validate($string, $config, $context) {
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         foreach ($this->defs as $i => $def) {
             $result = $this->defs[$i]->validate($string, $config, $context);
-            if ($result !== false) return $result;
+            if ($result !== false) {
+                return $result;
+            }
         }
         return false;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/DenyElementDecorator.php
+++ b/library/HTMLPurifier/AttrDef/CSS/DenyElementDecorator.php
@@ -5,22 +5,38 @@
  */
 class HTMLPurifier_AttrDef_CSS_DenyElementDecorator extends HTMLPurifier_AttrDef
 {
-    public $def, $element;
+    /**
+     * @type HTMLPurifier_AttrDef
+     */
+    public $def;
+    /**
+     * @type string
+     */
+    public $element;
 
     /**
-     * @param $def Definition to wrap
-     * @param $element Element to deny
+     * @param HTMLPurifier_AttrDef $def Definition to wrap
+     * @param string $element Element to deny
      */
-    public function __construct($def, $element) {
+    public function __construct($def, $element)
+    {
         $this->def = $def;
         $this->element = $element;
     }
+
     /**
      * Checks if CurrentToken is set and equal to $this->element
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
      */
-    public function validate($string, $config, $context) {
+    public function validate($string, $config, $context)
+    {
         $token = $context->get('CurrentToken', true);
-        if ($token && $token->name == $this->element) return false;
+        if ($token && $token->name == $this->element) {
+            return false;
+        }
         return $this->def->validate($string, $config, $context);
     }
 }

--- a/library/HTMLPurifier/AttrDef/CSS/Filter.php
+++ b/library/HTMLPurifier/AttrDef/CSS/Filter.php
@@ -7,23 +7,37 @@
  */
 class HTMLPurifier_AttrDef_CSS_Filter extends HTMLPurifier_AttrDef
 {
-
+    /**
+     * @type HTMLPurifier_AttrDef_Integer
+     */
     protected $intValidator;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->intValidator = new HTMLPurifier_AttrDef_Integer();
     }
 
-    public function validate($value, $config, $context) {
+    /**
+     * @param string $value
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($value, $config, $context)
+    {
         $value = $this->parseCDATA($value);
-        if ($value === 'none') return $value;
+        if ($value === 'none') {
+            return $value;
+        }
         // if we looped this we could support multiple filters
         $function_length = strcspn($value, '(');
         $function = trim(substr($value, 0, $function_length));
         if ($function !== 'alpha' &&
             $function !== 'Alpha' &&
             $function !== 'progid:DXImageTransform.Microsoft.Alpha'
-            ) return false;
+        ) {
+            return false;
+        }
         $cursor = $function_length + 1;
         $parameters_length = strcspn($value, ')', $cursor);
         $parameters = substr($value, $cursor, $parameters_length);
@@ -32,15 +46,25 @@ class HTMLPurifier_AttrDef_CSS_Filter extends HTMLPurifier_AttrDef
         $lookup = array();
         foreach ($params as $param) {
             list($key, $value) = explode('=', $param);
-            $key   = trim($key);
+            $key = trim($key);
             $value = trim($value);
-            if (isset($lookup[$key])) continue;
-            if ($key !== 'opacity') continue;
+            if (isset($lookup[$key])) {
+                continue;
+            }
+            if ($key !== 'opacity') {
+                continue;
+            }
             $value = $this->intValidator->validate($value, $config, $context);
-            if ($value === false) continue;
-            $int = (int) $value;
-            if ($int > 100) $value = '100';
-            if ($int < 0) $value = '0';
+            if ($value === false) {
+                continue;
+            }
+            $int = (int)$value;
+            if ($int > 100) {
+                $value = '100';
+            }
+            if ($int < 0) {
+                $value = '0';
+            }
             $ret_params[] = "$key=$value";
             $lookup[$key] = true;
         }
@@ -48,7 +72,6 @@ class HTMLPurifier_AttrDef_CSS_Filter extends HTMLPurifier_AttrDef
         $ret_function = "$function($ret_parameters)";
         return $ret_function;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/FontFamily.php
+++ b/library/HTMLPurifier/AttrDef/CSS/FontFamily.php
@@ -8,11 +8,18 @@ class HTMLPurifier_AttrDef_CSS_FontFamily extends HTMLPurifier_AttrDef
 
     protected $mask = null;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->mask = '_- ';
-        for ($c = 'a'; $c <= 'z'; $c++) $this->mask .= $c;
-        for ($c = 'A'; $c <= 'Z'; $c++) $this->mask .= $c;
-        for ($c = '0'; $c <= '9'; $c++) $this->mask .= $c; // cast-y, but should be fine
+        for ($c = 'a'; $c <= 'z'; $c++) {
+            $this->mask .= $c;
+        }
+        for ($c = 'A'; $c <= 'Z'; $c++) {
+            $this->mask .= $c;
+        }
+        for ($c = '0'; $c <= '9'; $c++) {
+            $this->mask .= $c;
+        } // cast-y, but should be fine
         // special bytes used by UTF-8
         for ($i = 0x80; $i <= 0xFF; $i++) {
             // We don't bother excluding invalid bytes in this range,
@@ -39,7 +46,14 @@ class HTMLPurifier_AttrDef_CSS_FontFamily extends HTMLPurifier_AttrDef
         // possible optimization: invert the mask.
     }
 
-    public function validate($string, $config, $context) {
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         static $generic_names = array(
             'serif' => true,
             'sans-serif' => true,
@@ -52,9 +66,11 @@ class HTMLPurifier_AttrDef_CSS_FontFamily extends HTMLPurifier_AttrDef
         // assume that no font names contain commas in them
         $fonts = explode(',', $string);
         $final = '';
-        foreach($fonts as $font) {
+        foreach ($fonts as $font) {
             $font = trim($font);
-            if ($font === '') continue;
+            if ($font === '') {
+                continue;
+            }
             // match a generic name
             if (isset($generic_names[$font])) {
                 if ($allowed_fonts === null || isset($allowed_fonts[$font])) {
@@ -65,9 +81,13 @@ class HTMLPurifier_AttrDef_CSS_FontFamily extends HTMLPurifier_AttrDef
             // match a quoted name
             if ($font[0] === '"' || $font[0] === "'") {
                 $length = strlen($font);
-                if ($length <= 2) continue;
+                if ($length <= 2) {
+                    continue;
+                }
                 $quote = $font[0];
-                if ($font[$length - 1] !== $quote) continue;
+                if ($font[$length - 1] !== $quote) {
+                    continue;
+                }
                 $font = substr($font, 1, $length - 2);
             }
 
@@ -188,7 +208,9 @@ class HTMLPurifier_AttrDef_CSS_FontFamily extends HTMLPurifier_AttrDef
             $final .= "'$font', ";
         }
         $final = rtrim($final, ', ');
-        if ($final === '') return false;
+        if ($final === '') {
+            return false;
+        }
         return $final;
     }
 

--- a/library/HTMLPurifier/AttrDef/CSS/Ident.php
+++ b/library/HTMLPurifier/AttrDef/CSS/Ident.php
@@ -6,19 +6,27 @@
 class HTMLPurifier_AttrDef_CSS_Ident extends HTMLPurifier_AttrDef
 {
 
-    public function validate($string, $config, $context) {
-
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $string = trim($string);
 
         // early abort: '' and '0' (strings that convert to false) are invalid
-        if (!$string) return false;
+        if (!$string) {
+            return false;
+        }
 
         $pattern = '/^(-?[A-Za-z_][A-Za-z_\-0-9]*)$/';
-        if (!preg_match($pattern, $string)) return false;
+        if (!preg_match($pattern, $string)) {
+            return false;
+        }
         return $string;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/ImportantDecorator.php
+++ b/library/HTMLPurifier/AttrDef/CSS/ImportantDecorator.php
@@ -5,20 +5,34 @@
  */
 class HTMLPurifier_AttrDef_CSS_ImportantDecorator extends HTMLPurifier_AttrDef
 {
-    public $def, $allow;
+    /**
+     * @type HTMLPurifier_AttrDef
+     */
+    public $def;
+    /**
+     * @type bool
+     */
+    public $allow;
 
     /**
-     * @param $def Definition to wrap
-     * @param $allow Whether or not to allow !important
+     * @param HTMLPurifier_AttrDef $def Definition to wrap
+     * @param bool $allow Whether or not to allow !important
      */
-    public function __construct($def, $allow = false) {
+    public function __construct($def, $allow = false)
+    {
         $this->def = $def;
         $this->allow = $allow;
     }
+
     /**
      * Intercepts and removes !important if necessary
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
      */
-    public function validate($string, $config, $context) {
+    public function validate($string, $config, $context)
+    {
         // test for ! and important tokens
         $string = trim($string);
         $is_important = false;
@@ -32,7 +46,9 @@ class HTMLPurifier_AttrDef_CSS_ImportantDecorator extends HTMLPurifier_AttrDef
             }
         }
         $string = $this->def->validate($string, $config, $context);
-        if ($this->allow && $is_important) $string .= ' !important';
+        if ($this->allow && $is_important) {
+            $string .= ' !important';
+        }
         return $string;
     }
 }

--- a/library/HTMLPurifier/AttrDef/CSS/Length.php
+++ b/library/HTMLPurifier/AttrDef/CSS/Length.php
@@ -6,42 +6,72 @@
 class HTMLPurifier_AttrDef_CSS_Length extends HTMLPurifier_AttrDef
 {
 
-    protected $min, $max;
+    /**
+     * @type HTMLPurifier_Length|string
+     */
+    protected $min;
 
     /**
-     * @param HTMLPurifier_Length $max Minimum length, or null for no bound. String is also acceptable.
-     * @param HTMLPurifier_Length $max Maximum length, or null for no bound. String is also acceptable.
+     * @type HTMLPurifier_Length|string
      */
-    public function __construct($min = null, $max = null) {
+    protected $max;
+
+    /**
+     * @param HTMLPurifier_Length|string $min Minimum length, or null for no bound. String is also acceptable.
+     * @param HTMLPurifier_Length|string $max Maximum length, or null for no bound. String is also acceptable.
+     */
+    public function __construct($min = null, $max = null)
+    {
         $this->min = $min !== null ? HTMLPurifier_Length::make($min) : null;
         $this->max = $max !== null ? HTMLPurifier_Length::make($max) : null;
     }
 
-    public function validate($string, $config, $context) {
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $string = $this->parseCDATA($string);
 
         // Optimizations
-        if ($string === '') return false;
-        if ($string === '0') return '0';
-        if (strlen($string) === 1) return false;
+        if ($string === '') {
+            return false;
+        }
+        if ($string === '0') {
+            return '0';
+        }
+        if (strlen($string) === 1) {
+            return false;
+        }
 
         $length = HTMLPurifier_Length::make($string);
-        if (!$length->isValid()) return false;
+        if (!$length->isValid()) {
+            return false;
+        }
 
         if ($this->min) {
             $c = $length->compareTo($this->min);
-            if ($c === false) return false;
-            if ($c < 0) return false;
+            if ($c === false) {
+                return false;
+            }
+            if ($c < 0) {
+                return false;
+            }
         }
         if ($this->max) {
             $c = $length->compareTo($this->max);
-            if ($c === false) return false;
-            if ($c > 0) return false;
+            if ($c === false) {
+                return false;
+            }
+            if ($c > 0) {
+                return false;
+            }
         }
-
         return $length->toString();
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/ListStyle.php
+++ b/library/HTMLPurifier/AttrDef/CSS/ListStyle.php
@@ -8,46 +8,72 @@ class HTMLPurifier_AttrDef_CSS_ListStyle extends HTMLPurifier_AttrDef
 {
 
     /**
-     * Local copy of component validators.
+     * Local copy of validators.
+     * @type HTMLPurifier_AttrDef[]
      * @note See HTMLPurifier_AttrDef_CSS_Font::$info for a similar impl.
      */
     protected $info;
 
-    public function __construct($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function __construct($config)
+    {
         $def = $config->getCSSDefinition();
-        $this->info['list-style-type']     = $def->info['list-style-type'];
+        $this->info['list-style-type'] = $def->info['list-style-type'];
         $this->info['list-style-position'] = $def->info['list-style-position'];
         $this->info['list-style-image'] = $def->info['list-style-image'];
     }
 
-    public function validate($string, $config, $context) {
-
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         // regular pre-processing
         $string = $this->parseCDATA($string);
-        if ($string === '') return false;
+        if ($string === '') {
+            return false;
+        }
 
         // assumes URI doesn't have spaces in it
         $bits = explode(' ', strtolower($string)); // bits to process
 
         $caught = array();
-        $caught['type']     = false;
+        $caught['type'] = false;
         $caught['position'] = false;
-        $caught['image']    = false;
+        $caught['image'] = false;
 
         $i = 0; // number of catches
         $none = false;
 
         foreach ($bits as $bit) {
-            if ($i >= 3) return; // optimization bit
-            if ($bit === '') continue;
+            if ($i >= 3) {
+                return;
+            } // optimization bit
+            if ($bit === '') {
+                continue;
+            }
             foreach ($caught as $key => $status) {
-                if ($status !== false) continue;
+                if ($status !== false) {
+                    continue;
+                }
                 $r = $this->info['list-style-' . $key]->validate($bit, $config, $context);
-                if ($r === false) continue;
+                if ($r === false) {
+                    continue;
+                }
                 if ($r === 'none') {
-                    if ($none) continue;
-                    else $none = true;
-                    if ($key == 'image') continue;
+                    if ($none) {
+                        continue;
+                    } else {
+                        $none = true;
+                    }
+                    if ($key == 'image') {
+                        continue;
+                    }
                 }
                 $caught[$key] = $r;
                 $i++;
@@ -55,24 +81,32 @@ class HTMLPurifier_AttrDef_CSS_ListStyle extends HTMLPurifier_AttrDef
             }
         }
 
-        if (!$i) return false;
+        if (!$i) {
+            return false;
+        }
 
         $ret = array();
 
         // construct type
-        if ($caught['type']) $ret[] = $caught['type'];
+        if ($caught['type']) {
+            $ret[] = $caught['type'];
+        }
 
         // construct image
-        if ($caught['image']) $ret[] = $caught['image'];
+        if ($caught['image']) {
+            $ret[] = $caught['image'];
+        }
 
         // construct position
-        if ($caught['position']) $ret[] = $caught['position'];
+        if ($caught['position']) {
+            $ret[] = $caught['position'];
+        }
 
-        if (empty($ret)) return false;
+        if (empty($ret)) {
+            return false;
+        }
         return implode(' ', $ret);
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/Multiple.php
+++ b/library/HTMLPurifier/AttrDef/CSS/Multiple.php
@@ -13,9 +13,9 @@
  */
 class HTMLPurifier_AttrDef_CSS_Multiple extends HTMLPurifier_AttrDef
 {
-
     /**
      * Instance of component definition to defer validation to.
+     * @type HTMLPurifier_AttrDef
      * @todo Make protected
      */
     public $single;
@@ -27,32 +27,45 @@ class HTMLPurifier_AttrDef_CSS_Multiple extends HTMLPurifier_AttrDef
     public $max;
 
     /**
-     * @param $single HTMLPurifier_AttrDef to multiply
-     * @param $max Max number of values allowed (usually four)
+     * @param HTMLPurifier_AttrDef $single HTMLPurifier_AttrDef to multiply
+     * @param int $max Max number of values allowed (usually four)
      */
-    public function __construct($single, $max = 4) {
+    public function __construct($single, $max = 4)
+    {
         $this->single = $single;
         $this->max = $max;
     }
 
-    public function validate($string, $config, $context) {
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $string = $this->parseCDATA($string);
-        if ($string === '') return false;
+        if ($string === '') {
+            return false;
+        }
         $parts = explode(' ', $string); // parseCDATA replaced \r, \t and \n
         $length = count($parts);
         $final = '';
         for ($i = 0, $num = 0; $i < $length && $num < $this->max; $i++) {
-            if (ctype_space($parts[$i])) continue;
+            if (ctype_space($parts[$i])) {
+                continue;
+            }
             $result = $this->single->validate($parts[$i], $config, $context);
             if ($result !== false) {
                 $final .= $result . ' ';
                 $num++;
             }
         }
-        if ($final === '') return false;
+        if ($final === '') {
+            return false;
+        }
         return rtrim($final);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/Number.php
+++ b/library/HTMLPurifier/AttrDef/CSS/Number.php
@@ -7,32 +7,44 @@ class HTMLPurifier_AttrDef_CSS_Number extends HTMLPurifier_AttrDef
 {
 
     /**
-     * Bool indicating whether or not only positive values allowed.
+     * Indicates whether or not only positive values are allowed.
+     * @type bool
      */
     protected $non_negative = false;
 
     /**
-     * @param $non_negative Bool indicating whether negatives are forbidden
+     * @param bool $non_negative indicates whether negatives are forbidden
      */
-    public function __construct($non_negative = false) {
+    public function __construct($non_negative = false)
+    {
         $this->non_negative = $non_negative;
     }
 
     /**
+     * @param string $number
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return string|bool
      * @warning Some contexts do not pass $config, $context. These
      *          variables should not be used without checking HTMLPurifier_Length
      */
-    public function validate($number, $config, $context) {
-
+    public function validate($number, $config, $context)
+    {
         $number = $this->parseCDATA($number);
 
-        if ($number === '') return false;
-        if ($number === '0') return '0';
+        if ($number === '') {
+            return false;
+        }
+        if ($number === '0') {
+            return '0';
+        }
 
         $sign = '';
         switch ($number[0]) {
             case '-':
-                if ($this->non_negative) return false;
+                if ($this->non_negative) {
+                    return false;
+                }
                 $sign = '-';
             case '+':
                 $number = substr($number, 1);
@@ -44,14 +56,20 @@ class HTMLPurifier_AttrDef_CSS_Number extends HTMLPurifier_AttrDef
         }
 
         // Period is the only non-numeric character allowed
-        if (strpos($number, '.') === false) return false;
+        if (strpos($number, '.') === false) {
+            return false;
+        }
 
         list($left, $right) = explode('.', $number, 2);
 
-        if ($left === '' && $right === '') return false;
-        if ($left !== '' && !ctype_digit($left)) return false;
+        if ($left === '' && $right === '') {
+            return false;
+        }
+        if ($left !== '' && !ctype_digit($left)) {
+            return false;
+        }
 
-        $left  = ltrim($left,  '0');
+        $left = ltrim($left, '0');
         $right = rtrim($right, '0');
 
         if ($right === '') {
@@ -59,11 +77,8 @@ class HTMLPurifier_AttrDef_CSS_Number extends HTMLPurifier_AttrDef
         } elseif (!ctype_digit($right)) {
             return false;
         }
-
         return $sign . $left . '.' . $right;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/Percentage.php
+++ b/library/HTMLPurifier/AttrDef/CSS/Percentage.php
@@ -7,34 +7,48 @@ class HTMLPurifier_AttrDef_CSS_Percentage extends HTMLPurifier_AttrDef
 {
 
     /**
-     * Instance of HTMLPurifier_AttrDef_CSS_Number to defer number validation
+     * Instance to defer number validation to.
+     * @type HTMLPurifier_AttrDef_CSS_Number
      */
     protected $number_def;
 
     /**
-     * @param Bool indicating whether to forbid negative values
+     * @param bool $non_negative Whether to forbid negative values
      */
-    public function __construct($non_negative = false) {
+    public function __construct($non_negative = false)
+    {
         $this->number_def = new HTMLPurifier_AttrDef_CSS_Number($non_negative);
     }
 
-    public function validate($string, $config, $context) {
-
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $string = $this->parseCDATA($string);
 
-        if ($string === '') return false;
+        if ($string === '') {
+            return false;
+        }
         $length = strlen($string);
-        if ($length === 1) return false;
-        if ($string[$length - 1] !== '%') return false;
+        if ($length === 1) {
+            return false;
+        }
+        if ($string[$length - 1] !== '%') {
+            return false;
+        }
 
         $number = substr($string, 0, $length - 1);
         $number = $this->number_def->validate($number, $config, $context);
 
-        if ($number === false) return false;
+        if ($number === false) {
+            return false;
+        }
         return "$number%";
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/TextDecoration.php
+++ b/library/HTMLPurifier/AttrDef/CSS/TextDecoration.php
@@ -8,8 +8,14 @@
 class HTMLPurifier_AttrDef_CSS_TextDecoration extends HTMLPurifier_AttrDef
 {
 
-    public function validate($string, $config, $context) {
-
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         static $allowed_values = array(
             'line-through' => true,
             'overline' => true,
@@ -18,7 +24,9 @@ class HTMLPurifier_AttrDef_CSS_TextDecoration extends HTMLPurifier_AttrDef
 
         $string = strtolower($this->parseCDATA($string));
 
-        if ($string === 'none') return $string;
+        if ($string === 'none') {
+            return $string;
+        }
 
         $parts = explode(' ', $string);
         $final = '';
@@ -28,11 +36,11 @@ class HTMLPurifier_AttrDef_CSS_TextDecoration extends HTMLPurifier_AttrDef
             }
         }
         $final = rtrim($final);
-        if ($final === '') return false;
+        if ($final === '') {
+            return false;
+        }
         return $final;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/CSS/URI.php
+++ b/library/HTMLPurifier/AttrDef/CSS/URI.php
@@ -12,25 +12,39 @@
 class HTMLPurifier_AttrDef_CSS_URI extends HTMLPurifier_AttrDef_URI
 {
 
-    public function __construct() {
+    public function __construct()
+    {
         parent::__construct(true); // always embedded
     }
 
-    public function validate($uri_string, $config, $context) {
+    /**
+     * @param string $uri_string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($uri_string, $config, $context)
+    {
         // parse the URI out of the string and then pass it onto
         // the parent object
 
         $uri_string = $this->parseCDATA($uri_string);
-        if (strpos($uri_string, 'url(') !== 0) return false;
+        if (strpos($uri_string, 'url(') !== 0) {
+            return false;
+        }
         $uri_string = substr($uri_string, 4);
         $new_length = strlen($uri_string) - 1;
-        if ($uri_string[$new_length] != ')') return false;
+        if ($uri_string[$new_length] != ')') {
+            return false;
+        }
         $uri = trim(substr($uri_string, 0, $new_length));
 
         if (!empty($uri) && ($uri[0] == "'" || $uri[0] == '"')) {
             $quote = $uri[0];
             $new_length = strlen($uri) - 1;
-            if ($uri[$new_length] !== $quote) return false;
+            if ($uri[$new_length] !== $quote) {
+                return false;
+            }
             $uri = substr($uri, 1, $new_length - 1);
         }
 
@@ -38,7 +52,9 @@ class HTMLPurifier_AttrDef_CSS_URI extends HTMLPurifier_AttrDef_URI
 
         $result = parent::validate($uri, $config, $context);
 
-        if ($result === false) return false;
+        if ($result === false) {
+            return false;
+        }
 
         // extra sanity check; should have been done by URI
         $result = str_replace(array('"', "\\", "\n", "\x0c", "\r"), "", $result);
@@ -51,11 +67,8 @@ class HTMLPurifier_AttrDef_CSS_URI extends HTMLPurifier_AttrDef_URI
         // an innerHTML cycle, so a very unlucky query parameter could
         // then change the meaning of the URL.  Unfortunately, there's
         // not much we can do about that...
-
         return "url(\"$result\")";
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/Clone.php
+++ b/library/HTMLPurifier/AttrDef/Clone.php
@@ -7,22 +7,38 @@
 class HTMLPurifier_AttrDef_Clone extends HTMLPurifier_AttrDef
 {
     /**
-     * What we're cloning
+     * What we're cloning.
+     * @type HTMLPurifier_AttrDef
      */
     protected $clone;
 
-    public function __construct($clone) {
+    /**
+     * @param HTMLPurifier_AttrDef $clone
+     */
+    public function __construct($clone)
+    {
         $this->clone = $clone;
     }
 
-    public function validate($v, $config, $context) {
+    /**
+     * @param string $v
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($v, $config, $context)
+    {
         return $this->clone->validate($v, $config, $context);
     }
 
-    public function make($string) {
+    /**
+     * @param string $string
+     * @return HTMLPurifier_AttrDef
+     */
+    public function make($string)
+    {
         return clone $this->clone;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/Enum.php
+++ b/library/HTMLPurifier/AttrDef/Enum.php
@@ -12,9 +12,10 @@ class HTMLPurifier_AttrDef_Enum extends HTMLPurifier_AttrDef
 
     /**
      * Lookup table of valid values.
+     * @type array
      * @todo Make protected
      */
-    public $valid_values   = array();
+    public $valid_values = array();
 
     /**
      * Bool indicating whether or not enumeration is case sensitive.
@@ -23,17 +24,23 @@ class HTMLPurifier_AttrDef_Enum extends HTMLPurifier_AttrDef
     protected $case_sensitive = false; // values according to W3C spec
 
     /**
-     * @param $valid_values List of valid values
-     * @param $case_sensitive Bool indicating whether or not case sensitive
+     * @param array $valid_values List of valid values
+     * @param bool $case_sensitive Whether or not case sensitive
      */
-    public function __construct(
-        $valid_values = array(), $case_sensitive = false
-    ) {
+    public function __construct($valid_values = array(), $case_sensitive = false)
+    {
         $this->valid_values = array_flip($valid_values);
         $this->case_sensitive = $case_sensitive;
     }
 
-    public function validate($string, $config, $context) {
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $string = trim($string);
         if (!$this->case_sensitive) {
             // we may want to do full case-insensitive libraries
@@ -45,11 +52,13 @@ class HTMLPurifier_AttrDef_Enum extends HTMLPurifier_AttrDef
     }
 
     /**
-     * @param $string In form of comma-delimited list of case-insensitive
+     * @param string $string In form of comma-delimited list of case-insensitive
      *      valid values. Example: "foo,bar,baz". Prepend "s:" to make
      *      case sensitive
+     * @return HTMLPurifier_AttrDef_Enum
      */
-    public function make($string) {
+    public function make($string)
+    {
         if (strlen($string) > 2 && $string[0] == 's' && $string[1] == ':') {
             $string = substr($string, 2);
             $sensitive = true;
@@ -59,7 +68,6 @@ class HTMLPurifier_AttrDef_Enum extends HTMLPurifier_AttrDef
         $values = explode(',', $string);
         return new HTMLPurifier_AttrDef_Enum($values, $sensitive);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/HTML/Bool.php
+++ b/library/HTMLPurifier/AttrDef/HTML/Bool.php
@@ -6,23 +6,46 @@
 class HTMLPurifier_AttrDef_HTML_Bool extends HTMLPurifier_AttrDef
 {
 
+    /**
+     * @type bool
+     */
     protected $name;
+
+    /**
+     * @type bool
+     */
     public $minimized = true;
 
-    public function __construct($name = false) {$this->name = $name;}
+    /**
+     * @param bool $name
+     */
+    public function __construct($name = false)
+    {
+        $this->name = $name;
+    }
 
-    public function validate($string, $config, $context) {
-        if (empty($string)) return false;
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
+        if (empty($string)) {
+            return false;
+        }
         return $this->name;
     }
 
     /**
-     * @param $string Name of attribute
+     * @param string $string Name of attribute
+     * @return HTMLPurifier_AttrDef_HTML_Bool
      */
-    public function make($string) {
+    public function make($string)
+    {
         return new HTMLPurifier_AttrDef_HTML_Bool($string);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/HTML/Class.php
+++ b/library/HTMLPurifier/AttrDef/HTML/Class.php
@@ -5,7 +5,14 @@
  */
 class HTMLPurifier_AttrDef_HTML_Class extends HTMLPurifier_AttrDef_HTML_Nmtokens
 {
-    protected function split($string, $config, $context) {
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    protected function split($string, $config, $context)
+    {
         // really, this twiddle should be lazy loaded
         $name = $config->getDefinition('HTML')->doctype->name;
         if ($name == "XHTML 1.1" || $name == "XHTML 2.0") {
@@ -14,13 +21,20 @@ class HTMLPurifier_AttrDef_HTML_Class extends HTMLPurifier_AttrDef_HTML_Nmtokens
             return preg_split('/\s+/', $string);
         }
     }
-    protected function filter($tokens, $config, $context) {
+
+    /**
+     * @param array $tokens
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    protected function filter($tokens, $config, $context)
+    {
         $allowed = $config->get('Attr.AllowedClasses');
         $forbidden = $config->get('Attr.ForbiddenClasses');
         $ret = array();
         foreach ($tokens as $token) {
-            if (
-                ($allowed === null || isset($allowed[$token])) &&
+            if (($allowed === null || isset($allowed[$token])) &&
                 !isset($forbidden[$token]) &&
                 // We need this O(n) check because of PHP's array
                 // implementation that casts -0 to 0.

--- a/library/HTMLPurifier/AttrDef/HTML/Color.php
+++ b/library/HTMLPurifier/AttrDef/HTML/Color.php
@@ -6,28 +6,46 @@
 class HTMLPurifier_AttrDef_HTML_Color extends HTMLPurifier_AttrDef
 {
 
-    public function validate($string, $config, $context) {
-
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         static $colors = null;
-        if ($colors === null) $colors = $config->get('Core.ColorKeywords');
+        if ($colors === null) {
+            $colors = $config->get('Core.ColorKeywords');
+        }
 
         $string = trim($string);
 
-        if (empty($string)) return false;
+        if (empty($string)) {
+            return false;
+        }
         $lower = strtolower($string);
-        if (isset($colors[$lower])) return $colors[$lower];
-        if ($string[0] === '#') $hex = substr($string, 1);
-        else $hex = $string;
+        if (isset($colors[$lower])) {
+            return $colors[$lower];
+        }
+        if ($string[0] === '#') {
+            $hex = substr($string, 1);
+        } else {
+            $hex = $string;
+        }
 
         $length = strlen($hex);
-        if ($length !== 3 && $length !== 6) return false;
-        if (!ctype_xdigit($hex)) return false;
-        if ($length === 3) $hex = $hex[0].$hex[0].$hex[1].$hex[1].$hex[2].$hex[2];
-
+        if ($length !== 3 && $length !== 6) {
+            return false;
+        }
+        if (!ctype_xdigit($hex)) {
+            return false;
+        }
+        if ($length === 3) {
+            $hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+        }
         return "#$hex";
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/HTML/FrameTarget.php
+++ b/library/HTMLPurifier/AttrDef/HTML/FrameTarget.php
@@ -6,16 +6,33 @@
 class HTMLPurifier_AttrDef_HTML_FrameTarget extends HTMLPurifier_AttrDef_Enum
 {
 
+    /**
+     * @type array
+     */
     public $valid_values = false; // uninitialized value
+
+    /**
+     * @type bool
+     */
     protected $case_sensitive = false;
 
-    public function __construct() {}
-
-    public function validate($string, $config, $context) {
-        if ($this->valid_values === false) $this->valid_values = $config->get('Attr.AllowedFrameTargets');
-        return parent::validate($string, $config, $context);
+    public function __construct()
+    {
     }
 
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
+        if ($this->valid_values === false) {
+            $this->valid_values = $config->get('Attr.AllowedFrameTargets');
+        }
+        return parent::validate($string, $config, $context);
+    }
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/HTML/ID.php
+++ b/library/HTMLPurifier/AttrDef/HTML/ID.php
@@ -18,34 +18,56 @@ class HTMLPurifier_AttrDef_HTML_ID extends HTMLPurifier_AttrDef
     /**
      * Determines whether or not we're validating an ID in a CSS
      * selector context.
+     * @type bool
      */
     protected $selector;
 
-    public function __construct($selector = false) {
+    /**
+     * @param bool $selector
+     */
+    public function __construct($selector = false)
+    {
         $this->selector = $selector;
     }
 
-    public function validate($id, $config, $context) {
-
-        if (!$this->selector && !$config->get('Attr.EnableID')) return false;
+    /**
+     * @param string $id
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($id, $config, $context)
+    {
+        if (!$this->selector && !$config->get('Attr.EnableID')) {
+            return false;
+        }
 
         $id = trim($id); // trim it first
 
-        if ($id === '') return false;
+        if ($id === '') {
+            return false;
+        }
 
         $prefix = $config->get('Attr.IDPrefix');
         if ($prefix !== '') {
             $prefix .= $config->get('Attr.IDPrefixLocal');
             // prevent re-appending the prefix
-            if (strpos($id, $prefix) !== 0) $id = $prefix . $id;
+            if (strpos($id, $prefix) !== 0) {
+                $id = $prefix . $id;
+            }
         } elseif ($config->get('Attr.IDPrefixLocal') !== '') {
-            trigger_error('%Attr.IDPrefixLocal cannot be used unless '.
-                '%Attr.IDPrefix is set', E_USER_WARNING);
+            trigger_error(
+                '%Attr.IDPrefixLocal cannot be used unless ' .
+                '%Attr.IDPrefix is set',
+                E_USER_WARNING
+            );
         }
 
         if (!$this->selector) {
             $id_accumulator =& $context->get('IDAccumulator');
-            if (isset($id_accumulator->ids[$id])) return false;
+            if (isset($id_accumulator->ids[$id])) {
+                return false;
+            }
         }
 
         // we purposely avoid using regex, hopefully this is faster
@@ -53,11 +75,14 @@ class HTMLPurifier_AttrDef_HTML_ID extends HTMLPurifier_AttrDef
         if (ctype_alpha($id)) {
             $result = true;
         } else {
-            if (!ctype_alpha(@$id[0])) return false;
-            $trim = trim( // primitive style of regexps, I suppose
+            if (!ctype_alpha(@$id[0])) {
+                return false;
+            }
+            // primitive style of regexps, I suppose
+            $trim = trim(
                 $id,
                 'A..Za..z0..9:-._'
-              );
+            );
             $result = ($trim === '');
         }
 
@@ -66,15 +91,15 @@ class HTMLPurifier_AttrDef_HTML_ID extends HTMLPurifier_AttrDef
             return false;
         }
 
-        if (!$this->selector && $result) $id_accumulator->add($id);
+        if (!$this->selector && $result) {
+            $id_accumulator->add($id);
+        }
 
         // if no change was made to the ID, return the result
         // else, return the new id if stripping whitespace made it
         //     valid, or return false.
         return $result ? $id : false;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/HTML/Length.php
+++ b/library/HTMLPurifier/AttrDef/HTML/Length.php
@@ -10,32 +10,47 @@
 class HTMLPurifier_AttrDef_HTML_Length extends HTMLPurifier_AttrDef_HTML_Pixels
 {
 
-    public function validate($string, $config, $context) {
-
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $string = trim($string);
-        if ($string === '') return false;
+        if ($string === '') {
+            return false;
+        }
 
         $parent_result = parent::validate($string, $config, $context);
-        if ($parent_result !== false) return $parent_result;
+        if ($parent_result !== false) {
+            return $parent_result;
+        }
 
         $length = strlen($string);
         $last_char = $string[$length - 1];
 
-        if ($last_char !== '%') return false;
+        if ($last_char !== '%') {
+            return false;
+        }
 
         $points = substr($string, 0, $length - 1);
 
-        if (!is_numeric($points)) return false;
+        if (!is_numeric($points)) {
+            return false;
+        }
 
-        $points = (int) $points;
+        $points = (int)$points;
 
-        if ($points < 0) return '0%';
-        if ($points > 100) return '100%';
-
-        return ((string) $points) . '%';
-
+        if ($points < 0) {
+            return '0%';
+        }
+        if ($points > 100) {
+            return '100%';
+        }
+        return ((string)$points) . '%';
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/HTML/LinkTypes.php
+++ b/library/HTMLPurifier/AttrDef/HTML/LinkTypes.php
@@ -9,26 +9,44 @@
 class HTMLPurifier_AttrDef_HTML_LinkTypes extends HTMLPurifier_AttrDef
 {
 
-    /** Name config attribute to pull. */
+    /**
+     * Name config attribute to pull.
+     * @type string
+     */
     protected $name;
 
-    public function __construct($name) {
+    /**
+     * @param string $name
+     */
+    public function __construct($name)
+    {
         $configLookup = array(
             'rel' => 'AllowedRel',
             'rev' => 'AllowedRev'
         );
         if (!isset($configLookup[$name])) {
-            trigger_error('Unrecognized attribute name for link '.
-                'relationship.', E_USER_ERROR);
+            trigger_error(
+                'Unrecognized attribute name for link ' .
+                'relationship.',
+                E_USER_ERROR
+            );
             return;
         }
         $this->name = $configLookup[$name];
     }
 
-    public function validate($string, $config, $context) {
-
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $allowed = $config->get('Attr.' . $this->name);
-        if (empty($allowed)) return false;
+        if (empty($allowed)) {
+            return false;
+        }
 
         $string = $this->parseCDATA($string);
         $parts = explode(' ', $string);
@@ -37,17 +55,18 @@ class HTMLPurifier_AttrDef_HTML_LinkTypes extends HTMLPurifier_AttrDef
         $ret_lookup = array();
         foreach ($parts as $part) {
             $part = strtolower(trim($part));
-            if (!isset($allowed[$part])) continue;
+            if (!isset($allowed[$part])) {
+                continue;
+            }
             $ret_lookup[$part] = true;
         }
 
-        if (empty($ret_lookup)) return false;
+        if (empty($ret_lookup)) {
+            return false;
+        }
         $string = implode(' ', array_keys($ret_lookup));
-
         return $string;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/HTML/MultiLength.php
+++ b/library/HTMLPurifier/AttrDef/HTML/MultiLength.php
@@ -9,33 +9,52 @@
 class HTMLPurifier_AttrDef_HTML_MultiLength extends HTMLPurifier_AttrDef_HTML_Length
 {
 
-    public function validate($string, $config, $context) {
-
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $string = trim($string);
-        if ($string === '') return false;
+        if ($string === '') {
+            return false;
+        }
 
         $parent_result = parent::validate($string, $config, $context);
-        if ($parent_result !== false) return $parent_result;
+        if ($parent_result !== false) {
+            return $parent_result;
+        }
 
         $length = strlen($string);
         $last_char = $string[$length - 1];
 
-        if ($last_char !== '*') return false;
+        if ($last_char !== '*') {
+            return false;
+        }
 
         $int = substr($string, 0, $length - 1);
 
-        if ($int == '') return '*';
-        if (!is_numeric($int)) return false;
+        if ($int == '') {
+            return '*';
+        }
+        if (!is_numeric($int)) {
+            return false;
+        }
 
-        $int = (int) $int;
-
-        if ($int < 0) return false;
-        if ($int == 0) return '0';
-        if ($int == 1) return '*';
-        return ((string) $int) . '*';
-
+        $int = (int)$int;
+        if ($int < 0) {
+            return false;
+        }
+        if ($int == 0) {
+            return '0';
+        }
+        if ($int == 1) {
+            return '*';
+        }
+        return ((string)$int) . '*';
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/HTML/Nmtokens.php
+++ b/library/HTMLPurifier/AttrDef/HTML/Nmtokens.php
@@ -6,24 +6,38 @@
 class HTMLPurifier_AttrDef_HTML_Nmtokens extends HTMLPurifier_AttrDef
 {
 
-    public function validate($string, $config, $context) {
-
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $string = trim($string);
 
         // early abort: '' and '0' (strings that convert to false) are invalid
-        if (!$string) return false;
+        if (!$string) {
+            return false;
+        }
 
         $tokens = $this->split($string, $config, $context);
         $tokens = $this->filter($tokens, $config, $context);
-        if (empty($tokens)) return false;
+        if (empty($tokens)) {
+            return false;
+        }
         return implode(' ', $tokens);
-
     }
 
     /**
      * Splits a space separated list of tokens into its constituent parts.
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
      */
-    protected function split($string, $config, $context) {
+    protected function split($string, $config, $context)
+    {
         // OPTIMIZABLE!
         // do the preg_match, capture all subpatterns for reformulation
 
@@ -31,9 +45,9 @@ class HTMLPurifier_AttrDef_HTML_Nmtokens extends HTMLPurifier_AttrDef
         // escaping because I don't know how to do that with regexps
         // and plus it would complicate optimization efforts (you never
         // see that anyway).
-        $pattern = '/(?:(?<=\s)|\A)'. // look behind for space or string start
-                   '((?:--|-?[A-Za-z_])[A-Za-z_\-0-9]*)'.
-                   '(?:(?=\s)|\z)/'; // look ahead for space or string end
+        $pattern = '/(?:(?<=\s)|\A)' . // look behind for space or string start
+            '((?:--|-?[A-Za-z_])[A-Za-z_\-0-9]*)' .
+            '(?:(?=\s)|\z)/'; // look ahead for space or string end
         preg_match_all($pattern, $string, $matches);
         return $matches[1];
     }
@@ -42,11 +56,15 @@ class HTMLPurifier_AttrDef_HTML_Nmtokens extends HTMLPurifier_AttrDef
      * Template method for removing certain tokens based on arbitrary criteria.
      * @note If we wanted to be really functional, we'd do an array_filter
      *       with a callback. But... we're not.
+     * @param array $tokens
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
      */
-    protected function filter($tokens, $config, $context) {
+    protected function filter($tokens, $config, $context)
+    {
         return $tokens;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/HTML/Pixels.php
+++ b/library/HTMLPurifier/AttrDef/HTML/Pixels.php
@@ -6,43 +6,71 @@
 class HTMLPurifier_AttrDef_HTML_Pixels extends HTMLPurifier_AttrDef
 {
 
+    /**
+     * @type int
+     */
     protected $max;
 
-    public function __construct($max = null) {
+    /**
+     * @param int $max
+     */
+    public function __construct($max = null)
+    {
         $this->max = $max;
     }
 
-    public function validate($string, $config, $context) {
-
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $string = trim($string);
-        if ($string === '0') return $string;
-        if ($string === '')  return false;
+        if ($string === '0') {
+            return $string;
+        }
+        if ($string === '') {
+            return false;
+        }
         $length = strlen($string);
         if (substr($string, $length - 2) == 'px') {
             $string = substr($string, 0, $length - 2);
         }
-        if (!is_numeric($string)) return false;
-        $int = (int) $string;
+        if (!is_numeric($string)) {
+            return false;
+        }
+        $int = (int)$string;
 
-        if ($int < 0) return '0';
+        if ($int < 0) {
+            return '0';
+        }
 
         // upper-bound value, extremely high values can
         // crash operating systems, see <http://ha.ckers.org/imagecrash.html>
         // WARNING, above link WILL crash you if you're using Windows
 
-        if ($this->max !== null && $int > $this->max) return (string) $this->max;
-
-        return (string) $int;
-
+        if ($this->max !== null && $int > $this->max) {
+            return (string)$this->max;
+        }
+        return (string)$int;
     }
 
-    public function make($string) {
-        if ($string === '') $max = null;
-        else $max = (int) $string;
+    /**
+     * @param string $string
+     * @return HTMLPurifier_AttrDef
+     */
+    public function make($string)
+    {
+        if ($string === '') {
+            $max = null;
+        } else {
+            $max = (int)$string;
+        }
         $class = get_class($this);
         return new $class($max);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/Integer.php
+++ b/library/HTMLPurifier/AttrDef/Integer.php
@@ -11,17 +11,20 @@ class HTMLPurifier_AttrDef_Integer extends HTMLPurifier_AttrDef
 {
 
     /**
-     * Bool indicating whether or not negative values are allowed
+     * Whether or not negative values are allowed.
+     * @type bool
      */
     protected $negative = true;
 
     /**
-     * Bool indicating whether or not zero is allowed
+     * Whether or not zero is allowed.
+     * @type bool
      */
     protected $zero = true;
 
     /**
-     * Bool indicating whether or not positive values are allowed
+     * Whether or not positive values are allowed.
+     * @type bool
      */
     protected $positive = true;
 
@@ -30,44 +33,59 @@ class HTMLPurifier_AttrDef_Integer extends HTMLPurifier_AttrDef
      * @param $zero Bool indicating whether or not zero is allowed
      * @param $positive Bool indicating whether or not positive values are allowed
      */
-    public function __construct(
-        $negative = true, $zero = true, $positive = true
-    ) {
+    public function __construct($negative = true, $zero = true, $positive = true)
+    {
         $this->negative = $negative;
-        $this->zero     = $zero;
+        $this->zero = $zero;
         $this->positive = $positive;
     }
 
-    public function validate($integer, $config, $context) {
-
+    /**
+     * @param string $integer
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($integer, $config, $context)
+    {
         $integer = $this->parseCDATA($integer);
-        if ($integer === '') return false;
+        if ($integer === '') {
+            return false;
+        }
 
         // we could possibly simply typecast it to integer, but there are
         // certain fringe cases that must not return an integer.
 
         // clip leading sign
-        if ( $this->negative && $integer[0] === '-' ) {
+        if ($this->negative && $integer[0] === '-') {
             $digits = substr($integer, 1);
-            if ($digits === '0') $integer = '0'; // rm minus sign for zero
-        } elseif( $this->positive && $integer[0] === '+' ) {
+            if ($digits === '0') {
+                $integer = '0';
+            } // rm minus sign for zero
+        } elseif ($this->positive && $integer[0] === '+') {
             $digits = $integer = substr($integer, 1); // rm unnecessary plus
         } else {
             $digits = $integer;
         }
 
         // test if it's numeric
-        if (!ctype_digit($digits)) return false;
+        if (!ctype_digit($digits)) {
+            return false;
+        }
 
         // perform scope tests
-        if (!$this->zero     && $integer == 0) return false;
-        if (!$this->positive && $integer > 0) return false;
-        if (!$this->negative && $integer < 0) return false;
+        if (!$this->zero && $integer == 0) {
+            return false;
+        }
+        if (!$this->positive && $integer > 0) {
+            return false;
+        }
+        if (!$this->negative && $integer < 0) {
+            return false;
+        }
 
         return $integer;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/Lang.php
+++ b/library/HTMLPurifier/AttrDef/Lang.php
@@ -7,15 +7,25 @@
 class HTMLPurifier_AttrDef_Lang extends HTMLPurifier_AttrDef
 {
 
-    public function validate($string, $config, $context) {
-
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $string = trim($string);
-        if (!$string) return false;
+        if (!$string) {
+            return false;
+        }
 
         $subtags = explode('-', $string);
         $num_subtags = count($subtags);
 
-        if ($num_subtags == 0) return false; // sanity check
+        if ($num_subtags == 0) { // sanity check
+            return false;
+        }
 
         // process primary subtag : $subtags[0]
         $length = strlen($subtags[0]);
@@ -23,15 +33,15 @@ class HTMLPurifier_AttrDef_Lang extends HTMLPurifier_AttrDef
             case 0:
                 return false;
             case 1:
-                if (! ($subtags[0] == 'x' || $subtags[0] == 'i') ) {
+                if (!($subtags[0] == 'x' || $subtags[0] == 'i')) {
                     return false;
                 }
                 break;
             case 2:
             case 3:
-                if (! ctype_alpha($subtags[0]) ) {
+                if (!ctype_alpha($subtags[0])) {
                     return false;
-                } elseif (! ctype_lower($subtags[0]) ) {
+                } elseif (!ctype_lower($subtags[0])) {
                     $subtags[0] = strtolower($subtags[0]);
                 }
                 break;
@@ -40,17 +50,23 @@ class HTMLPurifier_AttrDef_Lang extends HTMLPurifier_AttrDef
         }
 
         $new_string = $subtags[0];
-        if ($num_subtags == 1) return $new_string;
+        if ($num_subtags == 1) {
+            return $new_string;
+        }
 
         // process second subtag : $subtags[1]
         $length = strlen($subtags[1]);
         if ($length == 0 || ($length == 1 && $subtags[1] != 'x') || $length > 8 || !ctype_alnum($subtags[1])) {
             return $new_string;
         }
-        if (!ctype_lower($subtags[1])) $subtags[1] = strtolower($subtags[1]);
+        if (!ctype_lower($subtags[1])) {
+            $subtags[1] = strtolower($subtags[1]);
+        }
 
         $new_string .= '-' . $subtags[1];
-        if ($num_subtags == 2) return $new_string;
+        if ($num_subtags == 2) {
+            return $new_string;
+        }
 
         // process all other subtags, index 2 and up
         for ($i = 2; $i < $num_subtags; $i++) {
@@ -63,11 +79,8 @@ class HTMLPurifier_AttrDef_Lang extends HTMLPurifier_AttrDef
             }
             $new_string .= '-' . $subtags[$i];
         }
-
         return $new_string;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/Switch.php
+++ b/library/HTMLPurifier/AttrDef/Switch.php
@@ -6,21 +6,41 @@
 class HTMLPurifier_AttrDef_Switch
 {
 
+    /**
+     * @type string
+     */
     protected $tag;
-    protected $withTag, $withoutTag;
+
+    /**
+     * @type HTMLPurifier_AttrDef
+     */
+    protected $withTag;
+
+    /**
+     * @type HTMLPurifier_AttrDef
+     */
+    protected $withoutTag;
 
     /**
      * @param string $tag Tag name to switch upon
      * @param HTMLPurifier_AttrDef $with_tag Call if token matches tag
      * @param HTMLPurifier_AttrDef $without_tag Call if token doesn't match, or there is no token
      */
-    public function __construct($tag, $with_tag, $without_tag) {
+    public function __construct($tag, $with_tag, $without_tag)
+    {
         $this->tag = $tag;
         $this->withTag = $with_tag;
         $this->withoutTag = $without_tag;
     }
 
-    public function validate($string, $config, $context) {
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $token = $context->get('CurrentToken', true);
         if (!$token || $token->name !== $this->tag) {
             return $this->withoutTag->validate($string, $config, $context);
@@ -28,7 +48,6 @@ class HTMLPurifier_AttrDef_Switch
             return $this->withTag->validate($string, $config, $context);
         }
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/Text.php
+++ b/library/HTMLPurifier/AttrDef/Text.php
@@ -6,10 +6,16 @@
 class HTMLPurifier_AttrDef_Text extends HTMLPurifier_AttrDef
 {
 
-    public function validate($string, $config, $context) {
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         return $this->parseCDATA($string);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/URI.php
+++ b/library/HTMLPurifier/AttrDef/URI.php
@@ -7,31 +7,54 @@
 class HTMLPurifier_AttrDef_URI extends HTMLPurifier_AttrDef
 {
 
+    /**
+     * @type HTMLPurifier_URIParser
+     */
     protected $parser;
+
+    /**
+     * @type bool
+     */
     protected $embedsResource;
 
     /**
-     * @param $embeds_resource_resource Does the URI here result in an extra HTTP request?
+     * @param bool $embeds_resource Does the URI here result in an extra HTTP request?
      */
-    public function __construct($embeds_resource = false) {
+    public function __construct($embeds_resource = false)
+    {
         $this->parser = new HTMLPurifier_URIParser();
-        $this->embedsResource = (bool) $embeds_resource;
+        $this->embedsResource = (bool)$embeds_resource;
     }
 
-    public function make($string) {
+    /**
+     * @param string $string
+     * @return HTMLPurifier_AttrDef_URI
+     */
+    public function make($string)
+    {
         $embeds = ($string === 'embedded');
         return new HTMLPurifier_AttrDef_URI($embeds);
     }
 
-    public function validate($uri, $config, $context) {
-
-        if ($config->get('URI.Disable')) return false;
+    /**
+     * @param string $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($uri, $config, $context)
+    {
+        if ($config->get('URI.Disable')) {
+            return false;
+        }
 
         $uri = $this->parseCDATA($uri);
 
         // parse the URI
         $uri = $this->parser->parse($uri);
-        if ($uri === false) return false;
+        if ($uri === false) {
+            return false;
+        }
 
         // add embedded flag to context for validators
         $context->register('EmbeddedURI', $this->embedsResource);
@@ -41,23 +64,35 @@ class HTMLPurifier_AttrDef_URI extends HTMLPurifier_AttrDef
 
             // generic validation
             $result = $uri->validate($config, $context);
-            if (!$result) break;
+            if (!$result) {
+                break;
+            }
 
             // chained filtering
             $uri_def = $config->getDefinition('URI');
             $result = $uri_def->filter($uri, $config, $context);
-            if (!$result) break;
+            if (!$result) {
+                break;
+            }
 
             // scheme-specific validation
             $scheme_obj = $uri->getSchemeObj($config, $context);
-            if (!$scheme_obj) break;
-            if ($this->embedsResource && !$scheme_obj->browsable) break;
+            if (!$scheme_obj) {
+                break;
+            }
+            if ($this->embedsResource && !$scheme_obj->browsable) {
+                break;
+            }
             $result = $scheme_obj->validate($uri, $config, $context);
-            if (!$result) break;
+            if (!$result) {
+                break;
+            }
 
             // Post chained filtering
             $result = $uri_def->postFilter($uri, $config, $context);
-            if (!$result) break;
+            if (!$result) {
+                break;
+            }
 
             // survived gauntlet
             $ok = true;
@@ -65,13 +100,12 @@ class HTMLPurifier_AttrDef_URI extends HTMLPurifier_AttrDef
         } while (false);
 
         $context->destroy('EmbeddedURI');
-        if (!$ok) return false;
-
+        if (!$ok) {
+            return false;
+        }
         // back to string
         return $uri->toString();
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/URI/Email.php
+++ b/library/HTMLPurifier/AttrDef/URI/Email.php
@@ -5,8 +5,11 @@ abstract class HTMLPurifier_AttrDef_URI_Email extends HTMLPurifier_AttrDef
 
     /**
      * Unpacks a mailbox into its display-name and address
+     * @param string $string
+     * @return mixed
      */
-    function unpack($string) {
+    public function unpack($string)
+    {
         // needs to be implemented
     }
 

--- a/library/HTMLPurifier/AttrDef/URI/Email/SimpleCheck.php
+++ b/library/HTMLPurifier/AttrDef/URI/Email/SimpleCheck.php
@@ -7,15 +7,23 @@
 class HTMLPurifier_AttrDef_URI_Email_SimpleCheck extends HTMLPurifier_AttrDef_URI_Email
 {
 
-    public function validate($string, $config, $context) {
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         // no support for named mailboxes i.e. "Bob <bob@example.com>"
         // that needs more percent encoding to be done
-        if ($string == '') return false;
+        if ($string == '') {
+            return false;
+        }
         $string = trim($string);
         $result = preg_match('/^[A-Z0-9._%-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i', $string);
         return $result ? $string : false;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/URI/Host.php
+++ b/library/HTMLPurifier/AttrDef/URI/Host.php
@@ -7,21 +7,31 @@ class HTMLPurifier_AttrDef_URI_Host extends HTMLPurifier_AttrDef
 {
 
     /**
-     * Instance of HTMLPurifier_AttrDef_URI_IPv4 sub-validator
+     * IPv4 sub-validator.
+     * @type HTMLPurifier_AttrDef_URI_IPv4
      */
     protected $ipv4;
 
     /**
-     * Instance of HTMLPurifier_AttrDef_URI_IPv6 sub-validator
+     * IPv6 sub-validator.
+     * @type HTMLPurifier_AttrDef_URI_IPv6
      */
     protected $ipv6;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->ipv4 = new HTMLPurifier_AttrDef_URI_IPv4();
         $this->ipv6 = new HTMLPurifier_AttrDef_URI_IPv6();
     }
 
-    public function validate($string, $config, $context) {
+    /**
+     * @param string $string
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($string, $config, $context)
+    {
         $length = strlen($string);
         // empty hostname is OK; it's usually semantically equivalent:
         // the default host as defined by a URI scheme is used:
@@ -29,18 +39,24 @@ class HTMLPurifier_AttrDef_URI_Host extends HTMLPurifier_AttrDef
         //      If the URI scheme defines a default for host, then that
         //      default applies when the host subcomponent is undefined
         //      or when the registered name is empty (zero length).
-        if ($string === '') return '';
-        if ($length > 1 && $string[0] === '[' && $string[$length-1] === ']') {
+        if ($string === '') {
+            return '';
+        }
+        if ($length > 1 && $string[0] === '[' && $string[$length - 1] === ']') {
             //IPv6
             $ip = substr($string, 1, $length - 2);
             $valid = $this->ipv6->validate($ip, $config, $context);
-            if ($valid === false) return false;
-            return '['. $valid . ']';
+            if ($valid === false) {
+                return false;
+            }
+            return '[' . $valid . ']';
         }
 
         // need to do checks on unusual encodings too
         $ipv4 = $this->ipv4->validate($string, $config, $context);
-        if ($ipv4 !== false) return $ipv4;
+        if ($ipv4 !== false) {
+            return $ipv4;
+        }
 
         // A regular domain name.
 
@@ -65,9 +81,9 @@ class HTMLPurifier_AttrDef_URI_Host extends HTMLPurifier_AttrDef
         $an  = '[a-z0-9]';  // alphanum
         $and = "[a-z0-9-$underscore]"; // alphanum | "-"
         // domainlabel = alphanum | alphanum *( alphanum | "-" ) alphanum
-        $domainlabel   = "$an($and*$an)?";
+        $domainlabel = "$an($and*$an)?";
         // toplabel    = alpha | alpha *( alphanum | "-" ) alphanum
-        $toplabel      = "$a($and*$an)?";
+        $toplabel = "$a($and*$an)?";
         // hostname    = *( domainlabel "." ) toplabel [ "." ]
         if (preg_match("/^($domainlabel\.)*$toplabel\.?$/i", $string)) {
             return $string;
@@ -105,10 +121,8 @@ class HTMLPurifier_AttrDef_URI_Host extends HTMLPurifier_AttrDef
                 // XXX error reporting
             }
         }
-
         return false;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/URI/IPv4.php
+++ b/library/HTMLPurifier/AttrDef/URI/IPv4.php
@@ -8,32 +8,38 @@ class HTMLPurifier_AttrDef_URI_IPv4 extends HTMLPurifier_AttrDef
 {
 
     /**
-     * IPv4 regex, protected so that IPv6 can reuse it
+     * IPv4 regex, protected so that IPv6 can reuse it.
+     * @type string
      */
     protected $ip4;
 
-    public function validate($aIP, $config, $context) {
-
-        if (!$this->ip4) $this->_loadRegex();
-
-        if (preg_match('#^' . $this->ip4 . '$#s', $aIP))
-        {
-                return $aIP;
+    /**
+     * @param string $aIP
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($aIP, $config, $context)
+    {
+        if (!$this->ip4) {
+            $this->_loadRegex();
         }
 
+        if (preg_match('#^' . $this->ip4 . '$#s', $aIP)) {
+            return $aIP;
+        }
         return false;
-
     }
 
     /**
      * Lazy load function to prevent regex from being stuffed in
      * cache.
      */
-    protected function _loadRegex() {
+    protected function _loadRegex()
+    {
         $oct = '(?:25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])'; // 0-255
         $this->ip4 = "(?:{$oct}\\.{$oct}\\.{$oct}\\.{$oct})";
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrDef/URI/IPv6.php
+++ b/library/HTMLPurifier/AttrDef/URI/IPv6.php
@@ -9,91 +9,81 @@
 class HTMLPurifier_AttrDef_URI_IPv6 extends HTMLPurifier_AttrDef_URI_IPv4
 {
 
-    public function validate($aIP, $config, $context) {
-
-        if (!$this->ip4) $this->_loadRegex();
+    /**
+     * @param string $aIP
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string
+     */
+    public function validate($aIP, $config, $context)
+    {
+        if (!$this->ip4) {
+            $this->_loadRegex();
+        }
 
         $original = $aIP;
 
         $hex = '[0-9a-fA-F]';
         $blk = '(?:' . $hex . '{1,4})';
-        $pre = '(?:/(?:12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))';   // /0 - /128
+        $pre = '(?:/(?:12[0-8]|1[0-1][0-9]|[1-9][0-9]|[0-9]))'; // /0 - /128
 
         //      prefix check
-        if (strpos($aIP, '/') !== false)
-        {
-                if (preg_match('#' . $pre . '$#s', $aIP, $find))
-                {
-                        $aIP = substr($aIP, 0, 0-strlen($find[0]));
-                        unset($find);
-                }
-                else
-                {
-                        return false;
-                }
+        if (strpos($aIP, '/') !== false) {
+            if (preg_match('#' . $pre . '$#s', $aIP, $find)) {
+                $aIP = substr($aIP, 0, 0 - strlen($find[0]));
+                unset($find);
+            } else {
+                return false;
+            }
         }
 
         //      IPv4-compatiblity check
-        if (preg_match('#(?<=:'.')' . $this->ip4 . '$#s', $aIP, $find))
-        {
-                $aIP = substr($aIP, 0, 0-strlen($find[0]));
-                $ip = explode('.', $find[0]);
-                $ip = array_map('dechex', $ip);
-                $aIP .= $ip[0] . $ip[1] . ':' . $ip[2] . $ip[3];
-                unset($find, $ip);
+        if (preg_match('#(?<=:' . ')' . $this->ip4 . '$#s', $aIP, $find)) {
+            $aIP = substr($aIP, 0, 0 - strlen($find[0]));
+            $ip = explode('.', $find[0]);
+            $ip = array_map('dechex', $ip);
+            $aIP .= $ip[0] . $ip[1] . ':' . $ip[2] . $ip[3];
+            unset($find, $ip);
         }
 
         //      compression check
         $aIP = explode('::', $aIP);
         $c = count($aIP);
-        if ($c > 2)
-        {
+        if ($c > 2) {
+            return false;
+        } elseif ($c == 2) {
+            list($first, $second) = $aIP;
+            $first = explode(':', $first);
+            $second = explode(':', $second);
+
+            if (count($first) + count($second) > 8) {
                 return false;
-        }
-        elseif ($c == 2)
-        {
-                list($first, $second) = $aIP;
-                $first = explode(':', $first);
-                $second = explode(':', $second);
+            }
 
-                if (count($first) + count($second) > 8)
-                {
-                        return false;
-                }
+            while (count($first) < 8) {
+                array_push($first, '0');
+            }
 
-                while(count($first) < 8)
-                {
-                        array_push($first, '0');
-                }
-
-                array_splice($first, 8 - count($second), 8, $second);
-                $aIP = $first;
-                unset($first,$second);
-        }
-        else
-        {
-                $aIP = explode(':', $aIP[0]);
+            array_splice($first, 8 - count($second), 8, $second);
+            $aIP = $first;
+            unset($first, $second);
+        } else {
+            $aIP = explode(':', $aIP[0]);
         }
         $c = count($aIP);
 
-        if ($c != 8)
-        {
-                return false;
+        if ($c != 8) {
+            return false;
         }
 
         //      All the pieces should be 16-bit hex strings. Are they?
-        foreach ($aIP as $piece)
-        {
-                if (!preg_match('#^[0-9a-fA-F]{4}$#s', sprintf('%04s', $piece)))
-                {
-                        return false;
-                }
+        foreach ($aIP as $piece) {
+            if (!preg_match('#^[0-9a-fA-F]{4}$#s', sprintf('%04s', $piece))) {
+                return false;
+            }
         }
-
         return $original;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform.php
+++ b/library/HTMLPurifier/AttrTransform.php
@@ -20,37 +20,41 @@ abstract class HTMLPurifier_AttrTransform
     /**
      * Abstract: makes changes to the attributes dependent on multiple values.
      *
-     * @param $attr Assoc array of attributes, usually from
+     * @param array $attr Assoc array of attributes, usually from
      *              HTMLPurifier_Token_Tag::$attr
-     * @param $config Mandatory HTMLPurifier_Config object.
-     * @param $context Mandatory HTMLPurifier_Context object
-     * @returns Processed attribute array.
+     * @param HTMLPurifier_Config $config Mandatory HTMLPurifier_Config object.
+     * @param HTMLPurifier_Context $context Mandatory HTMLPurifier_Context object
+     * @return array Processed attribute array.
      */
     abstract public function transform($attr, $config, $context);
 
     /**
      * Prepends CSS properties to the style attribute, creating the
      * attribute if it doesn't exist.
-     * @param $attr Attribute array to process (passed by reference)
-     * @param $css CSS to prepend
+     * @param array &$attr Attribute array to process (passed by reference)
+     * @param string $css CSS to prepend
      */
-    public function prependCSS(&$attr, $css) {
+    public function prependCSS(&$attr, $css)
+    {
         $attr['style'] = isset($attr['style']) ? $attr['style'] : '';
         $attr['style'] = $css . $attr['style'];
     }
 
     /**
      * Retrieves and removes an attribute
-     * @param $attr Attribute array to process (passed by reference)
-     * @param $key Key of attribute to confiscate
+     * @param array &$attr Attribute array to process (passed by reference)
+     * @param mixed $key Key of attribute to confiscate
+     * @return mixed
      */
-    public function confiscateAttr(&$attr, $key) {
-        if (!isset($attr[$key])) return null;
+    public function confiscateAttr(&$attr, $key)
+    {
+        if (!isset($attr[$key])) {
+            return null;
+        }
         $value = $attr[$key];
         unset($attr[$key]);
         return $value;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/Background.php
+++ b/library/HTMLPurifier/AttrTransform/Background.php
@@ -3,21 +3,26 @@
 /**
  * Pre-transform that changes proprietary background attribute to CSS.
  */
-class HTMLPurifier_AttrTransform_Background extends HTMLPurifier_AttrTransform {
-
-    public function transform($attr, $config, $context) {
-
-        if (!isset($attr['background'])) return $attr;
+class HTMLPurifier_AttrTransform_Background extends HTMLPurifier_AttrTransform
+{
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (!isset($attr['background'])) {
+            return $attr;
+        }
 
         $background = $this->confiscateAttr($attr, 'background');
         // some validation should happen here
 
         $this->prependCSS($attr, "background-image:url($background);");
-
         return $attr;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/BdoDir.php
+++ b/library/HTMLPurifier/AttrTransform/BdoDir.php
@@ -8,12 +8,20 @@
 class HTMLPurifier_AttrTransform_BdoDir extends HTMLPurifier_AttrTransform
 {
 
-    public function transform($attr, $config, $context) {
-        if (isset($attr['dir'])) return $attr;
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (isset($attr['dir'])) {
+            return $attr;
+        }
         $attr['dir'] = $config->get('Attr.DefaultTextDir');
         return $attr;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/BgColor.php
+++ b/library/HTMLPurifier/AttrTransform/BgColor.php
@@ -3,21 +3,26 @@
 /**
  * Pre-transform that changes deprecated bgcolor attribute to CSS.
  */
-class HTMLPurifier_AttrTransform_BgColor extends HTMLPurifier_AttrTransform {
-
-    public function transform($attr, $config, $context) {
-
-        if (!isset($attr['bgcolor'])) return $attr;
+class HTMLPurifier_AttrTransform_BgColor extends HTMLPurifier_AttrTransform
+{
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (!isset($attr['bgcolor'])) {
+            return $attr;
+        }
 
         $bgcolor = $this->confiscateAttr($attr, 'bgcolor');
         // some validation should happen here
 
         $this->prependCSS($attr, "background-color:$bgcolor;");
-
         return $attr;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/BoolToCSS.php
+++ b/library/HTMLPurifier/AttrTransform/BoolToCSS.php
@@ -3,34 +3,45 @@
 /**
  * Pre-transform that changes converts a boolean attribute to fixed CSS
  */
-class HTMLPurifier_AttrTransform_BoolToCSS extends HTMLPurifier_AttrTransform {
-
+class HTMLPurifier_AttrTransform_BoolToCSS extends HTMLPurifier_AttrTransform
+{
     /**
-     * Name of boolean attribute that is trigger
+     * Name of boolean attribute that is trigger.
+     * @type string
      */
     protected $attr;
 
     /**
-     * CSS declarations to add to style, needs trailing semicolon
+     * CSS declarations to add to style, needs trailing semicolon.
+     * @type string
      */
     protected $css;
 
     /**
-     * @param $attr string attribute name to convert from
-     * @param $css string CSS declarations to add to style (needs semicolon)
+     * @param string $attr attribute name to convert from
+     * @param string $css CSS declarations to add to style (needs semicolon)
      */
-    public function __construct($attr, $css) {
+    public function __construct($attr, $css)
+    {
         $this->attr = $attr;
-        $this->css  = $css;
+        $this->css = $css;
     }
 
-    public function transform($attr, $config, $context) {
-        if (!isset($attr[$this->attr])) return $attr;
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (!isset($attr[$this->attr])) {
+            return $attr;
+        }
         unset($attr[$this->attr]);
         $this->prependCSS($attr, $this->css);
         return $attr;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/Border.php
+++ b/library/HTMLPurifier/AttrTransform/Border.php
@@ -3,16 +3,24 @@
 /**
  * Pre-transform that changes deprecated border attribute to CSS.
  */
-class HTMLPurifier_AttrTransform_Border extends HTMLPurifier_AttrTransform {
-
-    public function transform($attr, $config, $context) {
-        if (!isset($attr['border'])) return $attr;
+class HTMLPurifier_AttrTransform_Border extends HTMLPurifier_AttrTransform
+{
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (!isset($attr['border'])) {
+            return $attr;
+        }
         $border_width = $this->confiscateAttr($attr, 'border');
         // some validation should happen here
         $this->prependCSS($attr, "border:{$border_width}px solid;");
         return $attr;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/EnumToCSS.php
+++ b/library/HTMLPurifier/AttrTransform/EnumToCSS.php
@@ -4,55 +4,65 @@
  * Generic pre-transform that converts an attribute with a fixed number of
  * values (enumerated) to CSS.
  */
-class HTMLPurifier_AttrTransform_EnumToCSS extends HTMLPurifier_AttrTransform {
-
+class HTMLPurifier_AttrTransform_EnumToCSS extends HTMLPurifier_AttrTransform
+{
     /**
-     * Name of attribute to transform from
+     * Name of attribute to transform from.
+     * @type string
      */
     protected $attr;
 
     /**
-     * Lookup array of attribute values to CSS
+     * Lookup array of attribute values to CSS.
+     * @type array
      */
     protected $enumToCSS = array();
 
     /**
-     * Case sensitivity of the matching
+     * Case sensitivity of the matching.
+     * @type bool
      * @warning Currently can only be guaranteed to work with ASCII
      *          values.
      */
     protected $caseSensitive = false;
 
     /**
-     * @param $attr String attribute name to transform from
-     * @param $enumToCSS Lookup array of attribute values to CSS
-     * @param $case_sensitive Boolean case sensitivity indicator, default false
+     * @param string $attr Attribute name to transform from
+     * @param array $enum_to_css Lookup array of attribute values to CSS
+     * @param bool $case_sensitive Case sensitivity indicator, default false
      */
-    public function __construct($attr, $enum_to_css, $case_sensitive = false) {
+    public function __construct($attr, $enum_to_css, $case_sensitive = false)
+    {
         $this->attr = $attr;
         $this->enumToCSS = $enum_to_css;
-        $this->caseSensitive = (bool) $case_sensitive;
+        $this->caseSensitive = (bool)$case_sensitive;
     }
 
-    public function transform($attr, $config, $context) {
-
-        if (!isset($attr[$this->attr])) return $attr;
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (!isset($attr[$this->attr])) {
+            return $attr;
+        }
 
         $value = trim($attr[$this->attr]);
         unset($attr[$this->attr]);
 
-        if (!$this->caseSensitive) $value = strtolower($value);
+        if (!$this->caseSensitive) {
+            $value = strtolower($value);
+        }
 
         if (!isset($this->enumToCSS[$value])) {
             return $attr;
         }
-
         $this->prependCSS($attr, $this->enumToCSS[$value]);
-
         return $attr;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/ImgRequired.php
+++ b/library/HTMLPurifier/AttrTransform/ImgRequired.php
@@ -11,11 +11,19 @@
 class HTMLPurifier_AttrTransform_ImgRequired extends HTMLPurifier_AttrTransform
 {
 
-    public function transform($attr, $config, $context) {
-
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
         $src = true;
         if (!isset($attr['src'])) {
-            if ($config->get('Core.RemoveInvalidImg')) return $attr;
+            if ($config->get('Core.RemoveInvalidImg')) {
+                return $attr;
+            }
             $attr['src'] = $config->get('Attr.DefaultInvalidImage');
             $src = false;
         }
@@ -25,7 +33,7 @@ class HTMLPurifier_AttrTransform_ImgRequired extends HTMLPurifier_AttrTransform
                 $alt = $config->get('Attr.DefaultImageAlt');
                 if ($alt === null) {
                     // truncate if the alt is too long
-                    $attr['alt'] = substr(basename($attr['src']),0,40);
+                    $attr['alt'] = substr(basename($attr['src']), 0, 40);
                 } else {
                     $attr['alt'] = $alt;
                 }
@@ -33,11 +41,8 @@ class HTMLPurifier_AttrTransform_ImgRequired extends HTMLPurifier_AttrTransform
                 $attr['alt'] = $config->get('Attr.DefaultInvalidImageAlt');
             }
         }
-
         return $attr;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/ImgSpace.php
+++ b/library/HTMLPurifier/AttrTransform/ImgSpace.php
@@ -3,42 +3,59 @@
 /**
  * Pre-transform that changes deprecated hspace and vspace attributes to CSS
  */
-class HTMLPurifier_AttrTransform_ImgSpace extends HTMLPurifier_AttrTransform {
-
+class HTMLPurifier_AttrTransform_ImgSpace extends HTMLPurifier_AttrTransform
+{
+    /**
+     * @type string
+     */
     protected $attr;
+
+    /**
+     * @type array
+     */
     protected $css = array(
         'hspace' => array('left', 'right'),
         'vspace' => array('top', 'bottom')
     );
 
-    public function __construct($attr) {
+    /**
+     * @param string $attr
+     */
+    public function __construct($attr)
+    {
         $this->attr = $attr;
         if (!isset($this->css[$attr])) {
             trigger_error(htmlspecialchars($attr) . ' is not valid space attribute');
         }
     }
 
-    public function transform($attr, $config, $context) {
-
-        if (!isset($attr[$this->attr])) return $attr;
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (!isset($attr[$this->attr])) {
+            return $attr;
+        }
 
         $width = $this->confiscateAttr($attr, $this->attr);
         // some validation could happen here
 
-        if (!isset($this->css[$this->attr])) return $attr;
+        if (!isset($this->css[$this->attr])) {
+            return $attr;
+        }
 
         $style = '';
         foreach ($this->css[$this->attr] as $suffix) {
             $property = "margin-$suffix";
             $style .= "$property:{$width}px;";
         }
-
         $this->prependCSS($attr, $style);
-
         return $attr;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/Input.php
+++ b/library/HTMLPurifier/AttrTransform/Input.php
@@ -4,17 +4,31 @@
  * Performs miscellaneous cross attribute validation and filtering for
  * input elements. This is meant to be a post-transform.
  */
-class HTMLPurifier_AttrTransform_Input extends HTMLPurifier_AttrTransform {
-
+class HTMLPurifier_AttrTransform_Input extends HTMLPurifier_AttrTransform
+{
+    /**
+     * @type HTMLPurifier_AttrDef_HTML_Pixels
+     */
     protected $pixels;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->pixels = new HTMLPurifier_AttrDef_HTML_Pixels();
     }
 
-    public function transform($attr, $config, $context) {
-        if (!isset($attr['type'])) $t = 'text';
-        else $t = strtolower($attr['type']);
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (!isset($attr['type'])) {
+            $t = 'text';
+        } else {
+            $t = strtolower($attr['type']);
+        }
         if (isset($attr['checked']) && $t !== 'radio' && $t !== 'checkbox') {
             unset($attr['checked']);
         }
@@ -23,8 +37,11 @@ class HTMLPurifier_AttrTransform_Input extends HTMLPurifier_AttrTransform {
         }
         if (isset($attr['size']) && $t !== 'text' && $t !== 'password') {
             $result = $this->pixels->validate($attr['size'], $config, $context);
-            if ($result === false) unset($attr['size']);
-            else $attr['size'] = $result;
+            if ($result === false) {
+                unset($attr['size']);
+            } else {
+                $attr['size'] = $result;
+            }
         }
         if (isset($attr['src']) && $t !== 'image') {
             unset($attr['src']);
@@ -34,7 +51,6 @@ class HTMLPurifier_AttrTransform_Input extends HTMLPurifier_AttrTransform {
         }
         return $attr;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/Lang.php
+++ b/library/HTMLPurifier/AttrTransform/Lang.php
@@ -8,9 +8,15 @@
 class HTMLPurifier_AttrTransform_Lang extends HTMLPurifier_AttrTransform
 {
 
-    public function transform($attr, $config, $context) {
-
-        $lang     = isset($attr['lang']) ? $attr['lang'] : false;
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        $lang = isset($attr['lang']) ? $attr['lang'] : false;
         $xml_lang = isset($attr['xml:lang']) ? $attr['xml:lang'] : false;
 
         if ($lang !== false && $xml_lang === false) {
@@ -18,11 +24,8 @@ class HTMLPurifier_AttrTransform_Lang extends HTMLPurifier_AttrTransform
         } elseif ($xml_lang !== false) {
             $attr['lang'] = $xml_lang;
         }
-
         return $attr;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/Length.php
+++ b/library/HTMLPurifier/AttrTransform/Length.php
@@ -6,22 +6,40 @@
 class HTMLPurifier_AttrTransform_Length extends HTMLPurifier_AttrTransform
 {
 
+    /**
+     * @type string
+     */
     protected $name;
+
+    /**
+     * @type string
+     */
     protected $cssName;
 
-    public function __construct($name, $css_name = null) {
+    public function __construct($name, $css_name = null)
+    {
         $this->name = $name;
         $this->cssName = $css_name ? $css_name : $name;
     }
 
-    public function transform($attr, $config, $context) {
-        if (!isset($attr[$this->name])) return $attr;
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (!isset($attr[$this->name])) {
+            return $attr;
+        }
         $length = $this->confiscateAttr($attr, $this->name);
-        if(ctype_digit($length)) $length .= 'px';
+        if (ctype_digit($length)) {
+            $length .= 'px';
+        }
         $this->prependCSS($attr, $this->cssName . ":$length;");
         return $attr;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/Name.php
+++ b/library/HTMLPurifier/AttrTransform/Name.php
@@ -6,16 +6,28 @@
 class HTMLPurifier_AttrTransform_Name extends HTMLPurifier_AttrTransform
 {
 
-    public function transform($attr, $config, $context) {
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
         // Abort early if we're using relaxed definition of name
-        if ($config->get('HTML.Attr.Name.UseCDATA')) return $attr;
-        if (!isset($attr['name'])) return $attr;
+        if ($config->get('HTML.Attr.Name.UseCDATA')) {
+            return $attr;
+        }
+        if (!isset($attr['name'])) {
+            return $attr;
+        }
         $id = $this->confiscateAttr($attr, 'name');
-        if ( isset($attr['id']))   return $attr;
+        if (isset($attr['id'])) {
+            return $attr;
+        }
         $attr['id'] = $id;
         return $attr;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/NameSync.php
+++ b/library/HTMLPurifier/AttrTransform/NameSync.php
@@ -8,20 +8,34 @@
 class HTMLPurifier_AttrTransform_NameSync extends HTMLPurifier_AttrTransform
 {
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->idDef = new HTMLPurifier_AttrDef_HTML_ID();
     }
 
-    public function transform($attr, $config, $context) {
-        if (!isset($attr['name'])) return $attr;
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (!isset($attr['name'])) {
+            return $attr;
+        }
         $name = $attr['name'];
-        if (isset($attr['id']) && $attr['id'] === $name) return $attr;
+        if (isset($attr['id']) && $attr['id'] === $name) {
+            return $attr;
+        }
         $result = $this->idDef->validate($name, $config, $context);
-        if ($result === false) unset($attr['name']);
-        else $attr['name'] = $result;
+        if ($result === false) {
+            unset($attr['name']);
+        } else {
+            $attr['name'] = $result;
+        }
         return $attr;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/Nofollow.php
+++ b/library/HTMLPurifier/AttrTransform/Nofollow.php
@@ -8,14 +8,24 @@
  */
 class HTMLPurifier_AttrTransform_Nofollow extends HTMLPurifier_AttrTransform
 {
+    /**
+     * @type HTMLPurifier_URIParser
+     */
     private $parser;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->parser = new HTMLPurifier_URIParser();
     }
 
-    public function transform($attr, $config, $context) {
-
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
         if (!isset($attr['href'])) {
             return $attr;
         }
@@ -35,11 +45,8 @@ class HTMLPurifier_AttrTransform_Nofollow extends HTMLPurifier_AttrTransform
                 $attr['rel'] = 'nofollow';
             }
         }
-
         return $attr;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/SafeEmbed.php
+++ b/library/HTMLPurifier/AttrTransform/SafeEmbed.php
@@ -2,9 +2,19 @@
 
 class HTMLPurifier_AttrTransform_SafeEmbed extends HTMLPurifier_AttrTransform
 {
+    /**
+     * @type string
+     */
     public $name = "SafeEmbed";
 
-    public function transform($attr, $config, $context) {
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
         $attr['allowscriptaccess'] = 'never';
         $attr['allownetworking'] = 'internal';
         $attr['type'] = 'application/x-shockwave-flash';

--- a/library/HTMLPurifier/AttrTransform/SafeObject.php
+++ b/library/HTMLPurifier/AttrTransform/SafeObject.php
@@ -5,10 +5,22 @@
  */
 class HTMLPurifier_AttrTransform_SafeObject extends HTMLPurifier_AttrTransform
 {
+    /**
+     * @type string
+     */
     public $name = "SafeObject";
 
-    function transform($attr, $config, $context) {
-        if (!isset($attr['type'])) $attr['type'] = 'application/x-shockwave-flash';
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
+        if (!isset($attr['type'])) {
+            $attr['type'] = 'application/x-shockwave-flash';
+        }
         return $attr;
     }
 }

--- a/library/HTMLPurifier/AttrTransform/SafeParam.php
+++ b/library/HTMLPurifier/AttrTransform/SafeParam.php
@@ -14,15 +14,30 @@
  */
 class HTMLPurifier_AttrTransform_SafeParam extends HTMLPurifier_AttrTransform
 {
+    /**
+     * @type string
+     */
     public $name = "SafeParam";
+
+    /**
+     * @type HTMLPurifier_AttrDef_URI
+     */
     private $uri;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->uri = new HTMLPurifier_AttrDef_URI(true); // embedded
         $this->wmode = new HTMLPurifier_AttrDef_Enum(array('window', 'opaque', 'transparent'));
     }
 
-    public function transform($attr, $config, $context) {
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
         // If we add support for other objects, we'll need to alter the
         // transforms.
         switch ($attr['name']) {

--- a/library/HTMLPurifier/AttrTransform/ScriptRequired.php
+++ b/library/HTMLPurifier/AttrTransform/ScriptRequired.php
@@ -5,7 +5,14 @@
  */
 class HTMLPurifier_AttrTransform_ScriptRequired extends HTMLPurifier_AttrTransform
 {
-    public function transform($attr, $config, $context) {
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
         if (!isset($attr['type'])) {
             $attr['type'] = 'text/javascript';
         }

--- a/library/HTMLPurifier/AttrTransform/TargetBlank.php
+++ b/library/HTMLPurifier/AttrTransform/TargetBlank.php
@@ -9,14 +9,24 @@
  */
 class HTMLPurifier_AttrTransform_TargetBlank extends HTMLPurifier_AttrTransform
 {
+    /**
+     * @type HTMLPurifier_URIParser
+     */
     private $parser;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->parser = new HTMLPurifier_URIParser();
     }
 
-    public function transform($attr, $config, $context) {
-
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
         if (!isset($attr['href'])) {
             return $attr;
         }
@@ -28,11 +38,8 @@ class HTMLPurifier_AttrTransform_TargetBlank extends HTMLPurifier_AttrTransform
         if ($scheme->browsable && !$url->isBenign($config, $context)) {
             $attr['target'] = '_blank';
         }
-
         return $attr;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTransform/Textarea.php
+++ b/library/HTMLPurifier/AttrTransform/Textarea.php
@@ -5,14 +5,23 @@
  */
 class HTMLPurifier_AttrTransform_Textarea extends HTMLPurifier_AttrTransform
 {
-
-    public function transform($attr, $config, $context) {
+    /**
+     * @param array $attr
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function transform($attr, $config, $context)
+    {
         // Calculated from Firefox
-        if (!isset($attr['cols'])) $attr['cols'] = '22';
-        if (!isset($attr['rows'])) $attr['rows'] = '3';
+        if (!isset($attr['cols'])) {
+            $attr['cols'] = '22';
+        }
+        if (!isset($attr['rows'])) {
+            $attr['rows'] = '3';
+        }
         return $attr;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/AttrTypes.php
+++ b/library/HTMLPurifier/AttrTypes.php
@@ -6,7 +6,8 @@
 class HTMLPurifier_AttrTypes
 {
     /**
-     * Lookup array of attribute string identifiers to concrete implementations
+     * Lookup array of attribute string identifiers to concrete implementations.
+     * @type HTMLPurifier_AttrDef[]
      */
     protected $info = array();
 
@@ -14,7 +15,8 @@ class HTMLPurifier_AttrTypes
      * Constructs the info array, supplying default implementations for attribute
      * types.
      */
-    public function __construct() {
+    public function __construct()
+    {
         // XXX This is kind of poor, since we don't actually /clone/
         // instances; instead, we use the supplied make() attribute. So,
         // the underlying class must know how to deal with arguments.
@@ -54,36 +56,39 @@ class HTMLPurifier_AttrTypes
         $this->info['Number']   = new HTMLPurifier_AttrDef_Integer(false, false, true);
     }
 
-    private static function makeEnum($in) {
+    private static function makeEnum($in)
+    {
         return new HTMLPurifier_AttrDef_Clone(new HTMLPurifier_AttrDef_Enum(explode(',', $in)));
     }
 
     /**
      * Retrieves a type
-     * @param $type String type name
-     * @return Object AttrDef for type
+     * @param string $type String type name
+     * @return HTMLPurifier_AttrDef Object AttrDef for type
      */
-    public function get($type) {
-
+    public function get($type)
+    {
         // determine if there is any extra info tacked on
-        if (strpos($type, '#') !== false) list($type, $string) = explode('#', $type, 2);
-        else $string = '';
+        if (strpos($type, '#') !== false) {
+            list($type, $string) = explode('#', $type, 2);
+        } else {
+            $string = '';
+        }
 
         if (!isset($this->info[$type])) {
             trigger_error('Cannot retrieve undefined attribute type ' . $type, E_USER_ERROR);
             return;
         }
-
         return $this->info[$type]->make($string);
-
     }
 
     /**
      * Sets a new implementation for a type
-     * @param $type String type name
-     * @param $impl Object AttrDef for type
+     * @param string $type String type name
+     * @param HTMLPurifier_AttrDef $impl Object AttrDef for type
      */
-    public function set($type, $impl) {
+    public function set($type, $impl)
+    {
         $this->info[$type] = $impl;
     }
 }

--- a/library/HTMLPurifier/AttrValidator.php
+++ b/library/HTMLPurifier/AttrValidator.php
@@ -11,15 +11,16 @@ class HTMLPurifier_AttrValidator
     /**
      * Validates the attributes of a token, returning a modified token
      * that has valid tokens
-     * @param $token Reference to token to validate. We require a reference
+     * @param HTMLPurifier_Token $token Reference to token to validate. We require a reference
      *     because the operation this class performs on the token are
      *     not atomic, so the context CurrentToken to be updated
      *     throughout
-     * @param $config Instance of HTMLPurifier_Config
-     * @param $context Instance of HTMLPurifier_Context
+     * @param HTMLPurifier_Config $config Instance of HTMLPurifier_Config
+     * @param HTMLPurifier_Context $context Instance of HTMLPurifier_Context
+     * @return HTMLPurifier_Token
      */
-    public function validateToken(&$token, &$config, $context) {
-
+    public function validateToken(&$token, &$config, $context)
+    {
         $definition = $config->getHTMLDefinition();
         $e =& $context->get('ErrorCollector', true);
 
@@ -32,12 +33,15 @@ class HTMLPurifier_AttrValidator
 
         // initialize CurrentToken if necessary
         $current_token =& $context->get('CurrentToken', true);
-        if (!$current_token) $context->register('CurrentToken', $token);
+        if (!$current_token) {
+            $context->register('CurrentToken', $token);
+        }
 
-        if (
-            !$token instanceof HTMLPurifier_Token_Start &&
+        if (!$token instanceof HTMLPurifier_Token_Start &&
             !$token instanceof HTMLPurifier_Token_Empty
-        ) return $token;
+        ) {
+            return $token;
+        }
 
         // create alias to global definition array, see also $defs
         // DEFINITION CALL
@@ -51,7 +55,9 @@ class HTMLPurifier_AttrValidator
         foreach ($definition->info_attr_transform_pre as $transform) {
             $attr = $transform->transform($o = $attr, $config, $context);
             if ($e) {
-                if ($attr != $o) $e->send(E_NOTICE, 'AttrValidator: Attributes transformed', $o, $attr);
+                if ($attr != $o) {
+                    $e->send(E_NOTICE, 'AttrValidator: Attributes transformed', $o, $attr);
+                }
             }
         }
 
@@ -60,7 +66,9 @@ class HTMLPurifier_AttrValidator
         foreach ($definition->info[$token->name]->attr_transform_pre as $transform) {
             $attr = $transform->transform($o = $attr, $config, $context);
             if ($e) {
-                if ($attr != $o) $e->send(E_NOTICE, 'AttrValidator: Attributes transformed', $o, $attr);
+                if ($attr != $o) {
+                    $e->send(E_NOTICE, 'AttrValidator: Attributes transformed', $o, $attr);
+                }
             }
         }
 
@@ -77,7 +85,7 @@ class HTMLPurifier_AttrValidator
         foreach ($attr as $attr_key => $value) {
 
             // call the definition
-            if ( isset($defs[$attr_key]) ) {
+            if (isset($defs[$attr_key])) {
                 // there is a local definition defined
                 if ($defs[$attr_key] === false) {
                     // We've explicitly been told not to allow this element.
@@ -89,15 +97,19 @@ class HTMLPurifier_AttrValidator
                 } else {
                     // validate according to the element's definition
                     $result = $defs[$attr_key]->validate(
-                                    $value, $config, $context
-                               );
+                        $value,
+                        $config,
+                        $context
+                    );
                 }
-            } elseif ( isset($d_defs[$attr_key]) ) {
+            } elseif (isset($d_defs[$attr_key])) {
                 // there is a global definition defined, validate according
                 // to the global definition
                 $result = $d_defs[$attr_key]->validate(
-                                $value, $config, $context
-                           );
+                    $value,
+                    $config,
+                    $context
+                );
             } else {
                 // system never heard of the attribute? DELETE!
                 $result = false;
@@ -107,7 +119,9 @@ class HTMLPurifier_AttrValidator
             if ($result === false || $result === null) {
                 // this is a generic error message that should replaced
                 // with more specific ones when possible
-                if ($e) $e->send(E_ERROR, 'AttrValidator: Attribute removed');
+                if ($e) {
+                    $e->send(E_ERROR, 'AttrValidator: Attribute removed');
+                }
 
                 // remove the attribute
                 unset($attr[$attr_key]);
@@ -137,7 +151,9 @@ class HTMLPurifier_AttrValidator
         foreach ($definition->info_attr_transform_post as $transform) {
             $attr = $transform->transform($o = $attr, $config, $context);
             if ($e) {
-                if ($attr != $o) $e->send(E_NOTICE, 'AttrValidator: Attributes transformed', $o, $attr);
+                if ($attr != $o) {
+                    $e->send(E_NOTICE, 'AttrValidator: Attributes transformed', $o, $attr);
+                }
             }
         }
 
@@ -145,14 +161,18 @@ class HTMLPurifier_AttrValidator
         foreach ($definition->info[$token->name]->attr_transform_post as $transform) {
             $attr = $transform->transform($o = $attr, $config, $context);
             if ($e) {
-                if ($attr != $o) $e->send(E_NOTICE, 'AttrValidator: Attributes transformed', $o, $attr);
+                if ($attr != $o) {
+                    $e->send(E_NOTICE, 'AttrValidator: Attributes transformed', $o, $attr);
+                }
             }
         }
 
         $token->attr = $attr;
 
         // destroy CurrentToken if we made it ourselves
-        if (!$current_token) $context->destroy('CurrentToken');
+        if (!$current_token) {
+            $context->destroy('CurrentToken');
+        }
 
     }
 

--- a/library/HTMLPurifier/Bootstrap.php
+++ b/library/HTMLPurifier/Bootstrap.php
@@ -32,11 +32,15 @@ class HTMLPurifier_Bootstrap
 
     /**
      * Autoload function for HTML Purifier
-     * @param $class Class to load
+     * @param string $class Class to load
+     * @return bool
      */
-    public static function autoload($class) {
+    public static function autoload($class)
+    {
         $file = HTMLPurifier_Bootstrap::getPath($class);
-        if (!$file) return false;
+        if (!$file) {
+            return false;
+        }
         // Technically speaking, it should be ok and more efficient to
         // just do 'require', but Antonio Parraga reports that with
         // Zend extensions such as Zend debugger and APC, this invariant
@@ -48,9 +52,14 @@ class HTMLPurifier_Bootstrap
 
     /**
      * Returns the path for a specific class.
+     * @param string $class Class path to get
+     * @return string
      */
-    public static function getPath($class) {
-        if (strncmp('HTMLPurifier', $class, 12) !== 0) return false;
+    public static function getPath($class)
+    {
+        if (strncmp('HTMLPurifier', $class, 12) !== 0) {
+            return false;
+        }
         // Custom implementations
         if (strncmp('HTMLPurifier_Language_', $class, 22) === 0) {
             $code = str_replace('_', '-', substr($class, 22));
@@ -58,16 +67,19 @@ class HTMLPurifier_Bootstrap
         } else {
             $file = str_replace('_', '/', $class) . '.php';
         }
-        if (!file_exists(HTMLPURIFIER_PREFIX . '/' . $file)) return false;
+        if (!file_exists(HTMLPURIFIER_PREFIX . '/' . $file)) {
+            return false;
+        }
         return $file;
     }
 
     /**
      * "Pre-registers" our autoloader on the SPL stack.
      */
-    public static function registerAutoload() {
+    public static function registerAutoload()
+    {
         $autoload = array('HTMLPurifier_Bootstrap', 'autoload');
-        if ( ($funcs = spl_autoload_functions()) === false ) {
+        if (($funcs = spl_autoload_functions()) === false) {
             spl_autoload_register($autoload);
         } elseif (function_exists('spl_autoload_unregister')) {
             if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
@@ -83,27 +95,30 @@ class HTMLPurifier_Bootstrap
                         // places where we need to error out
                         $reflector = new ReflectionMethod($func[0], $func[1]);
                         if (!$reflector->isStatic()) {
-                            throw new Exception('
-                                HTML Purifier autoloader registrar is not compatible
+                            throw new Exception(
+                                'HTML Purifier autoloader registrar is not compatible
                                 with non-static object methods due to PHP Bug #44144;
                                 Please do not use HTMLPurifier.autoload.php (or any
                                 file that includes this file); instead, place the code:
                                 spl_autoload_register(array(\'HTMLPurifier_Bootstrap\', \'autoload\'))
-                                after your own autoloaders.
-                            ');
+                                after your own autoloaders.'
+                            );
                         }
                         // Suprisingly, spl_autoload_register supports the
                         // Class::staticMethod callback format, although call_user_func doesn't
-                        if ($compat) $func = implode('::', $func);
+                        if ($compat) {
+                            $func = implode('::', $func);
+                        }
                     }
                     spl_autoload_unregister($func);
                 }
                 spl_autoload_register($autoload);
-                foreach ($funcs as $func) spl_autoload_register($func);
+                foreach ($funcs as $func) {
+                    spl_autoload_register($func);
+                }
             }
         }
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/CSSDefinition.php
+++ b/library/HTMLPurifier/CSSDefinition.php
@@ -11,35 +11,59 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
 
     /**
      * Assoc array of attribute name to definition object.
+     * @type HTMLPurifier_AttrDef[]
      */
     public $info = array();
 
     /**
      * Constructs the info array.  The meat of this class.
+     * @param HTMLPurifier_Config $config
      */
-    protected function doSetup($config) {
-
+    protected function doSetup($config)
+    {
         $this->info['text-align'] = new HTMLPurifier_AttrDef_Enum(
-            array('left', 'right', 'center', 'justify'), false);
+            array('left', 'right', 'center', 'justify'),
+            false
+        );
 
         $border_style =
-        $this->info['border-bottom-style'] =
-        $this->info['border-right-style'] =
-        $this->info['border-left-style'] =
-        $this->info['border-top-style'] =  new HTMLPurifier_AttrDef_Enum(
-            array('none', 'hidden', 'dotted', 'dashed', 'solid', 'double',
-            'groove', 'ridge', 'inset', 'outset'), false);
+            $this->info['border-bottom-style'] =
+            $this->info['border-right-style'] =
+            $this->info['border-left-style'] =
+            $this->info['border-top-style'] = new HTMLPurifier_AttrDef_Enum(
+                array(
+                    'none',
+                    'hidden',
+                    'dotted',
+                    'dashed',
+                    'solid',
+                    'double',
+                    'groove',
+                    'ridge',
+                    'inset',
+                    'outset'
+                ),
+                false
+            );
 
         $this->info['border-style'] = new HTMLPurifier_AttrDef_CSS_Multiple($border_style);
 
         $this->info['clear'] = new HTMLPurifier_AttrDef_Enum(
-            array('none', 'left', 'right', 'both'), false);
+            array('none', 'left', 'right', 'both'),
+            false
+        );
         $this->info['float'] = new HTMLPurifier_AttrDef_Enum(
-            array('none', 'left', 'right'), false);
+            array('none', 'left', 'right'),
+            false
+        );
         $this->info['font-style'] = new HTMLPurifier_AttrDef_Enum(
-            array('normal', 'italic', 'oblique'), false);
+            array('normal', 'italic', 'oblique'),
+            false
+        );
         $this->info['font-variant'] = new HTMLPurifier_AttrDef_Enum(
-            array('normal', 'small-caps'), false);
+            array('normal', 'small-caps'),
+            false
+        );
 
         $uri_or_none = new HTMLPurifier_AttrDef_CSS_Composite(
             array(
@@ -49,16 +73,31 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
         );
 
         $this->info['list-style-position'] = new HTMLPurifier_AttrDef_Enum(
-            array('inside', 'outside'), false);
+            array('inside', 'outside'),
+            false
+        );
         $this->info['list-style-type'] = new HTMLPurifier_AttrDef_Enum(
-            array('disc', 'circle', 'square', 'decimal', 'lower-roman',
-            'upper-roman', 'lower-alpha', 'upper-alpha', 'none'), false);
+            array(
+                'disc',
+                'circle',
+                'square',
+                'decimal',
+                'lower-roman',
+                'upper-roman',
+                'lower-alpha',
+                'upper-alpha',
+                'none'
+            ),
+            false
+        );
         $this->info['list-style-image'] = $uri_or_none;
 
         $this->info['list-style'] = new HTMLPurifier_AttrDef_CSS_ListStyle($config);
 
         $this->info['text-transform'] = new HTMLPurifier_AttrDef_Enum(
-            array('capitalize', 'uppercase', 'lowercase', 'none'), false);
+            array('capitalize', 'uppercase', 'lowercase', 'none'),
+            false
+        );
         $this->info['color'] = new HTMLPurifier_AttrDef_CSS_Color();
 
         $this->info['background-image'] = $uri_or_none;
@@ -71,104 +110,137 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
         $this->info['background-position'] = new HTMLPurifier_AttrDef_CSS_BackgroundPosition();
 
         $border_color =
-        $this->info['border-top-color'] =
-        $this->info['border-bottom-color'] =
-        $this->info['border-left-color'] =
-        $this->info['border-right-color'] =
-        $this->info['background-color'] = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_Enum(array('transparent')),
-            new HTMLPurifier_AttrDef_CSS_Color()
-        ));
+            $this->info['border-top-color'] =
+            $this->info['border-bottom-color'] =
+            $this->info['border-left-color'] =
+            $this->info['border-right-color'] =
+            $this->info['background-color'] = new HTMLPurifier_AttrDef_CSS_Composite(
+                array(
+                    new HTMLPurifier_AttrDef_Enum(array('transparent')),
+                    new HTMLPurifier_AttrDef_CSS_Color()
+                )
+            );
 
         $this->info['background'] = new HTMLPurifier_AttrDef_CSS_Background($config);
 
         $this->info['border-color'] = new HTMLPurifier_AttrDef_CSS_Multiple($border_color);
 
         $border_width =
-        $this->info['border-top-width'] =
-        $this->info['border-bottom-width'] =
-        $this->info['border-left-width'] =
-        $this->info['border-right-width'] = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_Enum(array('thin', 'medium', 'thick')),
-            new HTMLPurifier_AttrDef_CSS_Length('0') //disallow negative
-        ));
+            $this->info['border-top-width'] =
+            $this->info['border-bottom-width'] =
+            $this->info['border-left-width'] =
+            $this->info['border-right-width'] = new HTMLPurifier_AttrDef_CSS_Composite(
+                array(
+                    new HTMLPurifier_AttrDef_Enum(array('thin', 'medium', 'thick')),
+                    new HTMLPurifier_AttrDef_CSS_Length('0') //disallow negative
+                )
+            );
 
         $this->info['border-width'] = new HTMLPurifier_AttrDef_CSS_Multiple($border_width);
 
-        $this->info['letter-spacing'] = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_Enum(array('normal')),
-            new HTMLPurifier_AttrDef_CSS_Length()
-        ));
+        $this->info['letter-spacing'] = new HTMLPurifier_AttrDef_CSS_Composite(
+            array(
+                new HTMLPurifier_AttrDef_Enum(array('normal')),
+                new HTMLPurifier_AttrDef_CSS_Length()
+            )
+        );
 
-        $this->info['word-spacing'] = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_Enum(array('normal')),
-            new HTMLPurifier_AttrDef_CSS_Length()
-        ));
+        $this->info['word-spacing'] = new HTMLPurifier_AttrDef_CSS_Composite(
+            array(
+                new HTMLPurifier_AttrDef_Enum(array('normal')),
+                new HTMLPurifier_AttrDef_CSS_Length()
+            )
+        );
 
-        $this->info['font-size'] = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_Enum(array('xx-small', 'x-small',
-                'small', 'medium', 'large', 'x-large', 'xx-large',
-                'larger', 'smaller')),
-            new HTMLPurifier_AttrDef_CSS_Percentage(),
-            new HTMLPurifier_AttrDef_CSS_Length()
-        ));
+        $this->info['font-size'] = new HTMLPurifier_AttrDef_CSS_Composite(
+            array(
+                new HTMLPurifier_AttrDef_Enum(
+                    array(
+                        'xx-small',
+                        'x-small',
+                        'small',
+                        'medium',
+                        'large',
+                        'x-large',
+                        'xx-large',
+                        'larger',
+                        'smaller'
+                    )
+                ),
+                new HTMLPurifier_AttrDef_CSS_Percentage(),
+                new HTMLPurifier_AttrDef_CSS_Length()
+            )
+        );
 
-        $this->info['line-height'] = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_Enum(array('normal')),
-            new HTMLPurifier_AttrDef_CSS_Number(true), // no negatives
-            new HTMLPurifier_AttrDef_CSS_Length('0'),
-            new HTMLPurifier_AttrDef_CSS_Percentage(true)
-        ));
+        $this->info['line-height'] = new HTMLPurifier_AttrDef_CSS_Composite(
+            array(
+                new HTMLPurifier_AttrDef_Enum(array('normal')),
+                new HTMLPurifier_AttrDef_CSS_Number(true), // no negatives
+                new HTMLPurifier_AttrDef_CSS_Length('0'),
+                new HTMLPurifier_AttrDef_CSS_Percentage(true)
+            )
+        );
 
         $margin =
-        $this->info['margin-top'] =
-        $this->info['margin-bottom'] =
-        $this->info['margin-left'] =
-        $this->info['margin-right'] = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_CSS_Length(),
-            new HTMLPurifier_AttrDef_CSS_Percentage(),
-            new HTMLPurifier_AttrDef_Enum(array('auto'))
-        ));
+            $this->info['margin-top'] =
+            $this->info['margin-bottom'] =
+            $this->info['margin-left'] =
+            $this->info['margin-right'] = new HTMLPurifier_AttrDef_CSS_Composite(
+                array(
+                    new HTMLPurifier_AttrDef_CSS_Length(),
+                    new HTMLPurifier_AttrDef_CSS_Percentage(),
+                    new HTMLPurifier_AttrDef_Enum(array('auto'))
+                )
+            );
 
         $this->info['margin'] = new HTMLPurifier_AttrDef_CSS_Multiple($margin);
 
         // non-negative
         $padding =
-        $this->info['padding-top'] =
-        $this->info['padding-bottom'] =
-        $this->info['padding-left'] =
-        $this->info['padding-right'] = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_CSS_Length('0'),
-            new HTMLPurifier_AttrDef_CSS_Percentage(true)
-        ));
+            $this->info['padding-top'] =
+            $this->info['padding-bottom'] =
+            $this->info['padding-left'] =
+            $this->info['padding-right'] = new HTMLPurifier_AttrDef_CSS_Composite(
+                array(
+                    new HTMLPurifier_AttrDef_CSS_Length('0'),
+                    new HTMLPurifier_AttrDef_CSS_Percentage(true)
+                )
+            );
 
         $this->info['padding'] = new HTMLPurifier_AttrDef_CSS_Multiple($padding);
 
-        $this->info['text-indent'] = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_CSS_Length(),
-            new HTMLPurifier_AttrDef_CSS_Percentage()
-        ));
+        $this->info['text-indent'] = new HTMLPurifier_AttrDef_CSS_Composite(
+            array(
+                new HTMLPurifier_AttrDef_CSS_Length(),
+                new HTMLPurifier_AttrDef_CSS_Percentage()
+            )
+        );
 
-        $trusted_wh = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_CSS_Length('0'),
-            new HTMLPurifier_AttrDef_CSS_Percentage(true),
-            new HTMLPurifier_AttrDef_Enum(array('auto'))
-        ));
+        $trusted_wh = new HTMLPurifier_AttrDef_CSS_Composite(
+            array(
+                new HTMLPurifier_AttrDef_CSS_Length('0'),
+                new HTMLPurifier_AttrDef_CSS_Percentage(true),
+                new HTMLPurifier_AttrDef_Enum(array('auto'))
+            )
+        );
         $max = $config->get('CSS.MaxImgLength');
 
         $this->info['width'] =
         $this->info['height'] =
             $max === null ?
-            $trusted_wh :
-            new HTMLPurifier_AttrDef_Switch('img',
-                // For img tags:
-                new HTMLPurifier_AttrDef_CSS_Composite(array(
-                    new HTMLPurifier_AttrDef_CSS_Length('0', $max),
-                    new HTMLPurifier_AttrDef_Enum(array('auto'))
-                )),
-                // For everyone else:
-                $trusted_wh
-            );
+                $trusted_wh :
+                new HTMLPurifier_AttrDef_Switch(
+                    'img',
+                    // For img tags:
+                    new HTMLPurifier_AttrDef_CSS_Composite(
+                        array(
+                            new HTMLPurifier_AttrDef_CSS_Length('0', $max),
+                            new HTMLPurifier_AttrDef_Enum(array('auto'))
+                        )
+                    ),
+                    // For everyone else:
+                    $trusted_wh
+                );
 
         $this->info['text-decoration'] = new HTMLPurifier_AttrDef_CSS_TextDecoration();
 
@@ -176,8 +248,23 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
 
         // this could use specialized code
         $this->info['font-weight'] = new HTMLPurifier_AttrDef_Enum(
-            array('normal', 'bold', 'bolder', 'lighter', '100', '200', '300',
-            '400', '500', '600', '700', '800', '900'), false);
+            array(
+                'normal',
+                'bold',
+                'bolder',
+                'lighter',
+                '100',
+                '200',
+                '300',
+                '400',
+                '500',
+                '600',
+                '700',
+                '800',
+                '900'
+            ),
+            false
+        );
 
         // MUST be called after other font properties, as it references
         // a CSSDefinition object
@@ -190,27 +277,44 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
         $this->info['border-left'] =
         $this->info['border-right'] = new HTMLPurifier_AttrDef_CSS_Border($config);
 
-        $this->info['border-collapse'] = new HTMLPurifier_AttrDef_Enum(array(
-            'collapse', 'separate'));
+        $this->info['border-collapse'] = new HTMLPurifier_AttrDef_Enum(
+            array('collapse', 'separate')
+        );
 
-        $this->info['caption-side'] = new HTMLPurifier_AttrDef_Enum(array(
-            'top', 'bottom'));
+        $this->info['caption-side'] = new HTMLPurifier_AttrDef_Enum(
+            array('top', 'bottom')
+        );
 
-        $this->info['table-layout'] = new HTMLPurifier_AttrDef_Enum(array(
-            'auto', 'fixed'));
+        $this->info['table-layout'] = new HTMLPurifier_AttrDef_Enum(
+            array('auto', 'fixed')
+        );
 
-        $this->info['vertical-align'] = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_Enum(array('baseline', 'sub', 'super',
-                'top', 'text-top', 'middle', 'bottom', 'text-bottom')),
-            new HTMLPurifier_AttrDef_CSS_Length(),
-            new HTMLPurifier_AttrDef_CSS_Percentage()
-        ));
+        $this->info['vertical-align'] = new HTMLPurifier_AttrDef_CSS_Composite(
+            array(
+                new HTMLPurifier_AttrDef_Enum(
+                    array(
+                        'baseline',
+                        'sub',
+                        'super',
+                        'top',
+                        'text-top',
+                        'middle',
+                        'bottom',
+                        'text-bottom'
+                    )
+                ),
+                new HTMLPurifier_AttrDef_CSS_Length(),
+                new HTMLPurifier_AttrDef_CSS_Percentage()
+            )
+        );
 
         $this->info['border-spacing'] = new HTMLPurifier_AttrDef_CSS_Multiple(new HTMLPurifier_AttrDef_CSS_Length(), 2);
 
         // These CSS properties don't work on many browsers, but we live
         // in THE FUTURE!
-        $this->info['white-space'] = new HTMLPurifier_AttrDef_Enum(array('nowrap', 'normal', 'pre', 'pre-wrap', 'pre-line'));
+        $this->info['white-space'] = new HTMLPurifier_AttrDef_Enum(
+            array('nowrap', 'normal', 'pre', 'pre-wrap', 'pre-line')
+        );
 
         if ($config->get('CSS.Proprietary')) {
             $this->doSetupProprietary($config);
@@ -233,76 +337,119 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
         $this->setupConfigStuff($config);
     }
 
-    protected function doSetupProprietary($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    protected function doSetupProprietary($config)
+    {
         // Internet Explorer only scrollbar colors
-        $this->info['scrollbar-arrow-color']        = new HTMLPurifier_AttrDef_CSS_Color();
-        $this->info['scrollbar-base-color']         = new HTMLPurifier_AttrDef_CSS_Color();
-        $this->info['scrollbar-darkshadow-color']   = new HTMLPurifier_AttrDef_CSS_Color();
-        $this->info['scrollbar-face-color']         = new HTMLPurifier_AttrDef_CSS_Color();
-        $this->info['scrollbar-highlight-color']    = new HTMLPurifier_AttrDef_CSS_Color();
-        $this->info['scrollbar-shadow-color']       = new HTMLPurifier_AttrDef_CSS_Color();
+        $this->info['scrollbar-arrow-color'] = new HTMLPurifier_AttrDef_CSS_Color();
+        $this->info['scrollbar-base-color'] = new HTMLPurifier_AttrDef_CSS_Color();
+        $this->info['scrollbar-darkshadow-color'] = new HTMLPurifier_AttrDef_CSS_Color();
+        $this->info['scrollbar-face-color'] = new HTMLPurifier_AttrDef_CSS_Color();
+        $this->info['scrollbar-highlight-color'] = new HTMLPurifier_AttrDef_CSS_Color();
+        $this->info['scrollbar-shadow-color'] = new HTMLPurifier_AttrDef_CSS_Color();
 
         // technically not proprietary, but CSS3, and no one supports it
-        $this->info['opacity']          = new HTMLPurifier_AttrDef_CSS_AlphaValue();
-        $this->info['-moz-opacity']     = new HTMLPurifier_AttrDef_CSS_AlphaValue();
-        $this->info['-khtml-opacity']   = new HTMLPurifier_AttrDef_CSS_AlphaValue();
+        $this->info['opacity'] = new HTMLPurifier_AttrDef_CSS_AlphaValue();
+        $this->info['-moz-opacity'] = new HTMLPurifier_AttrDef_CSS_AlphaValue();
+        $this->info['-khtml-opacity'] = new HTMLPurifier_AttrDef_CSS_AlphaValue();
 
         // only opacity, for now
         $this->info['filter'] = new HTMLPurifier_AttrDef_CSS_Filter();
 
         // more CSS3
         $this->info['page-break-after'] =
-        $this->info['page-break-before'] = new HTMLPurifier_AttrDef_Enum(array('auto','always','avoid','left','right'));
-        $this->info['page-break-inside'] = new HTMLPurifier_AttrDef_Enum(array('auto','avoid'));
+        $this->info['page-break-before'] = new HTMLPurifier_AttrDef_Enum(
+            array(
+                'auto',
+                'always',
+                'avoid',
+                'left',
+                'right'
+            )
+        );
+        $this->info['page-break-inside'] = new HTMLPurifier_AttrDef_Enum(array('auto', 'avoid'));
 
     }
 
-    protected function doSetupTricky($config) {
-        $this->info['display'] = new HTMLPurifier_AttrDef_Enum(array(
-            'inline', 'block', 'list-item', 'run-in', 'compact',
-            'marker', 'table', 'inline-block', 'inline-table', 'table-row-group',
-            'table-header-group', 'table-footer-group', 'table-row',
-            'table-column-group', 'table-column', 'table-cell', 'table-caption', 'none'
-        ));
-        $this->info['visibility'] = new HTMLPurifier_AttrDef_Enum(array(
-            'visible', 'hidden', 'collapse'
-        ));
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    protected function doSetupTricky($config)
+    {
+        $this->info['display'] = new HTMLPurifier_AttrDef_Enum(
+            array(
+                'inline',
+                'block',
+                'list-item',
+                'run-in',
+                'compact',
+                'marker',
+                'table',
+                'inline-block',
+                'inline-table',
+                'table-row-group',
+                'table-header-group',
+                'table-footer-group',
+                'table-row',
+                'table-column-group',
+                'table-column',
+                'table-cell',
+                'table-caption',
+                'none'
+            )
+        );
+        $this->info['visibility'] = new HTMLPurifier_AttrDef_Enum(
+            array('visible', 'hidden', 'collapse')
+        );
         $this->info['overflow'] = new HTMLPurifier_AttrDef_Enum(array('visible', 'hidden', 'auto', 'scroll'));
     }
 
-    protected function doSetupTrusted($config) {
-        $this->info['position'] = new HTMLPurifier_AttrDef_Enum(array(
-            'static', 'relative', 'absolute', 'fixed'
-        ));
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    protected function doSetupTrusted($config)
+    {
+        $this->info['position'] = new HTMLPurifier_AttrDef_Enum(
+            array('static', 'relative', 'absolute', 'fixed')
+        );
         $this->info['top'] =
         $this->info['left'] =
         $this->info['right'] =
-        $this->info['bottom'] = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_CSS_Length(),
-            new HTMLPurifier_AttrDef_CSS_Percentage(),
-            new HTMLPurifier_AttrDef_Enum(array('auto')),
-        ));
-        $this->info['z-index'] = new HTMLPurifier_AttrDef_CSS_Composite(array(
-            new HTMLPurifier_AttrDef_Integer(),
-            new HTMLPurifier_AttrDef_Enum(array('auto')),
-        ));
+        $this->info['bottom'] = new HTMLPurifier_AttrDef_CSS_Composite(
+            array(
+                new HTMLPurifier_AttrDef_CSS_Length(),
+                new HTMLPurifier_AttrDef_CSS_Percentage(),
+                new HTMLPurifier_AttrDef_Enum(array('auto')),
+            )
+        );
+        $this->info['z-index'] = new HTMLPurifier_AttrDef_CSS_Composite(
+            array(
+                new HTMLPurifier_AttrDef_Integer(),
+                new HTMLPurifier_AttrDef_Enum(array('auto')),
+            )
+        );
     }
 
     /**
      * Performs extra config-based processing. Based off of
      * HTMLPurifier_HTMLDefinition.
+     * @param HTMLPurifier_Config $config
      * @todo Refactor duplicate elements into common class (probably using
      *       composition, not inheritance).
      */
-    protected function setupConfigStuff($config) {
-
+    protected function setupConfigStuff($config)
+    {
         // setup allowed elements
-        $support = "(for information on implementing this, see the ".
-                   "support forums) ";
+        $support = "(for information on implementing this, see the " .
+            "support forums) ";
         $allowed_properties = $config->get('CSS.AllowedProperties');
         if ($allowed_properties !== null) {
             foreach ($this->info as $name => $d) {
-                if(!isset($allowed_properties[$name])) unset($this->info[$name]);
+                if (!isset($allowed_properties[$name])) {
+                    unset($this->info[$name]);
+                }
                 unset($allowed_properties[$name]);
             }
             // emit errors
@@ -321,7 +468,6 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
                 }
             }
         }
-
     }
 }
 

--- a/library/HTMLPurifier/ChildDef.php
+++ b/library/HTMLPurifier/ChildDef.php
@@ -8,39 +8,43 @@ abstract class HTMLPurifier_ChildDef
     /**
      * Type of child definition, usually right-most part of class name lowercase.
      * Used occasionally in terms of context.
+     * @type string
      */
     public $type;
 
     /**
-     * Bool that indicates whether or not an empty array of children is okay
+     * Indicates whether or not an empty array of children is okay.
      *
      * This is necessary for redundant checking when changes affecting
      * a child node may cause a parent node to now be disallowed.
+     * @type bool
      */
     public $allow_empty;
 
     /**
-     * Lookup array of all elements that this definition could possibly allow
+     * Lookup array of all elements that this definition could possibly allow.
+     * @type array
      */
     public $elements = array();
 
     /**
      * Get lookup of tag names that should not close this element automatically.
      * All other elements will do so.
+     * @param HTMLPurifier_Config $config HTMLPurifier_Config object
+     * @return array
      */
-    public function getAllowedElements($config) {
+    public function getAllowedElements($config)
+    {
         return $this->elements;
     }
 
     /**
      * Validates nodes according to definition and returns modification.
      *
-     * @param $tokens_of_children Array of HTMLPurifier_Token
-     * @param $config HTMLPurifier_Config object
-     * @param $context HTMLPurifier_Context object
-     * @return bool true to leave nodes as is
-     * @return bool false to remove parent node
-     * @return array of replacement child tokens
+     * @param HTMLPurifier_Token[] $tokens_of_children Array of HTMLPurifier_Token
+     * @param HTMLPurifier_Config $config HTMLPurifier_Config object
+     * @param HTMLPurifier_Context $context HTMLPurifier_Context object
+     * @return bool|array true to leave nodes as is, false to remove parent node, array of replacement child tokens
      */
     abstract public function validateChildren($tokens_of_children, $config, $context);
 }

--- a/library/HTMLPurifier/ChildDef/Chameleon.php
+++ b/library/HTMLPurifier/ChildDef/Chameleon.php
@@ -14,33 +14,52 @@ class HTMLPurifier_ChildDef_Chameleon extends HTMLPurifier_ChildDef
 
     /**
      * Instance of the definition object to use when inline. Usually stricter.
+     * @type HTMLPurifier_ChildDef_Optional
      */
     public $inline;
 
     /**
      * Instance of the definition object to use when block.
+     * @type HTMLPurifier_ChildDef_Optional
      */
     public $block;
 
+    /**
+     * @type string
+     */
     public $type = 'chameleon';
 
     /**
-     * @param $inline List of elements to allow when inline.
-     * @param $block List of elements to allow when block.
+     * @param array $inline List of elements to allow when inline.
+     * @param array $block List of elements to allow when block.
      */
-    public function __construct($inline, $block) {
+    public function __construct($inline, $block)
+    {
         $this->inline = new HTMLPurifier_ChildDef_Optional($inline);
-        $this->block  = new HTMLPurifier_ChildDef_Optional($block);
+        $this->block = new HTMLPurifier_ChildDef_Optional($block);
         $this->elements = $this->block->elements;
     }
 
-    public function validateChildren($tokens_of_children, $config, $context) {
+    /**
+     * @param array $tokens_of_children
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function validateChildren($tokens_of_children, $config, $context)
+    {
         if ($context->get('IsInline') === false) {
             return $this->block->validateChildren(
-                $tokens_of_children, $config, $context);
+                $tokens_of_children,
+                $config,
+                $context
+            );
         } else {
             return $this->inline->validateChildren(
-                $tokens_of_children, $config, $context);
+                $tokens_of_children,
+                $config,
+                $context
+            );
         }
     }
 }

--- a/library/HTMLPurifier/ChildDef/Custom.php
+++ b/library/HTMLPurifier/ChildDef/Custom.php
@@ -8,28 +8,42 @@
  */
 class HTMLPurifier_ChildDef_Custom extends HTMLPurifier_ChildDef
 {
-    public $type = 'custom';
-    public $allow_empty = false;
     /**
-     * Allowed child pattern as defined by the DTD
+     * @type string
+     */
+    public $type = 'custom';
+
+    /**
+     * @type bool
+     */
+    public $allow_empty = false;
+
+    /**
+     * Allowed child pattern as defined by the DTD.
+     * @type string
      */
     public $dtd_regex;
+
     /**
-     * PCRE regex derived from $dtd_regex
-     * @private
+     * PCRE regex derived from $dtd_regex.
+     * @type string
      */
     private $_pcre_regex;
+
     /**
      * @param $dtd_regex Allowed child pattern from the DTD
      */
-    public function __construct($dtd_regex) {
+    public function __construct($dtd_regex)
+    {
         $this->dtd_regex = $dtd_regex;
         $this->_compileRegex();
     }
+
     /**
      * Compiles the PCRE regex from a DTD regex ($dtd_regex to $_pcre_regex)
      */
-    protected function _compileRegex() {
+    protected function _compileRegex()
+    {
         $raw = str_replace(' ', '', $this->dtd_regex);
         if ($raw{0} != '(') {
             $raw = "($raw)";
@@ -57,11 +71,21 @@ class HTMLPurifier_ChildDef_Custom extends HTMLPurifier_ChildDef
 
         $this->_pcre_regex = $reg;
     }
-    public function validateChildren($tokens_of_children, $config, $context) {
+
+    /**
+     * @param array $tokens_of_children
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function validateChildren($tokens_of_children, $config, $context)
+    {
         $list_of_children = '';
         $nesting = 0; // depth into the nest
         foreach ($tokens_of_children as $token) {
-            if (!empty($token->is_whitespace)) continue;
+            if (!empty($token->is_whitespace)) {
+                continue;
+            }
 
             $is_child = ($nesting == 0); // direct
 
@@ -79,11 +103,10 @@ class HTMLPurifier_ChildDef_Custom extends HTMLPurifier_ChildDef
         $list_of_children = ',' . rtrim($list_of_children, ',');
         $okay =
             preg_match(
-                '/^,?'.$this->_pcre_regex.'$/',
+                '/^,?' . $this->_pcre_regex . '$/',
                 $list_of_children
             );
-
-        return (bool) $okay;
+        return (bool)$okay;
     }
 }
 

--- a/library/HTMLPurifier/ChildDef/Empty.php
+++ b/library/HTMLPurifier/ChildDef/Empty.php
@@ -9,10 +9,28 @@
  */
 class HTMLPurifier_ChildDef_Empty extends HTMLPurifier_ChildDef
 {
+    /**
+     * @type bool
+     */
     public $allow_empty = true;
+
+    /**
+     * @type string
+     */
     public $type = 'empty';
-    public function __construct() {}
-    public function validateChildren($tokens_of_children, $config, $context) {
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @param array $tokens_of_children
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function validateChildren($tokens_of_children, $config, $context)
+    {
         return array();
     }
 }

--- a/library/HTMLPurifier/ChildDef/List.php
+++ b/library/HTMLPurifier/ChildDef/List.php
@@ -5,16 +5,32 @@
  */
 class HTMLPurifier_ChildDef_List extends HTMLPurifier_ChildDef
 {
+    /**
+     * @type string
+     */
     public $type = 'list';
+    /**
+     * @type array
+     */
     // lying a little bit, so that we can handle ul and ol ourselves
     // XXX: This whole business with 'wrap' is all a bit unsatisfactory
     public $elements = array('li' => true, 'ul' => true, 'ol' => true);
-    public function validateChildren($tokens_of_children, $config, $context) {
+
+    /**
+     * @param array $tokens_of_children
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function validateChildren($tokens_of_children, $config, $context)
+    {
         // Flag for subclasses
         $this->whitespace = false;
 
         // if there are no tokens, delete parent node
-        if (empty($tokens_of_children)) return false;
+        if (empty($tokens_of_children)) {
+            return false;
+        }
 
         // the new set of children
         $result = array();
@@ -62,7 +78,7 @@ class HTMLPurifier_ChildDef_List extends HTMLPurifier_ChildDef
                         $result[] = new HTMLPurifier_Token_Start('li');
                     } else {
                         // backtrack until </li> found
-                        while(true) {
+                        while (true) {
                             $t = array_pop($result);
                             if ($t instanceof HTMLPurifier_Token_End) {
                                 // XXX actually, these invariants could very plausibly be violated
@@ -84,7 +100,10 @@ class HTMLPurifier_ChildDef_List extends HTMLPurifier_ChildDef
                                 break;
                             } else {
                                 if (!$t->is_whitespace) {
-                                    trigger_error("Only whitespace present invariant violated in List ChildDef", E_USER_ERROR);
+                                    trigger_error(
+                                        "Only whitespace present invariant violated in List ChildDef",
+                                        E_USER_ERROR
+                                    );
                                     return false;
                                 }
                             }
@@ -108,11 +127,15 @@ class HTMLPurifier_ChildDef_List extends HTMLPurifier_ChildDef
         if ($need_close_li) {
             $result[] = new HTMLPurifier_Token_End('li');
         }
-        if (empty($result)) return false;
+        if (empty($result)) {
+            return false;
+        }
         if ($all_whitespace) {
             return false;
         }
-        if ($tokens_of_children == $result) return true;
+        if ($tokens_of_children == $result) {
+            return true;
+        }
         return $result;
     }
 }

--- a/library/HTMLPurifier/ChildDef/Optional.php
+++ b/library/HTMLPurifier/ChildDef/Optional.php
@@ -9,15 +9,34 @@
  */
 class HTMLPurifier_ChildDef_Optional extends HTMLPurifier_ChildDef_Required
 {
+    /**
+     * @type bool
+     */
     public $allow_empty = true;
+
+    /**
+     * @type string
+     */
     public $type = 'optional';
-    public function validateChildren($tokens_of_children, $config, $context) {
+
+    /**
+     * @param array $tokens_of_children
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function validateChildren($tokens_of_children, $config, $context)
+    {
         $result = parent::validateChildren($tokens_of_children, $config, $context);
         // we assume that $tokens_of_children is not modified
         if ($result === false) {
-            if (empty($tokens_of_children)) return true;
-            elseif ($this->whitespace) return $tokens_of_children;
-            else return array();
+            if (empty($tokens_of_children)) {
+                return true;
+            } elseif ($this->whitespace) {
+                return $tokens_of_children;
+            } else {
+                return array();
+            }
         }
         return $result;
     }

--- a/library/HTMLPurifier/ChildDef/Required.php
+++ b/library/HTMLPurifier/ChildDef/Required.php
@@ -7,17 +7,21 @@ class HTMLPurifier_ChildDef_Required extends HTMLPurifier_ChildDef
 {
     /**
      * Lookup table of allowed elements.
-     * @public
+     * @type array
      */
     public $elements = array();
+
     /**
      * Whether or not the last passed node was all whitespace.
+     * @type bool
      */
     protected $whitespace = false;
+
     /**
-     * @param $elements List of allowed element names (lowercase).
+     * @param array|string $elements List of allowed element names (lowercase).
      */
-    public function __construct($elements) {
+    public function __construct($elements)
+    {
         if (is_string($elements)) {
             $elements = str_replace(' ', '', $elements);
             $elements = explode('|', $elements);
@@ -27,19 +31,39 @@ class HTMLPurifier_ChildDef_Required extends HTMLPurifier_ChildDef
             $elements = array_flip($elements);
             foreach ($elements as $i => $x) {
                 $elements[$i] = true;
-                if (empty($i)) unset($elements[$i]); // remove blank
+                if (empty($i)) {
+                    unset($elements[$i]);
+                } // remove blank
             }
         }
         $this->elements = $elements;
     }
+
+    /**
+     * @type bool
+     */
     public $allow_empty = false;
+
+    /**
+     * @type string
+     */
     public $type = 'required';
-    public function validateChildren($tokens_of_children, $config, $context) {
+
+    /**
+     * @param array $tokens_of_children
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function validateChildren($tokens_of_children, $config, $context)
+    {
         // Flag for subclasses
         $this->whitespace = false;
 
         // if there are no tokens, delete parent node
-        if (empty($tokens_of_children)) return false;
+        if (empty($tokens_of_children)) {
+            return false;
+        }
 
         // the new set of children
         $result = array();
@@ -104,12 +128,16 @@ class HTMLPurifier_ChildDef_Required extends HTMLPurifier_ChildDef
                 // drop silently
             }
         }
-        if (empty($result)) return false;
+        if (empty($result)) {
+            return false;
+        }
         if ($all_whitespace) {
             $this->whitespace = true;
             return false;
         }
-        if ($tokens_of_children == $result) return true;
+        if ($tokens_of_children == $result) {
+            return true;
+        }
         return $result;
     }
 }

--- a/library/HTMLPurifier/ChildDef/StrictBlockquote.php
+++ b/library/HTMLPurifier/ChildDef/StrictBlockquote.php
@@ -5,23 +5,51 @@
  */
 class HTMLPurifier_ChildDef_StrictBlockquote extends HTMLPurifier_ChildDef_Required
 {
+    /**
+     * @type array
+     */
     protected $real_elements;
+
+    /**
+     * @type array
+     */
     protected $fake_elements;
+
+    /**
+     * @type bool
+     */
     public $allow_empty = true;
+
+    /**
+     * @type string
+     */
     public $type = 'strictblockquote';
+
+    /**
+     * @type bool
+     */
     protected $init = false;
 
     /**
+     * @param HTMLPurifier_Config $config
+     * @return array
      * @note We don't want MakeWellFormed to auto-close inline elements since
      *       they might be allowed.
      */
-    public function getAllowedElements($config) {
+    public function getAllowedElements($config)
+    {
         $this->init($config);
         return $this->fake_elements;
     }
 
-    public function validateChildren($tokens_of_children, $config, $context) {
-
+    /**
+     * @param array $tokens_of_children
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function validateChildren($tokens_of_children, $config, $context)
+    {
         $this->init($config);
 
         // trick the parent class into thinking it allows more
@@ -29,12 +57,16 @@ class HTMLPurifier_ChildDef_StrictBlockquote extends HTMLPurifier_ChildDef_Requi
         $result = parent::validateChildren($tokens_of_children, $config, $context);
         $this->elements = $this->real_elements;
 
-        if ($result === false) return array();
-        if ($result === true) $result = $tokens_of_children;
+        if ($result === false) {
+            return array();
+        }
+        if ($result === true) {
+            $result = $tokens_of_children;
+        }
 
         $def = $config->getHTMLDefinition();
         $block_wrap_start = new HTMLPurifier_Token_Start($def->info_block_wrapper);
-        $block_wrap_end   = new HTMLPurifier_Token_End(  $def->info_block_wrapper);
+        $block_wrap_end = new HTMLPurifier_Token_End($def->info_block_wrapper);
         $is_inline = false;
         $depth = 0;
         $ret = array();
@@ -45,13 +77,11 @@ class HTMLPurifier_ChildDef_StrictBlockquote extends HTMLPurifier_ChildDef_Requi
             // ifs are nested for readability
             if (!$is_inline) {
                 if (!$depth) {
-                     if (
-                        ($token instanceof HTMLPurifier_Token_Text && !$token->is_whitespace) ||
-                        (!$token instanceof HTMLPurifier_Token_Text && !isset($this->elements[$token->name]))
-                     ) {
+                    if (($token instanceof HTMLPurifier_Token_Text && !$token->is_whitespace) ||
+                        (!$token instanceof HTMLPurifier_Token_Text && !isset($this->elements[$token->name]))) {
                         $is_inline = true;
                         $ret[] = $block_wrap_start;
-                     }
+                    }
                 }
             } else {
                 if (!$depth) {
@@ -66,14 +96,24 @@ class HTMLPurifier_ChildDef_StrictBlockquote extends HTMLPurifier_ChildDef_Requi
                 }
             }
             $ret[] = $token;
-            if ($token instanceof HTMLPurifier_Token_Start) $depth++;
-            if ($token instanceof HTMLPurifier_Token_End)   $depth--;
+            if ($token instanceof HTMLPurifier_Token_Start) {
+                $depth++;
+            }
+            if ($token instanceof HTMLPurifier_Token_End) {
+                $depth--;
+            }
         }
-        if ($is_inline) $ret[] = $block_wrap_end;
+        if ($is_inline) {
+            $ret[] = $block_wrap_end;
+        }
         return $ret;
     }
 
-    private function init($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    private function init($config)
+    {
         if (!$this->init) {
             $def = $config->getHTMLDefinition();
             // allow all inline elements

--- a/library/HTMLPurifier/ChildDef/Table.php
+++ b/library/HTMLPurifier/ChildDef/Table.php
@@ -31,13 +31,44 @@
  */
 class HTMLPurifier_ChildDef_Table extends HTMLPurifier_ChildDef
 {
+    /**
+     * @type bool
+     */
     public $allow_empty = false;
+
+    /**
+     * @type string
+     */
     public $type = 'table';
-    public $elements = array('tr' => true, 'tbody' => true, 'thead' => true,
-        'tfoot' => true, 'caption' => true, 'colgroup' => true, 'col' => true);
-    public function __construct() {}
-    public function validateChildren($tokens_of_children, $config, $context) {
-        if (empty($tokens_of_children)) return false;
+
+    /**
+     * @type array
+     */
+    public $elements = array(
+        'tr' => true,
+        'tbody' => true,
+        'thead' => true,
+        'tfoot' => true,
+        'caption' => true,
+        'colgroup' => true,
+        'col' => true
+    );
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * @param array $tokens_of_children
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array
+     */
+    public function validateChildren($tokens_of_children, $config, $context)
+    {
+        if (empty($tokens_of_children)) {
+            return false;
+        }
 
         // this ensures that the loop gets run one last time before closing
         // up. It's a little bit of a hack, but it works! Just make sure you
@@ -46,23 +77,23 @@ class HTMLPurifier_ChildDef_Table extends HTMLPurifier_ChildDef
 
         // only one of these elements is allowed in a table
         $caption = false;
-        $thead   = false;
-        $tfoot   = false;
+        $thead = false;
+        $tfoot = false;
 
         // as many of these as you want
-        $cols    = array();
+        $cols = array();
         $content = array();
 
         $nesting = 0; // current depth so we can determine nodes
         $is_collecting = false; // are we globbing together tokens to package
-                                // into one of the collectors?
+        // into one of the collectors?
         $collection = array(); // collected nodes
         // INVARIANT: if $is_collecting, then !empty($collection)
         // The converse does NOT hold, see [WHITESPACE]
         $tag_index = 0; // the first node might be whitespace,
-                            // so this tells us where the start tag is
+        // so this tells us where the start tag is
         $tbody_mode = false; // if true, then we need to wrap any stray
-                             // <tr>s with a <tbody>.
+        // <tr>s with a <tbody>.
 
         foreach ($tokens_of_children as $token) {
             $is_child = ($nesting == 0);
@@ -88,7 +119,9 @@ class HTMLPurifier_ChildDef_Table extends HTMLPurifier_ChildDef
                             $content[] = $collection;
                             break;
                         case 'caption':
-                            if ($caption !== false) break;
+                            if ($caption !== false) {
+                                break;
+                            }
                             $caption = $collection;
                             break;
                         case 'thead':
@@ -116,11 +149,11 @@ class HTMLPurifier_ChildDef_Table extends HTMLPurifier_ChildDef
                                 // doesn't float an extra tfoot to the
                                 // bottom like it does for the first one.
                                 $collection[$tag_index]->name = 'tbody';
-                                $collection[count($collection)-1]->name = 'tbody';
+                                $collection[count($collection) - 1]->name = 'tbody';
                                 $content[] = $collection;
                             }
                             break;
-                         case 'colgroup':
+                        case 'colgroup':
                             $cols[] = $collection;
                             break;
                     }
@@ -134,7 +167,9 @@ class HTMLPurifier_ChildDef_Table extends HTMLPurifier_ChildDef
             }
 
             // terminate
-            if ($token === false) break;
+            if ($token === false) {
+                break;
+            }
 
             if ($is_child) {
                 // determine what we're dealing with
@@ -147,7 +182,7 @@ class HTMLPurifier_ChildDef_Table extends HTMLPurifier_ChildDef
                     $tag_index = 0;
                     continue;
                 }
-                switch($token->name) {
+                switch ($token->name) {
                     case 'caption':
                     case 'colgroup':
                     case 'thead':
@@ -172,7 +207,9 @@ class HTMLPurifier_ChildDef_Table extends HTMLPurifier_ChildDef
             }
         }
 
-        if (empty($content)) return false;
+        if (empty($content)) {
+            return false;
+        }
         // INVARIANT: all members of content are non-empty.  This can
         // be shown by observing when things are pushed onto content:
         // they are only ever pushed when is_collecting is true, and
@@ -180,10 +217,20 @@ class HTMLPurifier_ChildDef_Table extends HTMLPurifier_ChildDef
         // that collections are non-empty when is_collecting is true.
 
         $ret = array();
-        if ($caption !== false) $ret = array_merge($ret, $caption);
-        if ($cols !== false)    foreach ($cols as $token_array) $ret = array_merge($ret, $token_array);
-        if ($thead !== false)   $ret = array_merge($ret, $thead);
-        if ($tfoot !== false)   $ret = array_merge($ret, $tfoot);
+        if ($caption !== false) {
+            $ret = array_merge($ret, $caption);
+        }
+        if ($cols !== false) {
+            foreach ($cols as $token_array) {
+                $ret = array_merge($ret, $token_array);
+            }
+        }
+        if ($thead !== false) {
+            $ret = array_merge($ret, $thead);
+        }
+        if ($tfoot !== false) {
+            $ret = array_merge($ret, $tfoot);
+        }
 
         if ($tbody_mode) {
             // a little tricky, since the start of the collection may be
@@ -228,7 +275,7 @@ class HTMLPurifier_ChildDef_Table extends HTMLPurifier_ChildDef
             }
         }
 
-        if (!empty($collection) && $is_collecting == false){
+        if (!empty($collection) && $is_collecting == false) {
             // grab the trailing space
             $ret = array_merge($ret, $collection);
         }

--- a/library/HTMLPurifier/Config.php
+++ b/library/HTMLPurifier/Config.php
@@ -19,79 +19,89 @@ class HTMLPurifier_Config
 
     /**
      * HTML Purifier's version
+     * @type string
      */
     public $version = '4.5.0';
 
     /**
-     * @var bool indicator whether or not to automatically finalize
-     * the object if a read operation is done
+     * Whether or not to automatically finalize
+     * the object if a read operation is done.
+     * @type bool
      */
     public $autoFinalize = true;
 
     // protected member variables
 
     /**
-     * Namespace indexed array of serials for specific namespaces (see
-     * getSerial() for more info).
+     * Namespace indexed array of serials for specific namespaces.
+     * @see getSerial() for more info.
+     * @type string[]
      */
     protected $serials = array();
 
     /**
-     * Serial for entire configuration object
+     * Serial for entire configuration object.
+     * @type string
      */
     protected $serial;
 
     /**
-     * Parser for variables
+     * Parser for variables.
+     * @type HTMLPurifier_VarParser_Flexible
      */
     protected $parser = null;
 
     /**
-     * Reference HTMLPurifier_ConfigSchema for value checking
+     * Reference HTMLPurifier_ConfigSchema for value checking.
+     * @type HTMLPurifier_ConfigSchema
      * @note This is public for introspective purposes. Please don't
      *       abuse!
      */
     public $def;
 
     /**
-     * @var HTMLPurifier_Definition[] Indexed array of definitions
+     * Indexed array of definitions.
+     * @type HTMLPurifier_Definition[]
      */
     protected $definitions;
 
     /**
-     * Bool indicator whether or not config is finalized
+     * Whether or not config is finalized.
+     * @type bool
      */
     protected $finalized = false;
 
     /**
      * Property list containing configuration directives.
+     * @type array
      */
     protected $plist;
 
     /**
-     * Whether or not a set is taking place due to an
-     * alias lookup.
+     * Whether or not a set is taking place due to an alias lookup.
+     * @type bool
      */
     private $aliasMode;
 
     /**
-     * Set to false if you do not want line and file numbers in errors
+     * Set to false if you do not want line and file numbers in errors.
      * (useful when unit testing).  This will also compress some errors
      * and exceptions.
+     * @type bool
      */
     public $chatty = true;
 
     /**
      * Current lock; only gets to this namespace are allowed.
+     * @type string
      */
     private $lock;
 
     /**
      * Constructor
-     *
-     * @param HTMLPurifier_ConfigSchema $definition  ConfigSchema that defines
+     * @param HTMLPurifier_ConfigSchema $definition ConfigSchema that defines
      * what directives are allowed.
-     * @param mixed $parent
+     * @param HTMLPurifier_PropertyList $parent
      */
     public function __construct($definition, $parent = null)
     {
@@ -103,13 +113,11 @@ class HTMLPurifier_Config
 
     /**
      * Convenience constructor that creates a config object based on a mixed var
-     *
      * @param mixed $config Variable that defines the state of the config
      *                      object. Can be: a HTMLPurifier_Config() object,
      *                      an array of directives based on loadArray(),
      *                      or a string filename of an ini file.
      * @param HTMLPurifier_ConfigSchema $schema Schema object
-     *
      * @return HTMLPurifier_Config Configured object
      */
     public static function create($config, $schema = null)
@@ -125,17 +133,13 @@ class HTMLPurifier_Config
         }
         if (is_string($config)) {
             $ret->loadIni($config);
-        }
-        elseif (is_array($config)) $ret->loadArray($config);
+        } elseif (is_array($config)) $ret->loadArray($config);
         return $ret;
     }
 
     /**
      * Creates a new config object that inherits from a previous one.
-     *
-     * @param HTMLPurifier_Config $config Configuration object to inherit
-     *        from.
-     *
+     * @param HTMLPurifier_Config $config Configuration object to inherit from.
      * @return HTMLPurifier_Config object with $config as its parent.
      */
     public static function inherit(HTMLPurifier_Config $config)
@@ -195,7 +199,9 @@ class HTMLPurifier_Config
             if ($ns !== $this->lock) {
                 $this->triggerError(
                     'Cannot get value of namespace ' . $ns . ' when lock for ' .
-                    $this->lock . ' is active, this probably indicates a Definition setup method is accessing directives that are not within its namespace',
+                    $this->lock .
+                    ' is active, this probably indicates a Definition setup method ' .
+                    'is accessing directives that are not within its namespace',
                     E_USER_ERROR
                 );
                 return;
@@ -384,7 +390,9 @@ class HTMLPurifier_Config
     private function _listify($lookup)
     {
         $list = array();
-        foreach ($lookup as $name => $b) $list[] = $name;
+        foreach ($lookup as $name => $b) {
+            $list[] = $name;
+        }
         return implode(', ', $list);
     }
 
@@ -400,7 +408,7 @@ class HTMLPurifier_Config
      *             maybeGetRawHTMLDefinition, which is more explicitly
      *             named, instead.
      *
-     * @return mixed
+     * @return HTMLPurifier_HTMLDefinition
      */
     public function getHTMLDefinition($raw = false, $optimized = false)
     {
@@ -419,7 +427,7 @@ class HTMLPurifier_Config
      *             maybeGetRawCSSDefinition, which is more explicitly
      *             named, instead.
      *
-     * @return mixed
+     * @return HTMLPurifier_CSSDefinition
      */
     public function getCSSDefinition($raw = false, $optimized = false)
     {
@@ -438,7 +446,7 @@ class HTMLPurifier_Config
      *             maybeGetRawURIDefinition, which is more explicitly
      *             named, instead.
      *
-     * @return mixed
+     * @return HTMLPurifier_URIDefinition
      */
     public function getURIDefinition($raw = false, $optimized = false)
     {
@@ -460,7 +468,7 @@ class HTMLPurifier_Config
      *        maybe semantics is the "right thing to do."
      *
      * @throws HTMLPurifier_Exception
-     * @return mixed
+     * @return HTMLPurifier_Definition
      */
     public function getDefinition($type, $raw = false, $optimized = false)
     {
@@ -542,8 +550,12 @@ class HTMLPurifier_Config
                 }
                 if ($def->optimized !== $optimized) {
                     $msg = $optimized ? "optimized" : "unoptimized";
-                    $extra = $this->chatty ? " (this backtrace is for the first inconsistent call, which was for a $msg raw definition)" : "";
-                    throw new HTMLPurifier_Exception("Inconsistent use of optimized and unoptimized raw definition retrievals" . $extra);
+                    $extra = $this->chatty ?
+                        " (this backtrace is for the first inconsistent call, which was for a $msg raw definition)"
+                        : "";
+                    throw new HTMLPurifier_Exception(
+                        "Inconsistent use of optimized and unoptimized raw definition retrievals" . $extra
+                    );
                 }
             }
             // check if definition was in memory
@@ -576,7 +588,17 @@ class HTMLPurifier_Config
             if (!$optimized) {
                 if (!is_null($this->get($type . '.DefinitionID'))) {
                     if ($this->chatty) {
-                        $this->triggerError("Due to a documentation error in previous version of HTML Purifier, your definitions are not being cached.  If this is OK, you can remove the %$type.DefinitionRev and %$type.DefinitionID declaration.  Otherwise, modify your code to use maybeGetRawDefinition, and test if the returned value is null before making any edits (if it is null, that means that a cached version is available, and no raw operations are necessary).  See <a href='http://htmlpurifier.org/docs/enduser-customize.html#optimized'>Customize</a> for more details", E_USER_WARNING);
+                        $this->triggerError(
+                            'Due to a documentation error in previous version of HTML Purifier, your ' .
+                            'definitions are not being cached.  If this is OK, you can remove the ' .
+                            '%$type.DefinitionRev and %$type.DefinitionID declaration.  Otherwise, ' .
+                            'modify your code to use maybeGetRawDefinition, and test if the returned ' .
+                            'value is null before making any edits (if it is null, that means that a ' .
+                            'cached version is available, and no raw operations are necessary).  See ' .
+                            '<a href="http://htmlpurifier.org/docs/enduser-customize.html#optimized">' .
+                            'Customize</a> for more details',
+                            E_USER_WARNING
+                        );
                     } else {
                         $this->triggerError(
                             "Useless DefinitionID declaration",

--- a/library/HTMLPurifier/ConfigSchema.php
+++ b/library/HTMLPurifier/ConfigSchema.php
@@ -3,21 +3,24 @@
 /**
  * Configuration definition, defines directives and their defaults.
  */
-class HTMLPurifier_ConfigSchema {
-
+class HTMLPurifier_ConfigSchema
+{
     /**
      * Defaults of the directives and namespaces.
+     * @type array
      * @note This shares the exact same structure as HTMLPurifier_Config::$conf
      */
     public $defaults = array();
 
     /**
      * The default property list. Do not edit this property list.
+     * @type array
      */
     public $defaultPlist;
 
     /**
-     * Definition of the directives. The structure of this is:
+     * Definition of the directives.
+     * The structure of this is:
      *
      *  array(
      *      'Namespace' => array(
@@ -44,22 +47,27 @@ class HTMLPurifier_ConfigSchema {
      * This class is friendly with HTMLPurifier_Config. If you need introspection
      * about the schema, you're better of using the ConfigSchema_Interchange,
      * which uses more memory but has much richer information.
+     * @type array
      */
     public $info = array();
 
     /**
      * Application-wide singleton
+     * @type HTMLPurifier_ConfigSchema
      */
-    static protected $singleton;
+    protected static $singleton;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->defaultPlist = new HTMLPurifier_PropertyList();
     }
 
     /**
      * Unserializes the default ConfigSchema.
+     * @return HTMLPurifier_ConfigSchema
      */
-    public static function makeFromSerial() {
+    public static function makeFromSerial()
+    {
         $contents = file_get_contents(HTMLPURIFIER_PREFIX . '/HTMLPurifier/ConfigSchema/schema.ser');
         $r = unserialize($contents);
         if (!$r) {
@@ -71,8 +79,11 @@ class HTMLPurifier_ConfigSchema {
 
     /**
      * Retrieves an instance of the application-wide configuration definition.
+     * @param HTMLPurifier_ConfigSchema $prototype
+     * @return HTMLPurifier_ConfigSchema
      */
-    public static function instance($prototype = null) {
+    public static function instance($prototype = null)
+    {
         if ($prototype !== null) {
             HTMLPurifier_ConfigSchema::$singleton = $prototype;
         } elseif (HTMLPurifier_ConfigSchema::$singleton === null || $prototype === true) {
@@ -86,17 +97,19 @@ class HTMLPurifier_ConfigSchema {
      * @warning Will fail of directive's namespace is defined.
      * @warning This method's signature is slightly different from the legacy
      *          define() static method! Beware!
-     * @param $namespace Namespace the directive is in
-     * @param $name Key of directive
-     * @param $default Default value of directive
-     * @param $type Allowed type of the directive. See
+     * @param string $key Name of directive
+     * @param mixed $default Default value of directive
+     * @param string $type Allowed type of the directive. See
      *      HTMLPurifier_DirectiveDef::$type for allowed values
-     * @param $allow_null Whether or not to allow null values
+     * @param bool $allow_null Whether or not to allow null values
      */
-    public function add($key, $default, $type, $allow_null) {
+    public function add($key, $default, $type, $allow_null)
+    {
         $obj = new stdclass();
         $obj->type = is_int($type) ? $type : HTMLPurifier_VarParser::$types[$type];
-        if ($allow_null) $obj->allow_null = true;
+        if ($allow_null) {
+            $obj->allow_null = true;
+        }
         $this->info[$key] = $obj;
         $this->defaults[$key] = $default;
         $this->defaultPlist->set($key, $default);
@@ -107,11 +120,11 @@ class HTMLPurifier_ConfigSchema {
      *
      * Directive value aliases are convenient for developers because it lets
      * them set a directive to several values and get the same result.
-     * @param $namespace Directive's namespace
-     * @param $name Name of Directive
-     * @param $aliases Hash of aliased values to the real alias
+     * @param string $key Name of Directive
+     * @param array $aliases Hash of aliased values to the real alias
      */
-    public function addValueAliases($key, $aliases) {
+    public function addValueAliases($key, $aliases)
+    {
         if (!isset($this->info[$key]->aliases)) {
             $this->info[$key]->aliases = array();
         }
@@ -124,22 +137,21 @@ class HTMLPurifier_ConfigSchema {
      * Defines a set of allowed values for a directive.
      * @warning This is slightly different from the corresponding static
      *          method definition.
-     * @param $namespace Namespace of directive
-     * @param $name Name of directive
-     * @param $allowed Lookup array of allowed values
+     * @param string $key Name of directive
+     * @param array $allowed Lookup array of allowed values
      */
-    public function addAllowedValues($key, $allowed) {
+    public function addAllowedValues($key, $allowed)
+    {
         $this->info[$key]->allowed = $allowed;
     }
 
     /**
      * Defines a directive alias for backwards compatibility
-     * @param $namespace
-     * @param $name Directive that will be aliased
-     * @param $new_namespace
-     * @param $new_name Directive that the alias will be to
+     * @param string $key Directive that will be aliased
+     * @param string $new_key Directive that the alias will be to
      */
-    public function addAlias($key, $new_key) {
+    public function addAlias($key, $new_key)
+    {
         $obj = new stdclass;
         $obj->key = $new_key;
         $obj->isAlias = true;
@@ -149,7 +161,8 @@ class HTMLPurifier_ConfigSchema {
     /**
      * Replaces any stdclass that only has the type property with type integer.
      */
-    public function postProcess() {
+    public function postProcess()
+    {
         foreach ($this->info as $key => $v) {
             if (count((array) $v) == 1) {
                 $this->info[$key] = $v->type;
@@ -158,7 +171,6 @@ class HTMLPurifier_ConfigSchema {
             }
         }
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/ConfigSchema/Builder/ConfigSchema.php
+++ b/library/HTMLPurifier/ConfigSchema/Builder/ConfigSchema.php
@@ -7,7 +7,12 @@
 class HTMLPurifier_ConfigSchema_Builder_ConfigSchema
 {
 
-    public function build($interchange) {
+    /**
+     * @param HTMLPurifier_ConfigSchema_Interchange $interchange
+     * @return HTMLPurifier_ConfigSchema
+     */
+    public function build($interchange)
+    {
         $schema = new HTMLPurifier_ConfigSchema();
         foreach ($interchange->directives as $d) {
             $schema->add(
@@ -38,7 +43,6 @@ class HTMLPurifier_ConfigSchema_Builder_ConfigSchema
         $schema->postProcess();
         return $schema;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/ConfigSchema/Builder/Xml.php
+++ b/library/HTMLPurifier/ConfigSchema/Builder/Xml.php
@@ -7,10 +7,21 @@
 class HTMLPurifier_ConfigSchema_Builder_Xml extends XMLWriter
 {
 
+    /**
+     * @type HTMLPurifier_ConfigSchema_Interchange
+     */
     protected $interchange;
+
+    /**
+     * @type string
+     */
     private $namespace;
 
-    protected function writeHTMLDiv($html) {
+    /**
+     * @param string $html
+     */
+    protected function writeHTMLDiv($html)
+    {
         $this->startElement('div');
 
         $purifier = HTMLPurifier::getInstance();
@@ -21,12 +32,23 @@ class HTMLPurifier_ConfigSchema_Builder_Xml extends XMLWriter
         $this->endElement(); // div
     }
 
-    protected function export($var) {
-        if ($var === array()) return 'array()';
+    /**
+     * @param mixed $var
+     * @return string
+     */
+    protected function export($var)
+    {
+        if ($var === array()) {
+            return 'array()';
+        }
         return var_export($var, true);
     }
 
-    public function build($interchange) {
+    /**
+     * @param HTMLPurifier_ConfigSchema_Interchange $interchange
+     */
+    public function build($interchange)
+    {
         // global access, only use as last resort
         $this->interchange = $interchange;
 
@@ -39,19 +61,26 @@ class HTMLPurifier_ConfigSchema_Builder_Xml extends XMLWriter
             $this->buildDirective($directive);
         }
 
-        if ($this->namespace) $this->endElement(); // namespace
+        if ($this->namespace) {
+            $this->endElement();
+        } // namespace
 
         $this->endElement(); // configdoc
         $this->flush();
     }
 
-    public function buildDirective($directive) {
-
+    /**
+     * @param HTMLPurifier_ConfigSchema_Interchange_Directive $directive
+     */
+    public function buildDirective($directive)
+    {
         // Kludge, although I suppose having a notion of a "root namespace"
         // certainly makes things look nicer when documentation is built.
         // Depends on things being sorted.
         if (!$this->namespace || $this->namespace !== $directive->id->getRootNamespace()) {
-            if ($this->namespace) $this->endElement(); // namespace
+            if ($this->namespace) {
+                $this->endElement();
+            } // namespace
             $this->namespace = $directive->id->getRootNamespace();
             $this->startElement('namespace');
             $this->writeAttribute('id', $this->namespace);
@@ -64,43 +93,52 @@ class HTMLPurifier_ConfigSchema_Builder_Xml extends XMLWriter
         $this->writeElement('name', $directive->id->getDirective());
 
         $this->startElement('aliases');
-            foreach ($directive->aliases as $alias) $this->writeElement('alias', $alias->toString());
+        foreach ($directive->aliases as $alias) {
+            $this->writeElement('alias', $alias->toString());
+        }
         $this->endElement(); // aliases
 
         $this->startElement('constraints');
-            if ($directive->version) $this->writeElement('version', $directive->version);
-            $this->startElement('type');
-                if ($directive->typeAllowsNull) $this->writeAttribute('allow-null', 'yes');
-                $this->text($directive->type);
-            $this->endElement(); // type
-            if ($directive->allowed) {
-                $this->startElement('allowed');
-                    foreach ($directive->allowed as $value => $x) $this->writeElement('value', $value);
-                $this->endElement(); // allowed
+        if ($directive->version) {
+            $this->writeElement('version', $directive->version);
+        }
+        $this->startElement('type');
+        if ($directive->typeAllowsNull) {
+            $this->writeAttribute('allow-null', 'yes');
+        }
+        $this->text($directive->type);
+        $this->endElement(); // type
+        if ($directive->allowed) {
+            $this->startElement('allowed');
+            foreach ($directive->allowed as $value => $x) {
+                $this->writeElement('value', $value);
             }
-            $this->writeElement('default', $this->export($directive->default));
-            $this->writeAttribute('xml:space', 'preserve');
-            if ($directive->external) {
-                $this->startElement('external');
-                    foreach ($directive->external as $project) $this->writeElement('project', $project);
-                $this->endElement();
+            $this->endElement(); // allowed
+        }
+        $this->writeElement('default', $this->export($directive->default));
+        $this->writeAttribute('xml:space', 'preserve');
+        if ($directive->external) {
+            $this->startElement('external');
+            foreach ($directive->external as $project) {
+                $this->writeElement('project', $project);
             }
+            $this->endElement();
+        }
         $this->endElement(); // constraints
 
         if ($directive->deprecatedVersion) {
             $this->startElement('deprecated');
-                $this->writeElement('version', $directive->deprecatedVersion);
-                $this->writeElement('use', $directive->deprecatedUse->toString());
+            $this->writeElement('version', $directive->deprecatedVersion);
+            $this->writeElement('use', $directive->deprecatedUse->toString());
             $this->endElement(); // deprecated
         }
 
         $this->startElement('description');
-            $this->writeHTMLDiv($directive->description);
+        $this->writeHTMLDiv($directive->description);
         $this->endElement(); // description
 
         $this->endElement(); // directive
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/ConfigSchema/Interchange.php
+++ b/library/HTMLPurifier/ConfigSchema/Interchange.php
@@ -10,18 +10,23 @@ class HTMLPurifier_ConfigSchema_Interchange
 
     /**
      * Name of the application this schema is describing.
+     * @type string
      */
     public $name;
 
     /**
      * Array of Directive ID => array(directive info)
+     * @type HTMLPurifier_ConfigSchema_Interchange_Directive[]
      */
     public $directives = array();
 
     /**
      * Adds a directive array to $directives
+     * @param HTMLPurifier_ConfigSchema_Interchange_Directive $directive
+     * @throws HTMLPurifier_ConfigSchema_Exception
      */
-    public function addDirective($directive) {
+    public function addDirective($directive)
+    {
         if (isset($this->directives[$i = $directive->id->toString()])) {
             throw new HTMLPurifier_ConfigSchema_Exception("Cannot redefine directive '$i'");
         }
@@ -32,11 +37,11 @@ class HTMLPurifier_ConfigSchema_Interchange
      * Convenience function to perform standard validation. Throws exception
      * on failed validation.
      */
-    public function validate() {
+    public function validate()
+    {
         $validator = new HTMLPurifier_ConfigSchema_Validator();
         return $validator->validate($this);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/ConfigSchema/Interchange/Directive.php
+++ b/library/HTMLPurifier/ConfigSchema/Interchange/Directive.php
@@ -7,71 +7,83 @@ class HTMLPurifier_ConfigSchema_Interchange_Directive
 {
 
     /**
-     * ID of directive, instance of HTMLPurifier_ConfigSchema_Interchange_Id.
+     * ID of directive.
+     * @type HTMLPurifier_ConfigSchema_Interchange_Id
      */
     public $id;
 
     /**
-     * String type, e.g. 'integer' or 'istring'.
+     * Type, e.g. 'integer' or 'istring'.
+     * @type string
      */
     public $type;
 
     /**
      * Default value, e.g. 3 or 'DefaultVal'.
+     * @type mixed
      */
     public $default;
 
     /**
      * HTML description.
+     * @type string
      */
     public $description;
 
     /**
-     * Boolean whether or not null is allowed as a value.
+     * Whether or not null is allowed as a value.
+     * @type bool
      */
     public $typeAllowsNull = false;
 
     /**
-     * Lookup table of allowed scalar values, e.g. array('allowed' => true).
+     * Lookup table of allowed scalar values.
+     * e.g. array('allowed' => true).
      * Null if all values are allowed.
+     * @type array
      */
     public $allowed;
 
     /**
-     * List of aliases for the directive,
+     * List of aliases for the directive.
      * e.g. array(new HTMLPurifier_ConfigSchema_Interchange_Id('Ns', 'Dir'))).
+     * @type HTMLPurifier_ConfigSchema_Interchange_Id[]
      */
     public $aliases = array();
 
     /**
      * Hash of value aliases, e.g. array('alt' => 'real'). Null if value
      * aliasing is disabled (necessary for non-scalar types).
+     * @type array
      */
     public $valueAliases;
 
     /**
      * Version of HTML Purifier the directive was introduced, e.g. '1.3.1'.
      * Null if the directive has always existed.
+     * @type string
      */
     public $version;
 
     /**
-     * ID of directive that supercedes this old directive, is an instance
-     * of HTMLPurifier_ConfigSchema_Interchange_Id. Null if not deprecated.
+     * ID of directive that supercedes this old directive.
+     * Null if not deprecated.
+     * @type HTMLPurifier_ConfigSchema_Interchange_Id
      */
     public $deprecatedUse;
 
     /**
      * Version of HTML Purifier this directive was deprecated. Null if not
      * deprecated.
+     * @type string
      */
     public $deprecatedVersion;
 
     /**
      * List of external projects this directive depends on, e.g. array('CSSTidy').
+     * @type array
      */
     public $external = array();
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/ConfigSchema/Interchange/Id.php
+++ b/library/HTMLPurifier/ConfigSchema/Interchange/Id.php
@@ -6,32 +6,53 @@
 class HTMLPurifier_ConfigSchema_Interchange_Id
 {
 
+    /**
+     * @type string
+     */
     public $key;
 
-    public function __construct($key) {
+    /**
+     * @param string $key
+     */
+    public function __construct($key)
+    {
         $this->key = $key;
     }
 
     /**
+     * @return string
      * @warning This is NOT magic, to ensure that people don't abuse SPL and
      *          cause problems for PHP 5.0 support.
      */
-    public function toString() {
+    public function toString()
+    {
         return $this->key;
     }
 
-    public function getRootNamespace() {
+    /**
+     * @return string
+     */
+    public function getRootNamespace()
+    {
         return substr($this->key, 0, strpos($this->key, "."));
     }
 
-    public function getDirective() {
+    /**
+     * @return string
+     */
+    public function getDirective()
+    {
         return substr($this->key, strpos($this->key, ".") + 1);
     }
 
-    public static function make($id) {
+    /**
+     * @param string $id
+     * @return HTMLPurifier_ConfigSchema_Interchange_Id
+     */
+    public static function make($id)
+    {
         return new HTMLPurifier_ConfigSchema_Interchange_Id($id);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/ConfigSchema/Validator.php
+++ b/library/HTMLPurifier/ConfigSchema/Validator.php
@@ -12,36 +12,48 @@ class HTMLPurifier_ConfigSchema_Validator
 {
 
     /**
-     * Easy to access global objects.
+     * @type HTMLPurifier_ConfigSchema_Interchange
      */
-    protected $interchange, $aliases;
+    protected $interchange;
+
+    /**
+     * @type array
+     */
+    protected $aliases;
 
     /**
      * Context-stack to provide easy to read error messages.
+     * @type array
      */
     protected $context = array();
 
     /**
-     * HTMLPurifier_VarParser to test default's type.
+     * to test default's type.
+     * @type HTMLPurifier_VarParser
      */
     protected $parser;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->parser = new HTMLPurifier_VarParser();
     }
 
     /**
-     * Validates a fully-formed interchange object. Throws an
-     * HTMLPurifier_ConfigSchema_Exception if there's a problem.
+     * Validates a fully-formed interchange object.
+     * @param HTMLPurifier_ConfigSchema_Interchange $interchange
+     * @return bool
      */
-    public function validate($interchange) {
+    public function validate($interchange)
+    {
         $this->interchange = $interchange;
         $this->aliases = array();
         // PHP is a bit lax with integer <=> string conversions in
         // arrays, so we don't use the identical !== comparison
         foreach ($interchange->directives as $i => $directive) {
             $id = $directive->id->toString();
-            if ($i != $id) $this->error(false, "Integrity violation: key '$i' does not match internal id '$id'");
+            if ($i != $id) {
+                $this->error(false, "Integrity violation: key '$i' does not match internal id '$id'");
+            }
             $this->validateDirective($directive);
         }
         return true;
@@ -49,8 +61,10 @@ class HTMLPurifier_ConfigSchema_Validator
 
     /**
      * Validates a HTMLPurifier_ConfigSchema_Interchange_Id object.
+     * @param HTMLPurifier_ConfigSchema_Interchange_Id $id
      */
-    public function validateId($id) {
+    public function validateId($id)
+    {
         $id_string = $id->toString();
         $this->context[] = "id '$id_string'";
         if (!$id instanceof HTMLPurifier_ConfigSchema_Interchange_Id) {
@@ -67,8 +81,10 @@ class HTMLPurifier_ConfigSchema_Validator
 
     /**
      * Validates a HTMLPurifier_ConfigSchema_Interchange_Directive object.
+     * @param HTMLPurifier_ConfigSchema_Interchange_Directive $d
      */
-    public function validateDirective($d) {
+    public function validateDirective($d)
+    {
         $id = $d->id->toString();
         $this->context[] = "directive '$id'";
         $this->validateId($d->id);
@@ -108,9 +124,13 @@ class HTMLPurifier_ConfigSchema_Validator
     /**
      * Extra validation if $allowed member variable of
      * HTMLPurifier_ConfigSchema_Interchange_Directive is defined.
+     * @param HTMLPurifier_ConfigSchema_Interchange_Directive $d
      */
-    public function validateDirectiveAllowed($d) {
-        if (is_null($d->allowed)) return;
+    public function validateDirectiveAllowed($d)
+    {
+        if (is_null($d->allowed)) {
+            return;
+        }
         $this->with($d, 'allowed')
             ->assertNotEmpty()
             ->assertIsLookup(); // handled by InterchangeBuilder
@@ -119,7 +139,9 @@ class HTMLPurifier_ConfigSchema_Validator
         }
         $this->context[] = 'allowed';
         foreach ($d->allowed as $val => $x) {
-            if (!is_string($val)) $this->error("value $val", 'must be a string');
+            if (!is_string($val)) {
+                $this->error("value $val", 'must be a string');
+            }
         }
         array_pop($this->context);
     }
@@ -127,15 +149,23 @@ class HTMLPurifier_ConfigSchema_Validator
     /**
      * Extra validation if $valueAliases member variable of
      * HTMLPurifier_ConfigSchema_Interchange_Directive is defined.
+     * @param HTMLPurifier_ConfigSchema_Interchange_Directive $d
      */
-    public function validateDirectiveValueAliases($d) {
-        if (is_null($d->valueAliases)) return;
+    public function validateDirectiveValueAliases($d)
+    {
+        if (is_null($d->valueAliases)) {
+            return;
+        }
         $this->with($d, 'valueAliases')
             ->assertIsArray(); // handled by InterchangeBuilder
         $this->context[] = 'valueAliases';
         foreach ($d->valueAliases as $alias => $real) {
-            if (!is_string($alias)) $this->error("alias $alias", 'must be a string');
-            if (!is_string($real))  $this->error("alias target $real from alias '$alias'",  'must be a string');
+            if (!is_string($alias)) {
+                $this->error("alias $alias", 'must be a string');
+            }
+            if (!is_string($real)) {
+                $this->error("alias target $real from alias '$alias'", 'must be a string');
+            }
             if ($alias === $real) {
                 $this->error("alias '$alias'", "must not be an alias to itself");
             }
@@ -155,8 +185,10 @@ class HTMLPurifier_ConfigSchema_Validator
     /**
      * Extra validation if $aliases member variable of
      * HTMLPurifier_ConfigSchema_Interchange_Directive is defined.
+     * @param HTMLPurifier_ConfigSchema_Interchange_Directive $d
      */
-    public function validateDirectiveAliases($d) {
+    public function validateDirectiveAliases($d)
+    {
         $this->with($d, 'aliases')
             ->assertIsArray(); // handled by InterchangeBuilder
         $this->context[] = 'aliases';
@@ -180,27 +212,37 @@ class HTMLPurifier_ConfigSchema_Validator
     /**
      * Convenience function for generating HTMLPurifier_ConfigSchema_ValidatorAtom
      * for validating simple member variables of objects.
+     * @param $obj
+     * @param $member
+     * @return HTMLPurifier_ConfigSchema_ValidatorAtom
      */
-    protected function with($obj, $member) {
+    protected function with($obj, $member)
+    {
         return new HTMLPurifier_ConfigSchema_ValidatorAtom($this->getFormattedContext(), $obj, $member);
     }
 
     /**
      * Emits an error, providing helpful context.
+     * @throws HTMLPurifier_ConfigSchema_Exception
      */
-    protected function error($target, $msg) {
-        if ($target !== false) $prefix = ucfirst($target) . ' in ' .  $this->getFormattedContext();
-        else $prefix = ucfirst($this->getFormattedContext());
+    protected function error($target, $msg)
+    {
+        if ($target !== false) {
+            $prefix = ucfirst($target) . ' in ' . $this->getFormattedContext();
+        } else {
+            $prefix = ucfirst($this->getFormattedContext());
+        }
         throw new HTMLPurifier_ConfigSchema_Exception(trim($prefix . ' ' . $msg));
     }
 
     /**
      * Returns a formatted context string.
+     * @return string
      */
-    protected function getFormattedContext() {
+    protected function getFormattedContext()
+    {
         return implode(' in ', array_reverse($this->context));
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/ConfigSchema/ValidatorAtom.php
+++ b/library/HTMLPurifier/ConfigSchema/ValidatorAtom.php
@@ -8,59 +8,123 @@
  */
 class HTMLPurifier_ConfigSchema_ValidatorAtom
 {
+    /**
+     * @type string
+     */
+    protected $context;
 
-    protected $context, $obj, $member, $contents;
+    /**
+     * @type object
+     */
+    protected $obj;
 
-    public function __construct($context, $obj, $member) {
-        $this->context     = $context;
-        $this->obj         = $obj;
-        $this->member      = $member;
-        $this->contents    =& $obj->$member;
+    /**
+     * @type string
+     */
+    protected $member;
+
+    /**
+     * @type mixed
+     */
+    protected $contents;
+
+    public function __construct($context, $obj, $member)
+    {
+        $this->context = $context;
+        $this->obj = $obj;
+        $this->member = $member;
+        $this->contents =& $obj->$member;
     }
 
-    public function assertIsString() {
-        if (!is_string($this->contents)) $this->error('must be a string');
-        return $this;
-    }
-
-    public function assertIsBool() {
-        if (!is_bool($this->contents)) $this->error('must be a boolean');
-        return $this;
-    }
-
-    public function assertIsArray() {
-        if (!is_array($this->contents)) $this->error('must be an array');
-        return $this;
-    }
-
-    public function assertNotNull() {
-        if ($this->contents === null) $this->error('must not be null');
-        return $this;
-    }
-
-    public function assertAlnum() {
-        $this->assertIsString();
-        if (!ctype_alnum($this->contents)) $this->error('must be alphanumeric');
-        return $this;
-    }
-
-    public function assertNotEmpty() {
-        if (empty($this->contents)) $this->error('must not be empty');
-        return $this;
-    }
-
-    public function assertIsLookup() {
-        $this->assertIsArray();
-        foreach ($this->contents as $v) {
-            if ($v !== true) $this->error('must be a lookup array');
+    /**
+     * @return HTMLPurifier_ConfigSchema_ValidatorAtom
+     */
+    public function assertIsString()
+    {
+        if (!is_string($this->contents)) {
+            $this->error('must be a string');
         }
         return $this;
     }
 
-    protected function error($msg) {
-        throw new HTMLPurifier_ConfigSchema_Exception(ucfirst($this->member) . ' in ' . $this->context . ' ' . $msg);
+    /**
+     * @return HTMLPurifier_ConfigSchema_ValidatorAtom
+     */
+    public function assertIsBool()
+    {
+        if (!is_bool($this->contents)) {
+            $this->error('must be a boolean');
+        }
+        return $this;
     }
 
+    /**
+     * @return HTMLPurifier_ConfigSchema_ValidatorAtom
+     */
+    public function assertIsArray()
+    {
+        if (!is_array($this->contents)) {
+            $this->error('must be an array');
+        }
+        return $this;
+    }
+
+    /**
+     * @return HTMLPurifier_ConfigSchema_ValidatorAtom
+     */
+    public function assertNotNull()
+    {
+        if ($this->contents === null) {
+            $this->error('must not be null');
+        }
+        return $this;
+    }
+
+    /**
+     * @return HTMLPurifier_ConfigSchema_ValidatorAtom
+     */
+    public function assertAlnum()
+    {
+        $this->assertIsString();
+        if (!ctype_alnum($this->contents)) {
+            $this->error('must be alphanumeric');
+        }
+        return $this;
+    }
+
+    /**
+     * @return HTMLPurifier_ConfigSchema_ValidatorAtom
+     */
+    public function assertNotEmpty()
+    {
+        if (empty($this->contents)) {
+            $this->error('must not be empty');
+        }
+        return $this;
+    }
+
+    /**
+     * @return HTMLPurifier_ConfigSchema_ValidatorAtom
+     */
+    public function assertIsLookup()
+    {
+        $this->assertIsArray();
+        foreach ($this->contents as $v) {
+            if ($v !== true) {
+                $this->error('must be a lookup array');
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * @param string $msg
+     * @throws HTMLPurifier_ConfigSchema_Exception
+     */
+    protected function error($msg)
+    {
+        throw new HTMLPurifier_ConfigSchema_Exception(ucfirst($this->member) . ' in ' . $this->context . ' ' . $msg);
+    }
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/ContentSets.php
+++ b/library/HTMLPurifier/ContentSets.php
@@ -7,35 +7,42 @@ class HTMLPurifier_ContentSets
 {
 
     /**
-     * List of content set strings (pipe seperators) indexed by name.
+     * List of content set strings (pipe separators) indexed by name.
+     * @type array
      */
     public $info = array();
 
     /**
      * List of content set lookups (element => true) indexed by name.
+     * @type array
      * @note This is in HTMLPurifier_HTMLDefinition->info_content_sets
      */
     public $lookup = array();
 
     /**
-     * Synchronized list of defined content sets (keys of info)
+     * Synchronized list of defined content sets (keys of info).
+     * @type array
      */
     protected $keys = array();
     /**
-     * Synchronized list of defined content values (values of info)
+     * Synchronized list of defined content values (values of info).
+     * @type array
      */
     protected $values = array();
 
     /**
      * Merges in module's content sets, expands identifiers in the content
      * sets and populates the keys, values and lookup member variables.
-     * @param $modules List of HTMLPurifier_HTMLModule
+     * @param HTMLPurifier_HTMLModule[] $modules List of HTMLPurifier_HTMLModule
      */
-    public function __construct($modules) {
-        if (!is_array($modules)) $modules = array($modules);
+    public function __construct($modules)
+    {
+        if (!is_array($modules)) {
+            $modules = array($modules);
+        }
         // populate content_sets based on module hints
         // sorry, no way of overloading
-        foreach ($modules as $module_i => $module) {
+        foreach ($modules as $module) {
             foreach ($module->content_sets as $key => $value) {
                 $temp = $this->convertToLookup($value);
                 if (isset($this->lookup[$key])) {
@@ -70,11 +77,14 @@ class HTMLPurifier_ContentSets
 
     /**
      * Accepts a definition; generates and assigns a ChildDef for it
-     * @param $def HTMLPurifier_ElementDef reference
-     * @param $module Module that defined the ElementDef
+     * @param HTMLPurifier_ElementDef $def HTMLPurifier_ElementDef reference
+     * @param HTMLPurifier_HTMLModule $module Module that defined the ElementDef
      */
-    public function generateChildDef(&$def, $module) {
-        if (!empty($def->child)) return; // already done!
+    public function generateChildDef(&$def, $module)
+    {
+        if (!empty($def->child)) { // already done!
+            return;
+        }
         $content_model = $def->content_model;
         if (is_string($content_model)) {
             // Assume that $this->keys is alphanumeric
@@ -89,7 +99,8 @@ class HTMLPurifier_ContentSets
         $def->child = $this->getChildDef($def, $module);
     }
 
-    public function generateChildDefCallback($matches) {
+    public function generateChildDefCallback($matches)
+    {
         return $this->info[$matches[0]];
     }
 
@@ -98,10 +109,12 @@ class HTMLPurifier_ContentSets
      * member variables in HTMLPurifier_ElementDef
      * @note This will also defer to modules for custom HTMLPurifier_ChildDef
      *       subclasses that need content set expansion
-     * @param $def HTMLPurifier_ElementDef to have ChildDef extracted
+     * @param HTMLPurifier_ElementDef $def HTMLPurifier_ElementDef to have ChildDef extracted
+     * @param HTMLPurifier_HTMLModule $module Module that defined the ElementDef
      * @return HTMLPurifier_ChildDef corresponding to ElementDef
      */
-    public function getChildDef($def, $module) {
+    public function getChildDef($def, $module)
+    {
         $value = $def->content_model;
         if (is_object($value)) {
             trigger_error(
@@ -126,7 +139,9 @@ class HTMLPurifier_ContentSets
         if ($module->defines_child_def) { // save a func call
             $return = $module->getChildDef($def);
         }
-        if ($return !== false) return $return;
+        if ($return !== false) {
+            return $return;
+        }
         // error-out
         trigger_error(
             'Could not determine which ChildDef class to instantiate',
@@ -138,18 +153,18 @@ class HTMLPurifier_ContentSets
     /**
      * Converts a string list of elements separated by pipes into
      * a lookup array.
-     * @param $string List of elements
-     * @return Lookup array of elements
+     * @param string $string List of elements
+     * @return array Lookup array of elements
      */
-    protected function convertToLookup($string) {
+    protected function convertToLookup($string)
+    {
         $array = explode('|', str_replace(' ', '', $string));
         $ret = array();
-        foreach ($array as $i => $k) {
+        foreach ($array as $k) {
             $ret[$k] = true;
         }
         return $ret;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Context.php
+++ b/library/HTMLPurifier/Context.php
@@ -12,18 +12,22 @@ class HTMLPurifier_Context
 
     /**
      * Private array that stores the references.
+     * @type array
      */
     private $_storage = array();
 
     /**
      * Registers a variable into the context.
-     * @param $name String name
-     * @param $ref Reference to variable to be registered
+     * @param string $name String name
+     * @param mixed $ref Reference to variable to be registered
      */
-    public function register($name, &$ref) {
+    public function register($name, &$ref)
+    {
         if (isset($this->_storage[$name])) {
-            trigger_error("Name $name produces collision, cannot re-register",
-                          E_USER_ERROR);
+            trigger_error(
+                "Name $name produces collision, cannot re-register",
+                E_USER_ERROR
+            );
             return;
         }
         $this->_storage[$name] =& $ref;
@@ -31,14 +35,18 @@ class HTMLPurifier_Context
 
     /**
      * Retrieves a variable reference from the context.
-     * @param $name String name
-     * @param $ignore_error Boolean whether or not to ignore error
+     * @param string $name String name
+     * @param bool $ignore_error Boolean whether or not to ignore error
+     * @return mixed
      */
-    public function &get($name, $ignore_error = false) {
+    public function &get($name, $ignore_error = false)
+    {
         if (!isset($this->_storage[$name])) {
             if (!$ignore_error) {
-                trigger_error("Attempted to retrieve non-existent variable $name",
-                              E_USER_ERROR);
+                trigger_error(
+                    "Attempted to retrieve non-existent variable $name",
+                    E_USER_ERROR
+                );
             }
             $var = null; // so we can return by reference
             return $var;
@@ -47,13 +55,16 @@ class HTMLPurifier_Context
     }
 
     /**
-     * Destorys a variable in the context.
-     * @param $name String name
+     * Destroys a variable in the context.
+     * @param string $name String name
      */
-    public function destroy($name) {
+    public function destroy($name)
+    {
         if (!isset($this->_storage[$name])) {
-            trigger_error("Attempted to destroy non-existent variable $name",
-                          E_USER_ERROR);
+            trigger_error(
+                "Attempted to destroy non-existent variable $name",
+                E_USER_ERROR
+            );
             return;
         }
         unset($this->_storage[$name]);
@@ -61,22 +72,24 @@ class HTMLPurifier_Context
 
     /**
      * Checks whether or not the variable exists.
-     * @param $name String name
+     * @param string $name String name
+     * @return bool
      */
-    public function exists($name) {
+    public function exists($name)
+    {
         return isset($this->_storage[$name]);
     }
 
     /**
      * Loads a series of variables from an associative array
-     * @param $context_array Assoc array of variables to load
+     * @param array $context_array Assoc array of variables to load
      */
-    public function loadArray($context_array) {
+    public function loadArray($context_array)
+    {
         foreach ($context_array as $key => $discard) {
             $this->register($key, $context_array[$key]);
         }
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Definition.php
+++ b/library/HTMLPurifier/Definition.php
@@ -9,6 +9,7 @@ abstract class HTMLPurifier_Definition
 
     /**
      * Has setup() been called yet?
+     * @type bool
      */
     public $setup = false;
 
@@ -20,31 +21,35 @@ abstract class HTMLPurifier_Definition
      * is used and any writes to the raw definition object are short
      * circuited.  See enduser-customize.html for the high-level
      * picture.
+     * @type bool
      */
     public $optimized = null;
 
     /**
      * What type of definition is it?
+     * @type string
      */
     public $type;
 
     /**
      * Sets up the definition object into the final form, something
      * not done by the constructor
-     * @param $config HTMLPurifier_Config instance
+     * @param HTMLPurifier_Config $config
      */
     abstract protected function doSetup($config);
 
     /**
      * Setup function that aborts if already setup
-     * @param $config HTMLPurifier_Config instance
+     * @param HTMLPurifier_Config $config
      */
-    public function setup($config) {
-        if ($this->setup) return;
+    public function setup($config)
+    {
+        if ($this->setup) {
+            return;
+        }
         $this->setup = true;
         $this->doSetup($config);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/DefinitionCache.php
+++ b/library/HTMLPurifier/DefinitionCache.php
@@ -10,22 +10,27 @@
  */
 abstract class HTMLPurifier_DefinitionCache
 {
-
+    /**
+     * @type string
+     */
     public $type;
 
     /**
-     * @param $name Type of definition objects this instance of the
+     * @param string $type Type of definition objects this instance of the
      *      cache will handle.
      */
-    public function __construct($type) {
+    public function __construct($type)
+    {
         $this->type = $type;
     }
 
     /**
      * Generates a unique identifier for a particular configuration
-     * @param Instance of HTMLPurifier_Config
+     * @param HTMLPurifier_Config $config Instance of HTMLPurifier_Config
+     * @return string
      */
-    public function generateKey($config) {
+    public function generateKey($config)
+    {
         return $config->version . ',' . // possibly replace with function calls
                $config->getBatchSerial($this->type) . ',' .
                $config->get($this->type . '.DefinitionRev');
@@ -34,30 +39,37 @@ abstract class HTMLPurifier_DefinitionCache
     /**
      * Tests whether or not a key is old with respect to the configuration's
      * version and revision number.
-     * @param $key Key to test
-     * @param $config Instance of HTMLPurifier_Config to test against
+     * @param string $key Key to test
+     * @param HTMLPurifier_Config $config Instance of HTMLPurifier_Config to test against
+     * @return bool
      */
-    public function isOld($key, $config) {
-        if (substr_count($key, ',') < 2) return true;
+    public function isOld($key, $config)
+    {
+        if (substr_count($key, ',') < 2) {
+            return true;
+        }
         list($version, $hash, $revision) = explode(',', $key, 3);
         $compare = version_compare($version, $config->version);
         // version mismatch, is always old
-        if ($compare != 0) return true;
+        if ($compare != 0) {
+            return true;
+        }
         // versions match, ids match, check revision number
-        if (
-            $hash == $config->getBatchSerial($this->type) &&
-            $revision < $config->get($this->type . '.DefinitionRev')
-        ) return true;
+        if ($hash == $config->getBatchSerial($this->type) &&
+            $revision < $config->get($this->type . '.DefinitionRev')) {
+            return true;
+        }
         return false;
     }
 
     /**
      * Checks if a definition's type jives with the cache's type
      * @note Throws an error on failure
-     * @param $def Definition object to check
-     * @return Boolean true if good, false if not
+     * @param HTMLPurifier_Definition $def Definition object to check
+     * @return bool true if good, false if not
      */
-    public function checkDefType($def) {
+    public function checkDefType($def)
+    {
         if ($def->type !== $this->type) {
             trigger_error("Cannot use definition of type {$def->type} in cache for {$this->type}");
             return false;
@@ -67,31 +79,40 @@ abstract class HTMLPurifier_DefinitionCache
 
     /**
      * Adds a definition object to the cache
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
      */
     abstract public function add($def, $config);
 
     /**
      * Unconditionally saves a definition object to the cache
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
      */
     abstract public function set($def, $config);
 
     /**
      * Replace an object in the cache
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
      */
     abstract public function replace($def, $config);
 
     /**
      * Retrieves a definition object from the cache
+     * @param HTMLPurifier_Config $config
      */
     abstract public function get($config);
 
     /**
      * Removes a definition object to the cache
+     * @param HTMLPurifier_Config $config
      */
     abstract public function remove($config);
 
     /**
      * Clears all objects from cache
+     * @param HTMLPurifier_Config $config
      */
     abstract public function flush($config);
 
@@ -100,9 +121,9 @@ abstract class HTMLPurifier_DefinitionCache
      * @note Be carefuly implementing this method as flush. Flush must
      *       not interfere with other Definition types, and cleanup()
      *       should not be repeatedly called by userland code.
+     * @param HTMLPurifier_Config $config
      */
     abstract public function cleanup($config);
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/DefinitionCache/Decorator.php
+++ b/library/HTMLPurifier/DefinitionCache/Decorator.php
@@ -5,7 +5,7 @@ class HTMLPurifier_DefinitionCache_Decorator extends HTMLPurifier_DefinitionCach
 
     /**
      * Cache object we are decorating
-     * @var HTMLPurifier_DefinitionCache
+     * @type HTMLPurifier_DefinitionCache
      */
     public $cache;
 
@@ -15,13 +15,13 @@ class HTMLPurifier_DefinitionCache_Decorator extends HTMLPurifier_DefinitionCach
      */
     public $name;
 
-    public function __construct() {}
+    public function __construct()
+    {
+    }
 
     /**
      * Lazy decorator function
-     *
      * @param HTMLPurifier_DefinitionCache $cache Reference to cache object to decorate
-     *
      * @return HTMLPurifier_DefinitionCache_Decorator
      */
     public function decorate(&$cache)
@@ -29,48 +29,80 @@ class HTMLPurifier_DefinitionCache_Decorator extends HTMLPurifier_DefinitionCach
         $decorator = $this->copy();
         // reference is necessary for mocks in PHP 4
         $decorator->cache =& $cache;
-        $decorator->type  = $cache->type;
+        $decorator->type = $cache->type;
         return $decorator;
     }
 
     /**
      * Cross-compatible clone substitute
+     * @return HTMLPurifier_DefinitionCache_Decorator
      */
     public function copy()
     {
         return new HTMLPurifier_DefinitionCache_Decorator();
     }
 
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
     public function add($def, $config)
     {
         return $this->cache->add($def, $config);
     }
 
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
     public function set($def, $config)
     {
         return $this->cache->set($def, $config);
     }
 
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
     public function replace($def, $config)
     {
         return $this->cache->replace($def, $config);
     }
 
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
     public function get($config)
     {
         return $this->cache->get($config);
     }
 
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
     public function remove($config)
     {
         return $this->cache->remove($config);
     }
 
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
     public function flush($config)
     {
         return $this->cache->flush($config);
     }
 
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
     public function cleanup($config)
     {
         return $this->cache->cleanup($config);

--- a/library/HTMLPurifier/DefinitionCache/Decorator/Cleanup.php
+++ b/library/HTMLPurifier/DefinitionCache/Decorator/Cleanup.php
@@ -4,40 +4,75 @@
  * Definition cache decorator class that cleans up the cache
  * whenever there is a cache miss.
  */
-class HTMLPurifier_DefinitionCache_Decorator_Cleanup extends
-      HTMLPurifier_DefinitionCache_Decorator
+class HTMLPurifier_DefinitionCache_Decorator_Cleanup extends HTMLPurifier_DefinitionCache_Decorator
 {
-
+    /**
+     * @type string
+     */
     public $name = 'Cleanup';
 
-    public function copy() {
+    /**
+     * @return HTMLPurifier_DefinitionCache_Decorator_Cleanup
+     */
+    public function copy()
+    {
         return new HTMLPurifier_DefinitionCache_Decorator_Cleanup();
     }
 
-    public function add($def, $config) {
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function add($def, $config)
+    {
         $status = parent::add($def, $config);
-        if (!$status) parent::cleanup($config);
+        if (!$status) {
+            parent::cleanup($config);
+        }
         return $status;
     }
 
-    public function set($def, $config) {
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function set($def, $config)
+    {
         $status = parent::set($def, $config);
-        if (!$status) parent::cleanup($config);
+        if (!$status) {
+            parent::cleanup($config);
+        }
         return $status;
     }
 
-    public function replace($def, $config) {
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function replace($def, $config)
+    {
         $status = parent::replace($def, $config);
-        if (!$status) parent::cleanup($config);
+        if (!$status) {
+            parent::cleanup($config);
+        }
         return $status;
     }
 
-    public function get($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function get($config)
+    {
         $ret = parent::get($config);
-        if (!$ret) parent::cleanup($config);
+        if (!$ret) {
+            parent::cleanup($config);
+        }
         return $ret;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/DefinitionCache/Decorator/Memory.php
+++ b/library/HTMLPurifier/DefinitionCache/Decorator/Memory.php
@@ -5,42 +5,81 @@
  * to PHP's memory; good for unit tests or circumstances where
  * there are lots of configuration objects floating around.
  */
-class HTMLPurifier_DefinitionCache_Decorator_Memory extends
-      HTMLPurifier_DefinitionCache_Decorator
+class HTMLPurifier_DefinitionCache_Decorator_Memory extends HTMLPurifier_DefinitionCache_Decorator
 {
-
+    /**
+     * @type array
+     */
     protected $definitions;
+
+    /**
+     * @type string
+     */
     public $name = 'Memory';
 
-    public function copy() {
+    /**
+     * @return HTMLPurifier_DefinitionCache_Decorator_Memory
+     */
+    public function copy()
+    {
         return new HTMLPurifier_DefinitionCache_Decorator_Memory();
     }
 
-    public function add($def, $config) {
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function add($def, $config)
+    {
         $status = parent::add($def, $config);
-        if ($status) $this->definitions[$this->generateKey($config)] = $def;
+        if ($status) {
+            $this->definitions[$this->generateKey($config)] = $def;
+        }
         return $status;
     }
 
-    public function set($def, $config) {
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function set($def, $config)
+    {
         $status = parent::set($def, $config);
-        if ($status) $this->definitions[$this->generateKey($config)] = $def;
+        if ($status) {
+            $this->definitions[$this->generateKey($config)] = $def;
+        }
         return $status;
     }
 
-    public function replace($def, $config) {
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function replace($def, $config)
+    {
         $status = parent::replace($def, $config);
-        if ($status) $this->definitions[$this->generateKey($config)] = $def;
+        if ($status) {
+            $this->definitions[$this->generateKey($config)] = $def;
+        }
         return $status;
     }
 
-    public function get($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function get($config)
+    {
         $key = $this->generateKey($config);
-        if (isset($this->definitions[$key])) return $this->definitions[$key];
+        if (isset($this->definitions[$key])) {
+            return $this->definitions[$key];
+        }
         $this->definitions[$key] = parent::get($config);
         return $this->definitions[$key];
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/DefinitionCache/Decorator/Template.php.in
+++ b/library/HTMLPurifier/DefinitionCache/Decorator/Template.php.in
@@ -5,43 +5,78 @@ require_once 'HTMLPurifier/DefinitionCache/Decorator.php';
 /**
  * Definition cache decorator template.
  */
-class HTMLPurifier_DefinitionCache_Decorator_Template extends
-      HTMLPurifier_DefinitionCache_Decorator
+class HTMLPurifier_DefinitionCache_Decorator_Template extends HTMLPurifier_DefinitionCache_Decorator
 {
 
-    var $name = 'Template'; // replace this
+    /**
+     * @type string
+     */
+    public $name = 'Template'; // replace this
 
-    function copy() {
+    public function copy()
+    {
         // replace class name with yours
         return new HTMLPurifier_DefinitionCache_Decorator_Template();
     }
 
     // remove methods you don't need
 
-    function add($def, $config) {
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function add($def, $config)
+    {
         return parent::add($def, $config);
     }
 
-    function set($def, $config) {
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function set($def, $config)
+    {
         return parent::set($def, $config);
     }
 
-    function replace($def, $config) {
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function replace($def, $config)
+    {
         return parent::replace($def, $config);
     }
 
-    function get($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function get($config)
+    {
         return parent::get($config);
     }
 
-    function flush() {
-        return parent::flush();
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function flush($config)
+    {
+        return parent::flush($config);
     }
 
-    function cleanup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return mixed
+     */
+    public function cleanup($config)
+    {
         return parent::cleanup($config);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/DefinitionCache/Null.php
+++ b/library/HTMLPurifier/DefinitionCache/Null.php
@@ -6,34 +6,71 @@
 class HTMLPurifier_DefinitionCache_Null extends HTMLPurifier_DefinitionCache
 {
 
-    public function add($def, $config) {
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function add($def, $config)
+    {
         return false;
     }
 
-    public function set($def, $config) {
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function set($def, $config)
+    {
         return false;
     }
 
-    public function replace($def, $config) {
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function replace($def, $config)
+    {
         return false;
     }
 
-    public function remove($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function remove($config)
+    {
         return false;
     }
 
-    public function get($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function get($config)
+    {
         return false;
     }
 
-    public function flush($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function flush($config)
+    {
         return false;
     }
 
-    public function cleanup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function cleanup($config)
+    {
         return false;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/DefinitionCache/Serializer.php
+++ b/library/HTMLPurifier/DefinitionCache/Serializer.php
@@ -1,83 +1,160 @@
 <?php
 
-class HTMLPurifier_DefinitionCache_Serializer extends
-      HTMLPurifier_DefinitionCache
+class HTMLPurifier_DefinitionCache_Serializer extends HTMLPurifier_DefinitionCache
 {
 
-    public function add($def, $config) {
-        if (!$this->checkDefType($def)) return;
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return int|bool
+     */
+    public function add($def, $config)
+    {
+        if (!$this->checkDefType($def)) {
+            return;
+        }
         $file = $this->generateFilePath($config);
-        if (file_exists($file)) return false;
-        if (!$this->_prepareDir($config)) return false;
+        if (file_exists($file)) {
+            return false;
+        }
+        if (!$this->_prepareDir($config)) {
+            return false;
+        }
         return $this->_write($file, serialize($def), $config);
     }
 
-    public function set($def, $config) {
-        if (!$this->checkDefType($def)) return;
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return int|bool
+     */
+    public function set($def, $config)
+    {
+        if (!$this->checkDefType($def)) {
+            return;
+        }
         $file = $this->generateFilePath($config);
-        if (!$this->_prepareDir($config)) return false;
+        if (!$this->_prepareDir($config)) {
+            return false;
+        }
         return $this->_write($file, serialize($def), $config);
     }
 
-    public function replace($def, $config) {
-        if (!$this->checkDefType($def)) return;
+    /**
+     * @param HTMLPurifier_Definition $def
+     * @param HTMLPurifier_Config $config
+     * @return int|bool
+     */
+    public function replace($def, $config)
+    {
+        if (!$this->checkDefType($def)) {
+            return;
+        }
         $file = $this->generateFilePath($config);
-        if (!file_exists($file)) return false;
-        if (!$this->_prepareDir($config)) return false;
+        if (!file_exists($file)) {
+            return false;
+        }
+        if (!$this->_prepareDir($config)) {
+            return false;
+        }
         return $this->_write($file, serialize($def), $config);
     }
 
-    public function get($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return bool|HTMLPurifier_Config
+     */
+    public function get($config)
+    {
         $file = $this->generateFilePath($config);
-        if (!file_exists($file)) return false;
+        if (!file_exists($file)) {
+            return false;
+        }
         return unserialize(file_get_contents($file));
     }
 
-    public function remove($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function remove($config)
+    {
         $file = $this->generateFilePath($config);
-        if (!file_exists($file)) return false;
+        if (!file_exists($file)) {
+            return false;
+        }
         return unlink($file);
     }
 
-    public function flush($config) {
-        if (!$this->_prepareDir($config)) return false;
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function flush($config)
+    {
+        if (!$this->_prepareDir($config)) {
+            return false;
+        }
         $dir = $this->generateDirectoryPath($config);
-        $dh  = opendir($dir);
+        $dh = opendir($dir);
         while (false !== ($filename = readdir($dh))) {
-            if (empty($filename)) continue;
-            if ($filename[0] === '.') continue;
+            if (empty($filename)) {
+                continue;
+            }
+            if ($filename[0] === '.') {
+                continue;
+            }
             unlink($dir . '/' . $filename);
         }
     }
 
-    public function cleanup($config) {
-        if (!$this->_prepareDir($config)) return false;
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function cleanup($config)
+    {
+        if (!$this->_prepareDir($config)) {
+            return false;
+        }
         $dir = $this->generateDirectoryPath($config);
-        $dh  = opendir($dir);
+        $dh = opendir($dir);
         while (false !== ($filename = readdir($dh))) {
-            if (empty($filename)) continue;
-            if ($filename[0] === '.') continue;
+            if (empty($filename)) {
+                continue;
+            }
+            if ($filename[0] === '.') {
+                continue;
+            }
             $key = substr($filename, 0, strlen($filename) - 4);
-            if ($this->isOld($key, $config)) unlink($dir . '/' . $filename);
+            if ($this->isOld($key, $config)) {
+                unlink($dir . '/' . $filename);
+            }
         }
     }
 
     /**
      * Generates the file path to the serial file corresponding to
      * the configuration and definition name
+     * @param HTMLPurifier_Config $config
+     * @return string
      * @todo Make protected
      */
-    public function generateFilePath($config) {
+    public function generateFilePath($config)
+    {
         $key = $this->generateKey($config);
         return $this->generateDirectoryPath($config) . '/' . $key . '.ser';
     }
 
     /**
      * Generates the path to the directory contain this cache's serial files
+     * @param HTMLPurifier_Config $config
+     * @return string
      * @note No trailing slash
      * @todo Make protected
      */
-    public function generateDirectoryPath($config) {
+    public function generateDirectoryPath($config)
+    {
         $base = $this->generateBaseDirectoryPath($config);
         return $base . '/' . $this->type;
     }
@@ -85,9 +162,12 @@ class HTMLPurifier_DefinitionCache_Serializer extends
     /**
      * Generates path to base directory that contains all definition type
      * serials
+     * @param HTMLPurifier_Config $config
+     * @return mixed|string
      * @todo Make protected
      */
-    public function generateBaseDirectoryPath($config) {
+    public function generateBaseDirectoryPath($config)
+    {
         $base = $config->get('Cache.SerializerPath');
         $base = is_null($base) ? HTMLPURIFIER_PREFIX . '/HTMLPurifier/DefinitionCache/Serializer' : $base;
         return $base;
@@ -95,12 +175,13 @@ class HTMLPurifier_DefinitionCache_Serializer extends
 
     /**
      * Convenience wrapper function for file_put_contents
-     * @param $file File name to write to
-     * @param $data Data to write into file
-     * @param $config Config object
-     * @return Number of bytes written if success, or false if failure.
+     * @param string $file File name to write to
+     * @param string $data Data to write into file
+     * @param HTMLPurifier_Config $config
+     * @return int|bool Number of bytes written if success, or false if failure.
      */
-    private function _write($file, $data, $config) {
+    private function _write($file, $data, $config)
+    {
         $result = file_put_contents($file, $data);
         if ($result !== false) {
             // set permissions of the new file (no execute)
@@ -116,10 +197,11 @@ class HTMLPurifier_DefinitionCache_Serializer extends
 
     /**
      * Prepares the directory that this type stores the serials in
-     * @param $config Config object
-     * @return True if successful
+     * @param HTMLPurifier_Config $config
+     * @return bool True if successful
      */
-    private function _prepareDir($config) {
+    private function _prepareDir($config)
+    {
         $directory = $this->generateDirectoryPath($config);
         $chmod = $config->get('Cache.SerializerPermissions');
         if (!$chmod) {
@@ -128,9 +210,11 @@ class HTMLPurifier_DefinitionCache_Serializer extends
         if (!is_dir($directory)) {
             $base = $this->generateBaseDirectoryPath($config);
             if (!is_dir($base)) {
-                trigger_error('Base directory '.$base.' does not exist,
+                trigger_error(
+                    'Base directory ' . $base . ' does not exist,
                     please create or change using %Cache.SerializerPath',
-                    E_USER_WARNING);
+                    E_USER_WARNING
+                );
                 return false;
             } elseif (!$this->_testPermissions($base, $chmod)) {
                 return false;
@@ -147,18 +231,23 @@ class HTMLPurifier_DefinitionCache_Serializer extends
     /**
      * Tests permissions on a directory and throws out friendly
      * error messages and attempts to chmod it itself if possible
-     * @param $dir Directory path
-     * @param $chmod Permissions
-     * @return True if directory writable
+     * @param string $dir Directory path
+     * @param int $chmod Permissions
+     * @return bool True if directory is writable
      */
-    private function _testPermissions($dir, $chmod) {
+    private function _testPermissions($dir, $chmod)
+    {
         // early abort, if it is writable, everything is hunky-dory
-        if (is_writable($dir)) return true;
+        if (is_writable($dir)) {
+            return true;
+        }
         if (!is_dir($dir)) {
             // generally, you'll want to handle this beforehand
             // so a more specific error message can be given
-            trigger_error('Directory '.$dir.' does not exist',
-                E_USER_WARNING);
+            trigger_error(
+                'Directory ' . $dir . ' does not exist',
+                E_USER_WARNING
+            );
             return false;
         }
         if (function_exists('posix_getuid')) {
@@ -166,7 +255,9 @@ class HTMLPurifier_DefinitionCache_Serializer extends
             if (fileowner($dir) === posix_getuid()) {
                 // we can chmod it ourselves
                 $chmod = $chmod | 0700;
-                if (chmod($dir, $chmod)) return true;
+                if (chmod($dir, $chmod)) {
+                    return true;
+                }
             } elseif (filegroup($dir) === posix_getgid()) {
                 $chmod = $chmod | 0070;
             } else {
@@ -174,18 +265,21 @@ class HTMLPurifier_DefinitionCache_Serializer extends
                 // need to give global permissions
                 $chmod = $chmod | 0777;
             }
-            trigger_error('Directory '.$dir.' not writable, '.
+            trigger_error(
+                'Directory ' . $dir . ' not writable, ' .
                 'please chmod to ' . decoct($chmod),
-                E_USER_WARNING);
+                E_USER_WARNING
+            );
         } else {
             // generic error message
-            trigger_error('Directory '.$dir.' not writable, '.
+            trigger_error(
+                'Directory ' . $dir . ' not writable, ' .
                 'please alter file permissions',
-                E_USER_WARNING);
+                E_USER_WARNING
+            );
         }
         return false;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/DefinitionCacheFactory.php
+++ b/library/HTMLPurifier/DefinitionCacheFactory.php
@@ -5,11 +5,18 @@
  */
 class HTMLPurifier_DefinitionCacheFactory
 {
-
-    protected $caches = array('Serializer' => array());
-    protected $implementations = array();
     /**
-     * @var HTMLPurifier_DefinitionCache_Decorator[]
+     * @type array
+     */
+    protected $caches = array('Serializer' => array());
+
+    /**
+     * @type array
+     */
+    protected $implementations = array();
+
+    /**
+     * @type HTMLPurifier_DefinitionCache_Decorator[]
      */
     protected $decorators = array();
 
@@ -23,7 +30,7 @@ class HTMLPurifier_DefinitionCacheFactory
 
     /**
      * Retrieves an instance of global definition cache factory.
-     *
+     * @param HTMLPurifier_DefinitionCacheFactory $prototype
      * @return HTMLPurifier_DefinitionCacheFactory
      */
     public static function instance($prototype = null)
@@ -50,9 +57,9 @@ class HTMLPurifier_DefinitionCacheFactory
 
     /**
      * Factory method that creates a cache object based on configuration
-     *
-     * @param string $name Name of definitions handled by cache
+     * @param string $type Name of definitions handled by cache
      * @param HTMLPurifier_Config $config Config instance
+     * @return mixed
      */
     public function create($type, $config)
     {
@@ -63,10 +70,8 @@ class HTMLPurifier_DefinitionCacheFactory
         if (!empty($this->caches[$method][$type])) {
             return $this->caches[$method][$type];
         }
-        if (
-          isset($this->implementations[$method]) &&
-          class_exists($class = $this->implementations[$method], false)
-        ) {
+        if (isset($this->implementations[$method]) &&
+            class_exists($class = $this->implementations[$method], false)) {
             $cache = new $class($type);
         } else {
             if ($method != 'Serializer') {
@@ -96,7 +101,6 @@ class HTMLPurifier_DefinitionCacheFactory
         }
         $this->decorators[$decorator->name] = $decorator;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Doctype.php
+++ b/library/HTMLPurifier/Doctype.php
@@ -10,42 +10,55 @@ class HTMLPurifier_Doctype
 {
     /**
      * Full name of doctype
+     * @type string
      */
     public $name;
 
     /**
      * List of standard modules (string identifiers or literal objects)
      * that this doctype uses
+     * @type array
      */
     public $modules = array();
 
     /**
      * List of modules to use for tidying up code
+     * @type array
      */
     public $tidyModules = array();
 
     /**
      * Is the language derived from XML (i.e. XHTML)?
+     * @type bool
      */
     public $xml = true;
 
     /**
      * List of aliases for this doctype
+     * @type array
      */
     public $aliases = array();
 
     /**
      * Public DTD identifier
+     * @type string
      */
     public $dtdPublic;
 
     /**
      * System DTD identifier
+     * @type string
      */
     public $dtdSystem;
 
-    public function __construct($name = null, $xml = true, $modules = array(),
-        $tidyModules = array(), $aliases = array(), $dtd_public = null, $dtd_system = null
+    public function __construct(
+        $name = null,
+        $xml = true,
+        $modules = array(),
+        $tidyModules = array(),
+        $aliases = array(),
+        $dtd_public = null,
+        $dtd_system = null
     ) {
         $this->name         = $name;
         $this->xml          = $xml;

--- a/library/HTMLPurifier/DoctypeRegistry.php
+++ b/library/HTMLPurifier/DoctypeRegistry.php
@@ -4,12 +4,14 @@ class HTMLPurifier_DoctypeRegistry
 {
 
     /**
-     * Hash of doctype names to doctype objects
+     * Hash of doctype names to doctype objects.
+     * @type array
      */
     protected $doctypes;
 
     /**
-     * Lookup table of aliases to real doctype names
+     * Lookup table of aliases to real doctype names.
+     * @type array
      */
     protected $aliases;
 
@@ -17,32 +19,57 @@ class HTMLPurifier_DoctypeRegistry
      * Registers a doctype to the registry
      * @note Accepts a fully-formed doctype object, or the
      *       parameters for constructing a doctype object
-     * @param $doctype Name of doctype or literal doctype object
-     * @param $modules Modules doctype will load
-     * @param $modules_for_modes Modules doctype will load for certain modes
-     * @param $aliases Alias names for doctype
-     * @return Editable registered doctype
+     * @param string $doctype Name of doctype or literal doctype object
+     * @param bool $xml
+     * @param array $modules Modules doctype will load
+     * @param array $tidy_modules Modules doctype will load for certain modes
+     * @param array $aliases Alias names for doctype
+     * @param string $dtd_public
+     * @param string $dtd_system
+     * @return HTMLPurifier_Doctype Editable registered doctype
      */
-    public function register($doctype, $xml = true, $modules = array(),
-        $tidy_modules = array(), $aliases = array(), $dtd_public = null, $dtd_system = null
+    public function register(
+        $doctype,
+        $xml = true,
+        $modules = array(),
+        $tidy_modules = array(),
+        $aliases = array(),
+        $dtd_public = null,
+        $dtd_system = null
     ) {
-        if (!is_array($modules)) $modules = array($modules);
-        if (!is_array($tidy_modules)) $tidy_modules = array($tidy_modules);
-        if (!is_array($aliases)) $aliases = array($aliases);
+        if (!is_array($modules)) {
+            $modules = array($modules);
+        }
+        if (!is_array($tidy_modules)) {
+            $tidy_modules = array($tidy_modules);
+        }
+        if (!is_array($aliases)) {
+            $aliases = array($aliases);
+        }
         if (!is_object($doctype)) {
             $doctype = new HTMLPurifier_Doctype(
-                $doctype, $xml, $modules, $tidy_modules, $aliases, $dtd_public, $dtd_system
+                $doctype,
+                $xml,
+                $modules,
+                $tidy_modules,
+                $aliases,
+                $dtd_public,
+                $dtd_system
             );
         }
         $this->doctypes[$doctype->name] = $doctype;
         $name = $doctype->name;
         // hookup aliases
         foreach ($doctype->aliases as $alias) {
-            if (isset($this->doctypes[$alias])) continue;
+            if (isset($this->doctypes[$alias])) {
+                continue;
+            }
             $this->aliases[$alias] = $name;
         }
         // remove old aliases
-        if (isset($this->aliases[$name])) unset($this->aliases[$name]);
+        if (isset($this->aliases[$name])) {
+            unset($this->aliases[$name]);
+        }
         return $doctype;
     }
 
@@ -50,11 +77,14 @@ class HTMLPurifier_DoctypeRegistry
      * Retrieves reference to a doctype of a certain name
      * @note This function resolves aliases
      * @note When possible, use the more fully-featured make()
-     * @param $doctype Name of doctype
-     * @return Editable doctype object
+     * @param string $doctype Name of doctype
+     * @return HTMLPurifier_Doctype Editable doctype object
      */
-    public function get($doctype) {
-        if (isset($this->aliases[$doctype])) $doctype = $this->aliases[$doctype];
+    public function get($doctype)
+    {
+        if (isset($this->aliases[$doctype])) {
+            $doctype = $this->aliases[$doctype];
+        }
         if (!isset($this->doctypes[$doctype])) {
             trigger_error('Doctype ' . htmlspecialchars($doctype) . ' does not exist', E_USER_ERROR);
             $anon = new HTMLPurifier_Doctype($doctype);
@@ -70,20 +100,30 @@ class HTMLPurifier_DoctypeRegistry
      *       can hold on to (this is necessary in order to tell
      *       Generator whether or not the current document is XML
      *       based or not).
+     * @param HTMLPurifier_Config $config
+     * @return HTMLPurifier_Doctype
      */
-    public function make($config) {
+    public function make($config)
+    {
         return clone $this->get($this->getDoctypeFromConfig($config));
     }
 
     /**
      * Retrieves the doctype from the configuration object
+     * @param HTMLPurifier_Config $config
+     * @return string
      */
-    public function getDoctypeFromConfig($config) {
+    public function getDoctypeFromConfig($config)
+    {
         // recommended test
         $doctype = $config->get('HTML.Doctype');
-        if (!empty($doctype)) return $doctype;
+        if (!empty($doctype)) {
+            return $doctype;
+        }
         $doctype = $config->get('HTML.CustomDoctype');
-        if (!empty($doctype)) return $doctype;
+        if (!empty($doctype)) {
+            return $doctype;
+        }
         // backwards-compatibility
         if ($config->get('HTML.XHTML')) {
             $doctype = 'XHTML 1.0';
@@ -97,7 +137,6 @@ class HTMLPurifier_DoctypeRegistry
         }
         return $doctype;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/ElementDef.php
+++ b/library/HTMLPurifier/ElementDef.php
@@ -10,15 +10,16 @@
  */
 class HTMLPurifier_ElementDef
 {
-
     /**
      * Does the definition work by itself, or is it created solely
      * for the purpose of merging into another definition?
+     * @type bool
      */
     public $standalone = true;
 
     /**
-     * Associative array of attribute name to HTMLPurifier_AttrDef
+     * Associative array of attribute name to HTMLPurifier_AttrDef.
+     * @type array
      * @note Before being processed by HTMLPurifier_AttrCollections
      *       when modules are finalized during
      *       HTMLPurifier_HTMLDefinition->setup(), this array may also
@@ -43,26 +44,30 @@ class HTMLPurifier_ElementDef
     // nuking.
 
     /**
-     * List of tags HTMLPurifier_AttrTransform to be done before validation
+     * List of tags HTMLPurifier_AttrTransform to be done before validation.
+     * @type array
      */
     public $attr_transform_pre = array();
 
     /**
-     * List of tags HTMLPurifier_AttrTransform to be done after validation
+     * List of tags HTMLPurifier_AttrTransform to be done after validation.
+     * @type array
      */
     public $attr_transform_post = array();
 
     /**
      * HTMLPurifier_ChildDef of this tag.
+     * @type HTMLPurifier_ChildDef
      */
     public $child;
 
     /**
-     * Abstract string representation of internal ChildDef rules. See
-     * HTMLPurifier_ContentSets for how this is parsed and then transformed
+     * Abstract string representation of internal ChildDef rules.
+     * @see HTMLPurifier_ContentSets for how this is parsed and then transformed
      * into an HTMLPurifier_ChildDef.
      * @warning This is a temporary variable that is not available after
      *      being processed by HTMLDefinition
+     * @type string
      */
     public $content_model;
 
@@ -72,27 +77,29 @@ class HTMLPurifier_ElementDef
      * @warning This must be lowercase
      * @warning This is a temporary variable that is not available after
      *      being processed by HTMLDefinition
+     * @type string
      */
     public $content_model_type;
-
-
 
     /**
      * Does the element have a content model (#PCDATA | Inline)*? This
      * is important for chameleon ins and del processing in
      * HTMLPurifier_ChildDef_Chameleon. Dynamically set: modules don't
      * have to worry about this one.
+     * @type bool
      */
     public $descendants_are_inline = false;
 
     /**
-     * List of the names of required attributes this element has. Dynamically
-     * populated by HTMLPurifier_HTMLDefinition::getElement
+     * List of the names of required attributes this element has.
+     * Dynamically populated by HTMLPurifier_HTMLDefinition::getElement()
+     * @type array
      */
     public $required_attr = array();
 
     /**
      * Lookup table of tags excluded from all descendants of this tag.
+     * @type array
      * @note SGML permits exclusions for all descendants, but this is
      *       not possible with DTDs or XML Schemas. W3C has elected to
      *       use complicated compositions of content_models to simulate
@@ -106,6 +113,7 @@ class HTMLPurifier_ElementDef
 
     /**
      * This tag is explicitly auto-closed by the following tags.
+     * @type array
      */
     public $autoclose = array();
 
@@ -113,19 +121,22 @@ class HTMLPurifier_ElementDef
      * If a foreign element is found in this element, test if it is
      * allowed by this sub-element; if it is, instead of closing the
      * current element, place it inside this element.
+     * @type string
      */
     public $wrap;
 
     /**
      * Whether or not this is a formatting element affected by the
      * "Active Formatting Elements" algorithm.
+     * @type bool
      */
     public $formatting;
 
     /**
      * Low-level factory constructor for creating new standalone element defs
      */
-    public static function create($content_model, $content_model_type, $attr) {
+    public static function create($content_model, $content_model_type, $attr)
+    {
         $def = new HTMLPurifier_ElementDef();
         $def->content_model = $content_model;
         $def->content_model_type = $content_model_type;
@@ -137,11 +148,12 @@ class HTMLPurifier_ElementDef
      * Merges the values of another element definition into this one.
      * Values from the new element def take precedence if a value is
      * not mergeable.
+     * @param HTMLPurifier_ElementDef $def
      */
-    public function mergeIn($def) {
-
+    public function mergeIn($def)
+    {
         // later keys takes precedence
-        foreach($def->attr as $k => $v) {
+        foreach ($def->attr as $k => $v) {
             if ($k === 0) {
                 // merge in the includes
                 // sorry, no way to override an include
@@ -151,7 +163,9 @@ class HTMLPurifier_ElementDef
                 continue;
             }
             if ($v === false) {
-                if (isset($this->attr[$k])) unset($this->attr[$k]);
+                if (isset($this->attr[$k])) {
+                    unset($this->attr[$k]);
+                }
                 continue;
             }
             $this->attr[$k] = $v;
@@ -160,19 +174,24 @@ class HTMLPurifier_ElementDef
         $this->attr_transform_pre = array_merge($this->attr_transform_pre, $def->attr_transform_pre);
         $this->attr_transform_post = array_merge($this->attr_transform_post, $def->attr_transform_post);
 
-        if(!empty($def->content_model)) {
+        if (!empty($def->content_model)) {
             $this->content_model =
                 str_replace("#SUPER", $this->content_model, $def->content_model);
             $this->child = false;
         }
-        if(!empty($def->content_model_type)) {
+        if (!empty($def->content_model_type)) {
             $this->content_model_type = $def->content_model_type;
             $this->child = false;
         }
-        if(!is_null($def->child)) $this->child = $def->child;
-        if(!is_null($def->formatting)) $this->formatting = $def->formatting;
-        if($def->descendants_are_inline) $this->descendants_are_inline = $def->descendants_are_inline;
-
+        if (!is_null($def->child)) {
+            $this->child = $def->child;
+        }
+        if (!is_null($def->formatting)) {
+            $this->formatting = $def->formatting;
+        }
+        if ($def->descendants_are_inline) {
+            $this->descendants_are_inline = $def->descendants_are_inline;
+        }
     }
 
     /**
@@ -180,16 +199,18 @@ class HTMLPurifier_ElementDef
      * @param $a1 Array by reference that is merged into
      * @param $a2 Array that merges into $a1
      */
-    private function _mergeAssocArray(&$a1, $a2) {
+    private function _mergeAssocArray(&$a1, $a2)
+    {
         foreach ($a2 as $k => $v) {
             if ($v === false) {
-                if (isset($a1[$k])) unset($a1[$k]);
+                if (isset($a1[$k])) {
+                    unset($a1[$k]);
+                }
                 continue;
             }
             $a1[$k] = $v;
         }
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/EntityLookup.php
+++ b/library/HTMLPurifier/EntityLookup.php
@@ -3,20 +3,23 @@
 /**
  * Object that provides entity lookup table from entity name to character
  */
-class HTMLPurifier_EntityLookup {
-
+class HTMLPurifier_EntityLookup
+{
     /**
      * Assoc array of entity name to character represented.
+     * @type array
      */
     public $table;
 
     /**
      * Sets up the entity lookup table from the serialized file contents.
+     * @param bool $file
      * @note The serialized contents are versioned, but were generated
      *       using the maintenance script generate_entity_file.php
      * @warning This is not in constructor to help enforce the Singleton
      */
-    public function setup($file = false) {
+    public function setup($file = false)
+    {
         if (!$file) {
             $file = HTMLPURIFIER_PREFIX . '/HTMLPurifier/EntityLookup/entities.ser';
         }
@@ -25,9 +28,11 @@ class HTMLPurifier_EntityLookup {
 
     /**
      * Retrieves sole instance of the object.
-     * @param Optional prototype of custom lookup table to overload with.
+     * @param bool|HTMLPurifier_EntityLookup $prototype Optional prototype of custom lookup table to overload with.
+     * @return HTMLPurifier_EntityLookup
      */
-    public static function instance($prototype = false) {
+    public static function instance($prototype = false)
+    {
         // no references, since PHP doesn't copy unless modified
         static $instance = null;
         if ($prototype) {
@@ -38,7 +43,6 @@ class HTMLPurifier_EntityLookup {
         }
         return $instance;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/EntityParser.php
+++ b/library/HTMLPurifier/EntityParser.php
@@ -12,19 +12,21 @@ class HTMLPurifier_EntityParser
 
     /**
      * Reference to entity lookup table.
+     * @type HTMLPurifier_EntityLookup
      */
     protected $_entity_lookup;
 
     /**
      * Callback regex string for parsing entities.
+     * @type string
      */
     protected $_substituteEntitiesRegex =
-'/&(?:[#]x([a-fA-F0-9]+)|[#]0*(\d+)|([A-Za-z_:][A-Za-z0-9.\-_:]*));?/';
-//     1. hex             2. dec      3. string (XML style)
-
+        '/&(?:[#]x([a-fA-F0-9]+)|[#]0*(\d+)|([A-Za-z_:][A-Za-z0-9.\-_:]*));?/';
+        //     1. hex             2. dec      3. string (XML style)
 
     /**
      * Decimal to parsed string conversion table for special entities.
+     * @type array
      */
     protected $_special_dec2str =
             array(
@@ -37,6 +39,7 @@ class HTMLPurifier_EntityParser
 
     /**
      * Stripped entity names to decimal conversion table for special entities.
+     * @type array
      */
     protected $_special_ent2dec =
             array(
@@ -51,41 +54,45 @@ class HTMLPurifier_EntityParser
      * running this whenever you have parsed character is t3h 5uck, we run
      * it before everything else.
      *
-     * @param $string String to have non-special entities parsed.
-     * @returns Parsed string.
+     * @param string $string String to have non-special entities parsed.
+     * @return string Parsed string.
      */
-    public function substituteNonSpecialEntities($string) {
+    public function substituteNonSpecialEntities($string)
+    {
         // it will try to detect missing semicolons, but don't rely on it
         return preg_replace_callback(
             $this->_substituteEntitiesRegex,
             array($this, 'nonSpecialEntityCallback'),
             $string
-            );
+        );
     }
 
     /**
      * Callback function for substituteNonSpecialEntities() that does the work.
      *
-     * @param $matches  PCRE matches array, with 0 the entire match, and
+     * @param array $matches  PCRE matches array, with 0 the entire match, and
      *                  either index 1, 2 or 3 set with a hex value, dec value,
      *                  or string (respectively).
-     * @returns Replacement string.
+     * @return string Replacement string.
      */
 
-    protected function nonSpecialEntityCallback($matches) {
+    protected function nonSpecialEntityCallback($matches)
+    {
         // replaces all but big five
         $entity = $matches[0];
         $is_num = (@$matches[0][1] === '#');
         if ($is_num) {
             $is_hex = (@$entity[2] === 'x');
             $code = $is_hex ? hexdec($matches[1]) : (int) $matches[2];
-
             // abort for special characters
-            if (isset($this->_special_dec2str[$code]))  return $entity;
-
+            if (isset($this->_special_dec2str[$code])) {
+                return $entity;
+            }
             return HTMLPurifier_Encoder::unichr($code);
         } else {
-            if (isset($this->_special_ent2dec[$matches[3]])) return $entity;
+            if (isset($this->_special_ent2dec[$matches[3]])) {
+                return $entity;
+            }
             if (!$this->_entity_lookup) {
                 $this->_entity_lookup = HTMLPurifier_EntityLookup::instance();
             }
@@ -103,14 +110,16 @@ class HTMLPurifier_EntityParser
      * @notice We try to avoid calling this function because otherwise, it
      * would have to be called a lot (for every parsed section).
      *
-     * @param $string String to have non-special entities parsed.
-     * @returns Parsed string.
+     * @param string $string String to have non-special entities parsed.
+     * @return string Parsed string.
      */
-    public function substituteSpecialEntities($string) {
+    public function substituteSpecialEntities($string)
+    {
         return preg_replace_callback(
             $this->_substituteEntitiesRegex,
             array($this, 'specialEntityCallback'),
-            $string);
+            $string
+        );
     }
 
     /**
@@ -118,12 +127,13 @@ class HTMLPurifier_EntityParser
      *
      * This callback has same syntax as nonSpecialEntityCallback().
      *
-     * @param $matches  PCRE-style matches array, with 0 the entire match, and
+     * @param array $matches  PCRE-style matches array, with 0 the entire match, and
      *                  either index 1, 2 or 3 set with a hex value, dec value,
      *                  or string (respectively).
-     * @returns Replacement string.
+     * @return string Replacement string.
      */
-    protected function specialEntityCallback($matches) {
+    protected function specialEntityCallback($matches)
+    {
         $entity = $matches[0];
         $is_num = (@$matches[0][1] === '#');
         if ($is_num) {
@@ -138,7 +148,6 @@ class HTMLPurifier_EntityParser
                 $entity;
         }
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/ErrorStruct.php
+++ b/library/HTMLPurifier/ErrorStruct.php
@@ -19,6 +19,7 @@ class HTMLPurifier_ErrorStruct
 
     /**
      * Type of this struct.
+     * @type string
      */
     public $type;
 
@@ -28,11 +29,13 @@ class HTMLPurifier_ErrorStruct
      *  - TOKEN: Instance of HTMLPurifier_Token
      *  - ATTR: array('attr-name', 'value')
      *  - CSSPROP: array('prop-name', 'value')
+     * @type mixed
      */
     public $value;
 
     /**
      * Errors registered for this structure.
+     * @type array
      */
     public $errors = array();
 
@@ -40,10 +43,17 @@ class HTMLPurifier_ErrorStruct
      * Child ErrorStructs that are from this structure. For example, a TOKEN
      * ErrorStruct would contain ATTR ErrorStructs. This is a multi-dimensional
      * array in structure: [TYPE]['identifier']
+     * @type array
      */
     public $children = array();
 
-    public function getChild($type, $id) {
+    /**
+     * @param string $type
+     * @param string $id
+     * @return mixed
+     */
+    public function getChild($type, $id)
+    {
         if (!isset($this->children[$type][$id])) {
             $this->children[$type][$id] = new HTMLPurifier_ErrorStruct();
             $this->children[$type][$id]->type = $type;
@@ -51,10 +61,14 @@ class HTMLPurifier_ErrorStruct
         return $this->children[$type][$id];
     }
 
-    public function addError($severity, $message) {
+    /**
+     * @param int $severity
+     * @param string $message
+     */
+    public function addError($severity, $message)
+    {
         $this->errors[] = array($severity, $message);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Filter.php
+++ b/library/HTMLPurifier/Filter.php
@@ -23,24 +23,34 @@ class HTMLPurifier_Filter
 {
 
     /**
-     * Name of the filter for identification purposes
+     * Name of the filter for identification purposes.
+     * @type string
      */
     public $name;
 
     /**
      * Pre-processor function, handles HTML before HTML Purifier
+     * @param string $html
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return string
      */
-    public function preFilter($html, $config, $context) {
+    public function preFilter($html, $config, $context)
+    {
         return $html;
     }
 
     /**
      * Post-processor function, handles HTML after HTML Purifier
+     * @param string $html
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return string
      */
-    public function postFilter($html, $config, $context) {
+    public function postFilter($html, $config, $context)
+    {
         return $html;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Filter/YouTube.php
+++ b/library/HTMLPurifier/Filter/YouTube.php
@@ -3,36 +3,62 @@
 class HTMLPurifier_Filter_YouTube extends HTMLPurifier_Filter
 {
 
+    /**
+     * @type string
+     */
     public $name = 'YouTube';
 
-    public function preFilter($html, $config, $context) {
-        $pre_regex = '#<object[^>]+>.+?'.
+    /**
+     * @param string $html
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return string
+     */
+    public function preFilter($html, $config, $context)
+    {
+        $pre_regex = '#<object[^>]+>.+?' .
             'http://www.youtube.com/((?:v|cp)/[A-Za-z0-9\-_=]+).+?</object>#s';
         $pre_replace = '<span class="youtube-embed">\1</span>';
         return preg_replace($pre_regex, $pre_replace, $html);
     }
 
-    public function postFilter($html, $config, $context) {
+    /**
+     * @param string $html
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return string
+     */
+    public function postFilter($html, $config, $context)
+    {
         $post_regex = '#<span class="youtube-embed">((?:v|cp)/[A-Za-z0-9\-_=]+)</span>#';
         return preg_replace_callback($post_regex, array($this, 'postFilterCallback'), $html);
     }
 
-    protected function armorUrl($url) {
+    /**
+     * @param $url
+     * @return string
+     */
+    protected function armorUrl($url)
+    {
         return str_replace('--', '-&#45;', $url);
     }
 
-    protected function postFilterCallback($matches) {
+    /**
+     * @param array $matches
+     * @return string
+     */
+    protected function postFilterCallback($matches)
+    {
         $url = $this->armorUrl($matches[1]);
-        return '<object width="425" height="350" type="application/x-shockwave-flash" '.
-            'data="http://www.youtube.com/'.$url.'">'.
-            '<param name="movie" value="http://www.youtube.com/'.$url.'"></param>'.
-            '<!--[if IE]>'.
-            '<embed src="http://www.youtube.com/'.$url.'"'.
-            'type="application/x-shockwave-flash"'.
-            'wmode="transparent" width="425" height="350" />'.
-            '<![endif]-->'.
-            '</object>';
-
+        return '<object width="425" height="350" type="application/x-shockwave-flash" ' .
+        'data="http://www.youtube.com/' . $url . '">' .
+        '<param name="movie" value="http://www.youtube.com/' . $url . '"></param>' .
+        '<!--[if IE]>' .
+        '<embed src="http://www.youtube.com/' . $url . '"' .
+        'type="application/x-shockwave-flash"' .
+        'wmode="transparent" width="425" height="350" />' .
+        '<![endif]-->' .
+        '</object>';
     }
 }
 

--- a/library/HTMLPurifier/HTMLDefinition.php
+++ b/library/HTMLPurifier/HTMLDefinition.php
@@ -29,60 +29,71 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
     // FULLY-PUBLIC VARIABLES ---------------------------------------------
 
     /**
-     * Associative array of element names to HTMLPurifier_ElementDef
+     * Associative array of element names to HTMLPurifier_ElementDef.
+     * @type HTMLPurifier_ElementDef[]
      */
     public $info = array();
 
     /**
      * Associative array of global attribute name to attribute definition.
+     * @type array
      */
     public $info_global_attr = array();
 
     /**
      * String name of parent element HTML will be going into.
+     * @type string
      */
     public $info_parent = 'div';
 
     /**
      * Definition for parent element, allows parent element to be a
      * tag that's not allowed inside the HTML fragment.
+     * @type HTMLPurifier_ElementDef
      */
     public $info_parent_def;
 
     /**
-     * String name of element used to wrap inline elements in block context
+     * String name of element used to wrap inline elements in block context.
+     * @type string
      * @note This is rarely used except for BLOCKQUOTEs in strict mode
      */
     public $info_block_wrapper = 'p';
 
     /**
-     * Associative array of deprecated tag name to HTMLPurifier_TagTransform
+     * Associative array of deprecated tag name to HTMLPurifier_TagTransform.
+     * @type array
      */
     public $info_tag_transform = array();
 
     /**
      * Indexed list of HTMLPurifier_AttrTransform to be performed before validation.
+     * @type HTMLPurifier_AttrTransform[]
      */
     public $info_attr_transform_pre = array();
 
     /**
      * Indexed list of HTMLPurifier_AttrTransform to be performed after validation.
+     * @type HTMLPurifier_AttrTransform[]
      */
     public $info_attr_transform_post = array();
 
     /**
      * Nested lookup array of content set name (Block, Inline) to
      * element name to whether or not it belongs in that content set.
+     * @type array
      */
     public $info_content_sets = array();
 
     /**
      * Indexed list of HTMLPurifier_Injector to be used.
+     * @type HTMLPurifier_Injector[]
      */
     public $info_injector = array();
 
     /**
      * Doctype object
+     * @type HTMLPurifier_Doctype
      */
     public $doctype;
 
@@ -94,12 +105,13 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
      * Adds a custom attribute to a pre-existing element
      * @note This is strictly convenience, and does not have a corresponding
      *       method in HTMLPurifier_HTMLModule
-     * @param $element_name String element name to add attribute to
-     * @param $attr_name String name of attribute
-     * @param $def Attribute definition, can be string or object, see
+     * @param string $element_name Element name to add attribute to
+     * @param string $attr_name Name of attribute
+     * @param mixed $def Attribute definition, can be string or object, see
      *             HTMLPurifier_AttrTypes for details
      */
-    public function addAttribute($element_name, $attr_name, $def) {
+    public function addAttribute($element_name, $attr_name, $def)
+    {
         $module = $this->getAnonymousModule();
         if (!isset($module->info[$element_name])) {
             $element = $module->addBlankElement($element_name);
@@ -111,10 +123,11 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
 
     /**
      * Adds a custom element to your HTML definition
-     * @note See HTMLPurifier_HTMLModule::addElement for detailed
+     * @see HTMLPurifier_HTMLModule::addElement() for detailed
      *       parameter and return value descriptions.
      */
-    public function addElement($element_name, $type, $contents, $attr_collections, $attributes = array()) {
+    public function addElement($element_name, $type, $contents, $attr_collections, $attributes = array())
+    {
         $module = $this->getAnonymousModule();
         // assume that if the user is calling this, the element
         // is safe. This may not be a good idea
@@ -125,10 +138,13 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
     /**
      * Adds a blank element to your HTML definition, for overriding
      * existing behavior
-     * @note See HTMLPurifier_HTMLModule::addBlankElement for detailed
+     * @param string $element_name
+     * @return HTMLPurifier_ElementDef
+     * @see HTMLPurifier_HTMLModule::addBlankElement() for detailed
      *       parameter and return value descriptions.
      */
-    public function addBlankElement($element_name) {
+    public function addBlankElement($element_name)
+    {
         $module  = $this->getAnonymousModule();
         $element = $module->addBlankElement($element_name);
         return $element;
@@ -138,8 +154,10 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
      * Retrieves a reference to the anonymous module, so you can
      * bust out advanced features without having to make your own
      * module.
+     * @return HTMLPurifier_HTMLModule
      */
-    public function getAnonymousModule() {
+    public function getAnonymousModule()
+    {
         if (!$this->_anonModule) {
             $this->_anonModule = new HTMLPurifier_HTMLModule();
             $this->_anonModule->name = 'Anonymous';
@@ -149,20 +167,31 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
 
     private $_anonModule = null;
 
-
     // PUBLIC BUT INTERNAL VARIABLES --------------------------------------
 
+    /**
+     * @type string
+     */
     public $type = 'HTML';
-    public $manager; /**< Instance of HTMLPurifier_HTMLModuleManager */
+
+    /**
+     * @type HTMLPurifier_HTMLModuleManager
+     */
+    public $manager;
 
     /**
      * Performs low-cost, preliminary initialization.
      */
-    public function __construct() {
+    public function __construct()
+    {
         $this->manager = new HTMLPurifier_HTMLModuleManager();
     }
 
-    protected function doSetup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    protected function doSetup($config)
+    {
         $this->processModules($config);
         $this->setupConfigStuff($config);
         unset($this->manager);
@@ -176,9 +205,10 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
 
     /**
      * Extract out the information from the manager
+     * @param HTMLPurifier_Config $config
      */
-    protected function processModules($config) {
-
+    protected function processModules($config)
+    {
         if ($this->_anonModule) {
             // for user specific changes
             // this is late-loaded so we don't have to deal with PHP4
@@ -191,40 +221,53 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
         $this->doctype = $this->manager->doctype;
 
         foreach ($this->manager->modules as $module) {
-            foreach($module->info_tag_transform as $k => $v) {
-                if ($v === false) unset($this->info_tag_transform[$k]);
-                else $this->info_tag_transform[$k] = $v;
+            foreach ($module->info_tag_transform as $k => $v) {
+                if ($v === false) {
+                    unset($this->info_tag_transform[$k]);
+                } else {
+                    $this->info_tag_transform[$k] = $v;
+                }
             }
-            foreach($module->info_attr_transform_pre as $k => $v) {
-                if ($v === false) unset($this->info_attr_transform_pre[$k]);
-                else $this->info_attr_transform_pre[$k] = $v;
+            foreach ($module->info_attr_transform_pre as $k => $v) {
+                if ($v === false) {
+                    unset($this->info_attr_transform_pre[$k]);
+                } else {
+                    $this->info_attr_transform_pre[$k] = $v;
+                }
             }
-            foreach($module->info_attr_transform_post as $k => $v) {
-                if ($v === false) unset($this->info_attr_transform_post[$k]);
-                else $this->info_attr_transform_post[$k] = $v;
+            foreach ($module->info_attr_transform_post as $k => $v) {
+                if ($v === false) {
+                    unset($this->info_attr_transform_post[$k]);
+                } else {
+                    $this->info_attr_transform_post[$k] = $v;
+                }
             }
             foreach ($module->info_injector as $k => $v) {
-                if ($v === false) unset($this->info_injector[$k]);
-                else $this->info_injector[$k] = $v;
+                if ($v === false) {
+                    unset($this->info_injector[$k]);
+                } else {
+                    $this->info_injector[$k] = $v;
+                }
             }
         }
-
         $this->info = $this->manager->getElements();
         $this->info_content_sets = $this->manager->contentSets->lookup;
-
     }
 
     /**
      * Sets up stuff based on config. We need a better way of doing this.
+     * @param HTMLPurifier_Config $config
      */
-    protected function setupConfigStuff($config) {
-
+    protected function setupConfigStuff($config)
+    {
         $block_wrapper = $config->get('HTML.BlockWrapper');
         if (isset($this->info_content_sets['Block'][$block_wrapper])) {
             $this->info_block_wrapper = $block_wrapper;
         } else {
-            trigger_error('Cannot use non-block element as block wrapper',
-                E_USER_ERROR);
+            trigger_error(
+                'Cannot use non-block element as block wrapper',
+                E_USER_ERROR
+            );
         }
 
         $parent = $config->get('HTML.Parent');
@@ -233,14 +276,15 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
             $this->info_parent = $parent;
             $this->info_parent_def = $def;
         } else {
-            trigger_error('Cannot use unrecognized element as parent',
-                E_USER_ERROR);
+            trigger_error(
+                'Cannot use unrecognized element as parent',
+                E_USER_ERROR
+            );
             $this->info_parent_def = $this->manager->getElement($this->info_parent, true);
         }
 
         // support template text
-        $support = "(for information on implementing this, see the ".
-                   "support forums) ";
+        $support = "(for information on implementing this, see the support forums) ";
 
         // setup allowed elements -----------------------------------------
 
@@ -256,7 +300,9 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
 
         if (is_array($allowed_elements)) {
             foreach ($this->info as $name => $d) {
-                if(!isset($allowed_elements[$name])) unset($this->info[$name]);
+                if (!isset($allowed_elements[$name])) {
+                    unset($this->info[$name]);
+                }
                 unset($allowed_elements[$name]);
             }
             // emit errors
@@ -270,7 +316,6 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
 
         $allowed_attributes_mutable = $allowed_attributes; // by copy!
         if (is_array($allowed_attributes)) {
-
             // This actually doesn't do anything, since we went away from
             // global attributes. It's possible that userland code uses
             // it, but HTMLModuleManager doesn't!
@@ -285,7 +330,9 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
                         unset($allowed_attributes_mutable[$key]);
                     }
                 }
-                if ($delete) unset($this->info_global_attr[$attr]);
+                if ($delete) {
+                    unset($this->info_global_attr[$attr]);
+                }
             }
 
             foreach ($this->info as $tag => $info) {
@@ -302,7 +349,11 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
                     }
                     if ($delete) {
                         if ($this->info[$tag]->attr[$attr]->required) {
-                            trigger_error("Required attribute '$attr' in element '$tag' was not allowed, which means '$tag' will not be allowed either", E_USER_WARNING);
+                            trigger_error(
+                                "Required attribute '$attr' in element '$tag' " .
+                                "was not allowed, which means '$tag' will not be allowed either",
+                                E_USER_WARNING
+                            );
                         }
                         unset($this->info[$tag]->attr[$attr]);
                     }
@@ -318,23 +369,29 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
                             $element = htmlspecialchars($bits[0]);
                             $attribute = htmlspecialchars($bits[1]);
                             if (!isset($this->info[$element])) {
-                                trigger_error("Cannot allow attribute '$attribute' if element '$element' is not allowed/supported $support");
+                                trigger_error(
+                                    "Cannot allow attribute '$attribute' if element " .
+                                    "'$element' is not allowed/supported $support"
+                                );
                             } else {
-                                trigger_error("Attribute '$attribute' in element '$element' not supported $support",
-                                    E_USER_WARNING);
+                                trigger_error(
+                                    "Attribute '$attribute' in element '$element' not supported $support",
+                                    E_USER_WARNING
+                                );
                             }
                             break;
                         }
                         // otherwise fall through
                     case 1:
                         $attribute = htmlspecialchars($bits[0]);
-                        trigger_error("Global attribute '$attribute' is not ".
+                        trigger_error(
+                            "Global attribute '$attribute' is not ".
                             "supported in any elements $support",
-                            E_USER_WARNING);
+                            E_USER_WARNING
+                        );
                         break;
                 }
             }
-
         }
 
         // setup forbidden elements ---------------------------------------
@@ -348,25 +405,34 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
                 continue;
             }
             foreach ($info->attr as $attr => $x) {
-                if (
-                    isset($forbidden_attributes["$tag@$attr"]) ||
+                if (isset($forbidden_attributes["$tag@$attr"]) ||
                     isset($forbidden_attributes["*@$attr"]) ||
                     isset($forbidden_attributes[$attr])
                 ) {
                     unset($this->info[$tag]->attr[$attr]);
                     continue;
-                } // this segment might get removed eventually
-                elseif (isset($forbidden_attributes["$tag.$attr"])) {
+                } elseif (isset($forbidden_attributes["$tag.$attr"])) { // this segment might get removed eventually
                     // $tag.$attr are not user supplied, so no worries!
-                    trigger_error("Error with $tag.$attr: tag.attr syntax not supported for HTML.ForbiddenAttributes; use tag@attr instead", E_USER_WARNING);
+                    trigger_error(
+                        "Error with $tag.$attr: tag.attr syntax not supported for " .
+                        "HTML.ForbiddenAttributes; use tag@attr instead",
+                        E_USER_WARNING
+                    );
                 }
             }
         }
         foreach ($forbidden_attributes as $key => $v) {
-            if (strlen($key) < 2) continue;
-            if ($key[0] != '*') continue;
+            if (strlen($key) < 2) {
+                continue;
+            }
+            if ($key[0] != '*') {
+                continue;
+            }
             if ($key[1] == '.') {
-                trigger_error("Error with $key: *.attr syntax not supported for HTML.ForbiddenAttributes; use attr instead", E_USER_WARNING);
+                trigger_error(
+                    "Error with $key: *.attr syntax not supported for HTML.ForbiddenAttributes; use attr instead",
+                    E_USER_WARNING
+                );
             }
         }
 
@@ -385,12 +451,12 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
      * separate lists for processing. Format is element[attr1|attr2],element2...
      * @warning Although it's largely drawn from TinyMCE's implementation,
      *      it is different, and you'll probably have to modify your lists
-     * @param $list String list to parse
-     * @param array($allowed_elements, $allowed_attributes)
+     * @param array $list String list to parse
+     * @return array
      * @todo Give this its own class, probably static interface
      */
-    public function parseTinyMCEAllowedList($list) {
-
+    public function parseTinyMCEAllowedList($list)
+    {
         $list = str_replace(array(' ', "\t"), '', $list);
 
         $elements = array();
@@ -398,7 +464,9 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
 
         $chunks = preg_split('/(,|[\n\r]+)/', $list);
         foreach ($chunks as $chunk) {
-            if (empty($chunk)) continue;
+            if (empty($chunk)) {
+                continue;
+            }
             // remove TinyMCE element control characters
             if (!strpos($chunk, '[')) {
                 $element = $chunk;
@@ -406,20 +474,20 @@ class HTMLPurifier_HTMLDefinition extends HTMLPurifier_Definition
             } else {
                 list($element, $attr) = explode('[', $chunk);
             }
-            if ($element !== '*') $elements[$element] = true;
-            if (!$attr) continue;
+            if ($element !== '*') {
+                $elements[$element] = true;
+            }
+            if (!$attr) {
+                continue;
+            }
             $attr = substr($attr, 0, strlen($attr) - 1); // remove trailing ]
             $attr = explode('|', $attr);
             foreach ($attr as $key) {
                 $attributes["$element.$key"] = true;
             }
         }
-
         return array($elements, $attributes);
-
     }
-
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule.php
+++ b/library/HTMLPurifier/HTMLModule.php
@@ -21,13 +21,15 @@ class HTMLPurifier_HTMLModule
     // -- Overloadable ----------------------------------------------------
 
     /**
-     * Short unique string identifier of the module
+     * Short unique string identifier of the module.
+     * @type string
      */
     public $name;
 
     /**
-     * Informally, a list of elements this module changes. Not used in
-     * any significant way.
+     * Informally, a list of elements this module changes.
+     * Not used in any significant way.
+     * @type array
      */
     public $elements = array();
 
@@ -35,6 +37,7 @@ class HTMLPurifier_HTMLModule
      * Associative array of element names to element definitions.
      * Some definitions may be incomplete, to be merged in later
      * with the full definition.
+     * @type array
      */
     public $info = array();
 
@@ -43,6 +46,7 @@ class HTMLPurifier_HTMLModule
      * This is commonly used to, say, add an A element to the Inline
      * content set. This corresponds to an internal variable $content_sets
      * and NOT info_content_sets member variable of HTMLDefinition.
+     * @type array
      */
     public $content_sets = array();
 
@@ -53,21 +57,25 @@ class HTMLPurifier_HTMLModule
      * the style attribute to the Core. Corresponds to HTMLDefinition's
      * attr_collections->info, since the object's data is only info,
      * with extra behavior associated with it.
+     * @type array
      */
     public $attr_collections = array();
 
     /**
-     * Associative array of deprecated tag name to HTMLPurifier_TagTransform
+     * Associative array of deprecated tag name to HTMLPurifier_TagTransform.
+     * @type array
      */
     public $info_tag_transform = array();
 
     /**
      * List of HTMLPurifier_AttrTransform to be performed before validation.
+     * @type array
      */
     public $info_attr_transform_pre = array();
 
     /**
      * List of HTMLPurifier_AttrTransform to be performed after validation.
+     * @type array
      */
     public $info_attr_transform_post = array();
 
@@ -76,6 +84,7 @@ class HTMLPurifier_HTMLModule
      * An injector will only be invoked if all of it's pre-requisites are met;
      * if an injector fails setup, there will be no error; it will simply be
      * silently disabled.
+     * @type array
      */
     public $info_injector = array();
 
@@ -84,6 +93,7 @@ class HTMLPurifier_HTMLModule
      * For optimization reasons: may save a call to a function. Be sure
      * to set it if you do implement getChildDef(), otherwise it will have
      * no effect!
+     * @type bool
      */
     public $defines_child_def = false;
 
@@ -94,6 +104,7 @@ class HTMLPurifier_HTMLModule
      * which is based off of safe HTML, to explicitly say, "This is safe," even
      * though there are modules which are "unsafe")
      *
+     * @type bool
      * @note Previously, safety could be applied at an element level granularity.
      *       We've removed this ability, so in order to add "unsafe" elements
      *       or attributes, a dedicated module with this property set to false
@@ -106,51 +117,62 @@ class HTMLPurifier_HTMLModule
      * content_model and content_model_type member variables of
      * the HTMLPurifier_ElementDef class. There is a similar function
      * in HTMLPurifier_HTMLDefinition.
-     * @param $def HTMLPurifier_ElementDef instance
+     * @param HTMLPurifier_ElementDef $def
      * @return HTMLPurifier_ChildDef subclass
      */
-    public function getChildDef($def) {return false;}
+    public function getChildDef($def)
+    {
+        return false;
+    }
 
     // -- Convenience -----------------------------------------------------
 
     /**
      * Convenience function that sets up a new element
-     * @param $element Name of element to add
-     * @param $type What content set should element be registered to?
+     * @param string $element Name of element to add
+     * @param string|bool $type What content set should element be registered to?
      *              Set as false to skip this step.
-     * @param $contents Allowed children in form of:
+     * @param string $contents Allowed children in form of:
      *              "$content_model_type: $content_model"
-     * @param $attr_includes What attribute collections to register to
+     * @param array $attr_includes What attribute collections to register to
      *              element?
-     * @param $attr What unique attributes does the element define?
-     * @note See ElementDef for in-depth descriptions of these parameters.
-     * @return Created element definition object, so you
+     * @param array $attr What unique attributes does the element define?
+     * @see HTMLPurifier_ElementDef:: for in-depth descriptions of these parameters.
+     * @return HTMLPurifier_ElementDef Created element definition object, so you
      *         can set advanced parameters
      */
-    public function addElement($element, $type, $contents, $attr_includes = array(), $attr = array()) {
+    public function addElement($element, $type, $contents, $attr_includes = array(), $attr = array())
+    {
         $this->elements[] = $element;
         // parse content_model
         list($content_model_type, $content_model) = $this->parseContents($contents);
         // merge in attribute inclusions
         $this->mergeInAttrIncludes($attr, $attr_includes);
         // add element to content sets
-        if ($type) $this->addElementToContentSet($element, $type);
+        if ($type) {
+            $this->addElementToContentSet($element, $type);
+        }
         // create element
         $this->info[$element] = HTMLPurifier_ElementDef::create(
-            $content_model, $content_model_type, $attr
+            $content_model,
+            $content_model_type,
+            $attr
         );
         // literal object $contents means direct child manipulation
-        if (!is_string($contents)) $this->info[$element]->child = $contents;
+        if (!is_string($contents)) {
+            $this->info[$element]->child = $contents;
+        }
         return $this->info[$element];
     }
 
     /**
      * Convenience function that creates a totally blank, non-standalone
      * element.
-     * @param $element Name of element to create
-     * @return Created element
+     * @param string $element Name of element to create
+     * @return HTMLPurifier_ElementDef Created element
      */
-    public function addBlankElement($element) {
+    public function addBlankElement($element)
+    {
         if (!isset($this->info[$element])) {
             $this->elements[] = $element;
             $this->info[$element] = new HTMLPurifier_ElementDef();
@@ -163,27 +185,35 @@ class HTMLPurifier_HTMLModule
 
     /**
      * Convenience function that registers an element to a content set
-     * @param Element to register
-     * @param Name content set (warning: case sensitive, usually upper-case
+     * @param string $element Element to register
+     * @param string $type Name content set (warning: case sensitive, usually upper-case
      *        first letter)
      */
-    public function addElementToContentSet($element, $type) {
-        if (!isset($this->content_sets[$type])) $this->content_sets[$type] = '';
-        else $this->content_sets[$type] .= ' | ';
+    public function addElementToContentSet($element, $type)
+    {
+        if (!isset($this->content_sets[$type])) {
+            $this->content_sets[$type] = '';
+        } else {
+            $this->content_sets[$type] .= ' | ';
+        }
         $this->content_sets[$type] .= $element;
     }
 
     /**
      * Convenience function that transforms single-string contents
      * into separate content model and content model type
-     * @param $contents Allowed children in form of:
+     * @param string $contents Allowed children in form of:
      *                  "$content_model_type: $content_model"
+     * @return array
      * @note If contents is an object, an array of two nulls will be
      *       returned, and the callee needs to take the original $contents
      *       and use it directly.
      */
-    public function parseContents($contents) {
-        if (!is_string($contents)) return array(null, null); // defer
+    public function parseContents($contents)
+    {
+        if (!is_string($contents)) {
+            return array(null, null);
+        } // defer
         switch ($contents) {
             // check for shorthand content model forms
             case 'Empty':
@@ -202,13 +232,17 @@ class HTMLPurifier_HTMLModule
     /**
      * Convenience function that merges a list of attribute includes into
      * an attribute array.
-     * @param $attr Reference to attr array to modify
-     * @param $attr_includes Array of includes / string include to merge in
+     * @param array $attr Reference to attr array to modify
+     * @param array $attr_includes Array of includes / string include to merge in
      */
-    public function mergeInAttrIncludes(&$attr, $attr_includes) {
+    public function mergeInAttrIncludes(&$attr, $attr_includes)
+    {
         if (!is_array($attr_includes)) {
-            if (empty($attr_includes)) $attr_includes = array();
-            else $attr_includes = array($attr_includes);
+            if (empty($attr_includes)) {
+                $attr_includes = array();
+            } else {
+                $attr_includes = array($attr_includes);
+            }
         }
         $attr[0] = $attr_includes;
     }
@@ -216,16 +250,21 @@ class HTMLPurifier_HTMLModule
     /**
      * Convenience function that generates a lookup table with boolean
      * true as value.
-     * @param $list List of values to turn into a lookup
+     * @param string $list List of values to turn into a lookup
      * @note You can also pass an arbitrary number of arguments in
      *       place of the regular argument
-     * @return Lookup array equivalent of list
+     * @return array array equivalent of list
      */
-    public function makeLookup($list) {
-        if (is_string($list)) $list = func_get_args();
+    public function makeLookup($list)
+    {
+        if (is_string($list)) {
+            $list = func_get_args();
+        }
         $ret = array();
         foreach ($list as $value) {
-            if (is_null($value)) continue;
+            if (is_null($value)) {
+                continue;
+            }
             $ret[$value] = true;
         }
         return $ret;
@@ -235,10 +274,11 @@ class HTMLPurifier_HTMLModule
      * Lazy load construction of the module after determining whether
      * or not it's needed, and also when a finalized configuration object
      * is available.
-     * @param $config Instance of HTMLPurifier_Config
+     * @param HTMLPurifier_Config $config
      */
-    public function setup($config) {}
-
+    public function setup($config)
+    {
+    }
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Bdo.php
+++ b/library/HTMLPurifier/HTMLModule/Bdo.php
@@ -7,14 +7,28 @@
 class HTMLPurifier_HTMLModule_Bdo extends HTMLPurifier_HTMLModule
 {
 
+    /**
+     * @type string
+     */
     public $name = 'Bdo';
+
+    /**
+     * @type array
+     */
     public $attr_collections = array(
         'I18N' => array('dir' => false)
     );
 
-    public function setup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         $bdo = $this->addElement(
-            'bdo', 'Inline', 'Inline', array('Core', 'Lang'),
+            'bdo',
+            'Inline',
+            'Inline',
+            array('Core', 'Lang'),
             array(
                 'dir' => 'Enum#ltr,rtl', // required
                 // The Abstract Module specification has the attribute
@@ -25,7 +39,6 @@ class HTMLPurifier_HTMLModule_Bdo extends HTMLPurifier_HTMLModule
 
         $this->attr_collections['I18N']['dir'] = 'Enum#ltr,rtl';
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/CommonAttributes.php
+++ b/library/HTMLPurifier/HTMLModule/CommonAttributes.php
@@ -2,8 +2,14 @@
 
 class HTMLPurifier_HTMLModule_CommonAttributes extends HTMLPurifier_HTMLModule
 {
+    /**
+     * @type string
+     */
     public $name = 'CommonAttributes';
 
+    /**
+     * @type array
+     */
     public $attr_collections = array(
         'Core' => array(
             0 => array('Style'),
@@ -20,7 +26,6 @@ class HTMLPurifier_HTMLModule_CommonAttributes extends HTMLPurifier_HTMLModule
             0 => array('Core', 'I18N')
         )
     );
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Edit.php
+++ b/library/HTMLPurifier/HTMLModule/Edit.php
@@ -7,9 +7,16 @@
 class HTMLPurifier_HTMLModule_Edit extends HTMLPurifier_HTMLModule
 {
 
+    /**
+     * @type string
+     */
     public $name = 'Edit';
 
-    public function setup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         $contents = 'Chameleon: #PCDATA | Inline ! #PCDATA | Flow';
         $attr = array(
             'cite' => 'URI',
@@ -26,13 +33,23 @@ class HTMLPurifier_HTMLModule_Edit extends HTMLPurifier_HTMLModule
     // Inline context ! Block context (exclamation mark is
     // separator, see getChildDef for parsing)
 
+    /**
+     * @type bool
+     */
     public $defines_child_def = true;
-    public function getChildDef($def) {
-        if ($def->content_model_type != 'chameleon') return false;
+
+    /**
+     * @param HTMLPurifier_ElementDef $def
+     * @return HTMLPurifier_ChildDef_Chameleon
+     */
+    public function getChildDef($def)
+    {
+        if ($def->content_model_type != 'chameleon') {
+            return false;
+        }
         $value = explode('!', $def->content_model);
         return new HTMLPurifier_ChildDef_Chameleon($value[0], $value[1]);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Forms.php
+++ b/library/HTMLPurifier/HTMLModule/Forms.php
@@ -5,87 +5,142 @@
  */
 class HTMLPurifier_HTMLModule_Forms extends HTMLPurifier_HTMLModule
 {
+    /**
+     * @type string
+     */
     public $name = 'Forms';
+
+    /**
+     * @type bool
+     */
     public $safe = false;
 
+    /**
+     * @type array
+     */
     public $content_sets = array(
         'Block' => 'Form',
         'Inline' => 'Formctrl',
     );
 
-    public function setup($config) {
-        $form = $this->addElement('form', 'Form',
-          'Required: Heading | List | Block | fieldset', 'Common', array(
-            'accept' => 'ContentTypes',
-            'accept-charset' => 'Charsets',
-            'action*' => 'URI',
-            'method' => 'Enum#get,post',
-            // really ContentType, but these two are the only ones used today
-            'enctype' => 'Enum#application/x-www-form-urlencoded,multipart/form-data',
-        ));
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
+        $form = $this->addElement(
+            'form',
+            'Form',
+            'Required: Heading | List | Block | fieldset',
+            'Common',
+            array(
+                'accept' => 'ContentTypes',
+                'accept-charset' => 'Charsets',
+                'action*' => 'URI',
+                'method' => 'Enum#get,post',
+                // really ContentType, but these two are the only ones used today
+                'enctype' => 'Enum#application/x-www-form-urlencoded,multipart/form-data',
+            )
+        );
         $form->excludes = array('form' => true);
 
-        $input = $this->addElement('input', 'Formctrl', 'Empty', 'Common', array(
-            'accept' => 'ContentTypes',
-            'accesskey' => 'Character',
-            'alt' => 'Text',
-            'checked' => 'Bool#checked',
-            'disabled' => 'Bool#disabled',
-            'maxlength' => 'Number',
-            'name' => 'CDATA',
-            'readonly' => 'Bool#readonly',
-            'size' => 'Number',
-            'src' => 'URI#embedded',
-            'tabindex' => 'Number',
-            'type' => 'Enum#text,password,checkbox,button,radio,submit,reset,file,hidden,image',
-            'value' => 'CDATA',
-        ));
+        $input = $this->addElement(
+            'input',
+            'Formctrl',
+            'Empty',
+            'Common',
+            array(
+                'accept' => 'ContentTypes',
+                'accesskey' => 'Character',
+                'alt' => 'Text',
+                'checked' => 'Bool#checked',
+                'disabled' => 'Bool#disabled',
+                'maxlength' => 'Number',
+                'name' => 'CDATA',
+                'readonly' => 'Bool#readonly',
+                'size' => 'Number',
+                'src' => 'URI#embedded',
+                'tabindex' => 'Number',
+                'type' => 'Enum#text,password,checkbox,button,radio,submit,reset,file,hidden,image',
+                'value' => 'CDATA',
+            )
+        );
         $input->attr_transform_post[] = new HTMLPurifier_AttrTransform_Input();
 
-        $this->addElement('select', 'Formctrl', 'Required: optgroup | option', 'Common', array(
-            'disabled' => 'Bool#disabled',
-            'multiple' => 'Bool#multiple',
-            'name' => 'CDATA',
-            'size' => 'Number',
-            'tabindex' => 'Number',
-        ));
+        $this->addElement(
+            'select',
+            'Formctrl',
+            'Required: optgroup | option',
+            'Common',
+            array(
+                'disabled' => 'Bool#disabled',
+                'multiple' => 'Bool#multiple',
+                'name' => 'CDATA',
+                'size' => 'Number',
+                'tabindex' => 'Number',
+            )
+        );
 
-        $this->addElement('option', false, 'Optional: #PCDATA', 'Common', array(
-            'disabled' => 'Bool#disabled',
-            'label' => 'Text',
-            'selected' => 'Bool#selected',
-            'value' => 'CDATA',
-        ));
+        $this->addElement(
+            'option',
+            false,
+            'Optional: #PCDATA',
+            'Common',
+            array(
+                'disabled' => 'Bool#disabled',
+                'label' => 'Text',
+                'selected' => 'Bool#selected',
+                'value' => 'CDATA',
+            )
+        );
         // It's illegal for there to be more than one selected, but not
         // be multiple. Also, no selected means undefined behavior. This might
         // be difficult to implement; perhaps an injector, or a context variable.
 
-        $textarea = $this->addElement('textarea', 'Formctrl', 'Optional: #PCDATA', 'Common', array(
-            'accesskey' => 'Character',
-            'cols*' => 'Number',
-            'disabled' => 'Bool#disabled',
-            'name' => 'CDATA',
-            'readonly' => 'Bool#readonly',
-            'rows*' => 'Number',
-            'tabindex' => 'Number',
-        ));
+        $textarea = $this->addElement(
+            'textarea',
+            'Formctrl',
+            'Optional: #PCDATA',
+            'Common',
+            array(
+                'accesskey' => 'Character',
+                'cols*' => 'Number',
+                'disabled' => 'Bool#disabled',
+                'name' => 'CDATA',
+                'readonly' => 'Bool#readonly',
+                'rows*' => 'Number',
+                'tabindex' => 'Number',
+            )
+        );
         $textarea->attr_transform_pre[] = new HTMLPurifier_AttrTransform_Textarea();
 
-        $button = $this->addElement('button', 'Formctrl', 'Optional: #PCDATA | Heading | List | Block | Inline', 'Common', array(
-            'accesskey' => 'Character',
-            'disabled' => 'Bool#disabled',
-            'name' => 'CDATA',
-            'tabindex' => 'Number',
-            'type' => 'Enum#button,submit,reset',
-            'value' => 'CDATA',
-        ));
+        $button = $this->addElement(
+            'button',
+            'Formctrl',
+            'Optional: #PCDATA | Heading | List | Block | Inline',
+            'Common',
+            array(
+                'accesskey' => 'Character',
+                'disabled' => 'Bool#disabled',
+                'name' => 'CDATA',
+                'tabindex' => 'Number',
+                'type' => 'Enum#button,submit,reset',
+                'value' => 'CDATA',
+            )
+        );
 
         // For exclusions, ideally we'd specify content sets, not literal elements
         $button->excludes = $this->makeLookup(
-            'form', 'fieldset', // Form
-            'input', 'select', 'textarea', 'label', 'button', // Formctrl
+            'form',
+            'fieldset', // Form
+            'input',
+            'select',
+            'textarea',
+            'label',
+            'button', // Formctrl
             'a', // as per HTML 4.01 spec, this is omitted by modularization
-            'isindex', 'iframe' // legacy items
+            'isindex',
+            'iframe' // legacy items
         );
 
         // Extra exclusion: img usemap="" is not permitted within this element.
@@ -95,24 +150,40 @@ class HTMLPurifier_HTMLModule_Forms extends HTMLPurifier_HTMLModule
         // This is HIGHLY user-unfriendly; we need a custom child-def for this
         $this->addElement('fieldset', 'Form', 'Custom: (#WS?,legend,(Flow|#PCDATA)*)', 'Common');
 
-        $label = $this->addElement('label', 'Formctrl', 'Optional: #PCDATA | Inline', 'Common', array(
-            'accesskey' => 'Character',
-            // 'for' => 'IDREF', // IDREF not implemented, cannot allow
-        ));
+        $label = $this->addElement(
+            'label',
+            'Formctrl',
+            'Optional: #PCDATA | Inline',
+            'Common',
+            array(
+                'accesskey' => 'Character',
+                // 'for' => 'IDREF', // IDREF not implemented, cannot allow
+            )
+        );
         $label->excludes = array('label' => true);
 
-        $this->addElement('legend', false, 'Optional: #PCDATA | Inline', 'Common', array(
-            'accesskey' => 'Character',
-        ));
+        $this->addElement(
+            'legend',
+            false,
+            'Optional: #PCDATA | Inline',
+            'Common',
+            array(
+                'accesskey' => 'Character',
+            )
+        );
 
-        $this->addElement('optgroup', false, 'Required: option', 'Common', array(
-            'disabled' => 'Bool#disabled',
-            'label*' => 'Text',
-        ));
-
+        $this->addElement(
+            'optgroup',
+            false,
+            'Required: option',
+            'Common',
+            array(
+                'disabled' => 'Bool#disabled',
+                'label*' => 'Text',
+            )
+        );
         // Don't forget an injector for <isindex>. This one's a little complex
         // because it maps to multiple elements.
-
     }
 }
 

--- a/library/HTMLPurifier/HTMLModule/Hypertext.php
+++ b/library/HTMLPurifier/HTMLModule/Hypertext.php
@@ -6,11 +6,21 @@
 class HTMLPurifier_HTMLModule_Hypertext extends HTMLPurifier_HTMLModule
 {
 
+    /**
+     * @type string
+     */
     public $name = 'Hypertext';
 
-    public function setup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         $a = $this->addElement(
-            'a', 'Inline', 'Inline', 'Common',
+            'a',
+            'Inline',
+            'Inline',
+            'Common',
             array(
                 // 'accesskey' => 'Character',
                 // 'charset' => 'Charset',
@@ -25,7 +35,6 @@ class HTMLPurifier_HTMLModule_Hypertext extends HTMLPurifier_HTMLModule
         $a->formatting = true;
         $a->excludes = array('a' => true);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Iframe.php
+++ b/library/HTMLPurifier/HTMLModule/Iframe.php
@@ -10,15 +10,29 @@
 class HTMLPurifier_HTMLModule_Iframe extends HTMLPurifier_HTMLModule
 {
 
+    /**
+     * @type string
+     */
     public $name = 'Iframe';
+
+    /**
+     * @type bool
+     */
     public $safe = false;
 
-    public function setup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         if ($config->get('HTML.SafeIframe')) {
             $this->safe = true;
         }
         $this->addElement(
-            'iframe', 'Inline', 'Flow', 'Common',
+            'iframe',
+            'Inline',
+            'Flow',
+            'Common',
             array(
                 'src' => 'URI#embedded',
                 'width' => 'Length',
@@ -32,7 +46,6 @@ class HTMLPurifier_HTMLModule_Iframe extends HTMLPurifier_HTMLModule
             )
         );
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Image.php
+++ b/library/HTMLPurifier/HTMLModule/Image.php
@@ -8,18 +8,28 @@
 class HTMLPurifier_HTMLModule_Image extends HTMLPurifier_HTMLModule
 {
 
+    /**
+     * @type string
+     */
     public $name = 'Image';
 
-    public function setup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         $max = $config->get('HTML.MaxImgLength');
         $img = $this->addElement(
-            'img', 'Inline', 'Empty', 'Common',
+            'img',
+            'Inline',
+            'Empty',
+            'Common',
             array(
                 'alt*' => 'Text',
                 // According to the spec, it's Length, but percents can
                 // be abused, so we allow only Pixels.
                 'height' => 'Pixels#' . $max,
-                'width'  => 'Pixels#' . $max,
+                'width' => 'Pixels#' . $max,
                 'longdesc' => 'URI',
                 'src*' => new HTMLPurifier_AttrDef_URI(true), // embedded
             )
@@ -34,7 +44,6 @@ class HTMLPurifier_HTMLModule_Image extends HTMLPurifier_HTMLModule
         $img->attr_transform_post[] =
             new HTMLPurifier_AttrTransform_ImgRequired();
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Legacy.php
+++ b/library/HTMLPurifier/HTMLModule/Legacy.php
@@ -18,29 +18,58 @@
 
 class HTMLPurifier_HTMLModule_Legacy extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'Legacy';
 
-    public function setup($config) {
-
-        $this->addElement('basefont', 'Inline', 'Empty', false, array(
-            'color' => 'Color',
-            'face' => 'Text', // extremely broad, we should
-            'size' => 'Text', // tighten it
-            'id' => 'ID'
-        ));
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
+        $this->addElement(
+            'basefont',
+            'Inline',
+            'Empty',
+            null,
+            array(
+                'color' => 'Color',
+                'face' => 'Text', // extremely broad, we should
+                'size' => 'Text', // tighten it
+                'id' => 'ID'
+            )
+        );
         $this->addElement('center', 'Block', 'Flow', 'Common');
-        $this->addElement('dir', 'Block', 'Required: li', 'Common', array(
-            'compact' => 'Bool#compact'
-        ));
-        $this->addElement('font', 'Inline', 'Inline', array('Core', 'I18N'), array(
-            'color' => 'Color',
-            'face' => 'Text', // extremely broad, we should
-            'size' => 'Text', // tighten it
-        ));
-        $this->addElement('menu', 'Block', 'Required: li', 'Common', array(
-            'compact' => 'Bool#compact'
-        ));
+        $this->addElement(
+            'dir',
+            'Block',
+            'Required: li',
+            'Common',
+            array(
+                'compact' => 'Bool#compact'
+            )
+        );
+        $this->addElement(
+            'font',
+            'Inline',
+            'Inline',
+            array('Core', 'I18N'),
+            array(
+                'color' => 'Color',
+                'face' => 'Text', // extremely broad, we should
+                'size' => 'Text', // tighten it
+            )
+        );
+        $this->addElement(
+            'menu',
+            'Block',
+            'Required: li',
+            'Common',
+            array(
+                'compact' => 'Bool#compact'
+            )
+        );
 
         $s = $this->addElement('s', 'Inline', 'Inline', 'Common');
         $s->formatting = true;
@@ -98,7 +127,7 @@ class HTMLPurifier_HTMLModule_Legacy extends HTMLPurifier_HTMLModule
 
         $li = $this->addBlankElement('li');
         $li->attr['value'] = new HTMLPurifier_AttrDef_Integer();
-        $li->attr['type']  = 'Enum#s:1,i,I,a,A,disc,square,circle';
+        $li->attr['type'] = 'Enum#s:1,i,I,a,A,disc,square,circle';
 
         $ol = $this->addBlankElement('ol');
         $ol->attr['compact'] = 'Bool#compact';
@@ -151,9 +180,7 @@ class HTMLPurifier_HTMLModule_Legacy extends HTMLPurifier_HTMLModule
 
         $legend = $this->addBlankElement('legend');
         $legend->attr['align'] = 'LAlign';
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/List.php
+++ b/library/HTMLPurifier/HTMLModule/List.php
@@ -5,7 +5,9 @@
  */
 class HTMLPurifier_HTMLModule_List extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'List';
 
     // According to the abstract schema, the List content set is a fully formed
@@ -17,9 +19,16 @@ class HTMLPurifier_HTMLModule_List extends HTMLPurifier_HTMLModule
     // we don't have support for such nested expressions without using
     // the incredibly inefficient and draconic Custom ChildDef.
 
+    /**
+     * @type array
+     */
     public $content_sets = array('Flow' => 'List');
 
-    public function setup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         $ol = $this->addElement('ol', 'List', new HTMLPurifier_ChildDef_List(), 'Common');
         $ul = $this->addElement('ul', 'List', new HTMLPurifier_ChildDef_List(), 'Common');
         // XXX The wrap attribute is handled by MakeWellFormed.  This is all
@@ -37,7 +46,6 @@ class HTMLPurifier_HTMLModule_List extends HTMLPurifier_HTMLModule
         $this->addElement('dd', false, 'Flow', 'Common');
         $this->addElement('dt', false, 'Inline', 'Common');
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Name.php
+++ b/library/HTMLPurifier/HTMLModule/Name.php
@@ -2,10 +2,16 @@
 
 class HTMLPurifier_HTMLModule_Name extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'Name';
 
-    public function setup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         $elements = array('a', 'applet', 'form', 'frame', 'iframe', 'img', 'map');
         foreach ($elements as $name) {
             $element = $this->addBlankElement($name);
@@ -15,7 +21,6 @@ class HTMLPurifier_HTMLModule_Name extends HTMLPurifier_HTMLModule
             }
         }
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Nofollow.php
+++ b/library/HTMLPurifier/HTMLModule/Nofollow.php
@@ -7,13 +7,19 @@
 class HTMLPurifier_HTMLModule_Nofollow extends HTMLPurifier_HTMLModule
 {
 
+    /**
+     * @type string
+     */
     public $name = 'Nofollow';
 
-    public function setup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         $a = $this->addBlankElement('a');
         $a->attr_transform_post[] = new HTMLPurifier_AttrTransform_Nofollow();
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/NonXMLCommonAttributes.php
+++ b/library/HTMLPurifier/HTMLModule/NonXMLCommonAttributes.php
@@ -2,8 +2,14 @@
 
 class HTMLPurifier_HTMLModule_NonXMLCommonAttributes extends HTMLPurifier_HTMLModule
 {
+    /**
+     * @type string
+     */
     public $name = 'NonXMLCommonAttributes';
 
+    /**
+     * @type array
+     */
     public $attr_collections = array(
         'Lang' => array(
             'lang' => 'LanguageCode',

--- a/library/HTMLPurifier/HTMLModule/Object.php
+++ b/library/HTMLPurifier/HTMLModule/Object.php
@@ -7,13 +7,26 @@
  */
 class HTMLPurifier_HTMLModule_Object extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'Object';
+
+    /**
+     * @type bool
+     */
     public $safe = false;
 
-    public function setup($config) {
-
-        $this->addElement('object', 'Inline', 'Optional: #PCDATA | Flow | param', 'Common',
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
+        $this->addElement(
+            'object',
+            'Inline',
+            'Optional: #PCDATA | Flow | param',
+            'Common',
             array(
                 'archive' => 'URI',
                 'classid' => 'URI',
@@ -30,18 +43,20 @@ class HTMLPurifier_HTMLModule_Object extends HTMLPurifier_HTMLModule
             )
         );
 
-        $this->addElement('param', false, 'Empty', false,
+        $this->addElement(
+            'param',
+            false,
+            'Empty',
+            null,
             array(
                 'id' => 'ID',
                 'name*' => 'Text',
                 'type' => 'Text',
                 'value' => 'Text',
                 'valuetype' => 'Enum#data,ref,object'
-           )
+            )
         );
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Presentation.php
+++ b/library/HTMLPurifier/HTMLModule/Presentation.php
@@ -13,24 +13,30 @@
 class HTMLPurifier_HTMLModule_Presentation extends HTMLPurifier_HTMLModule
 {
 
+    /**
+     * @type string
+     */
     public $name = 'Presentation';
 
-    public function setup($config) {
-        $this->addElement('hr',     'Block',  'Empty',  'Common');
-        $this->addElement('sub',    'Inline', 'Inline', 'Common');
-        $this->addElement('sup',    'Inline', 'Inline', 'Common');
-        $b = $this->addElement('b',      'Inline', 'Inline', 'Common');
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
+        $this->addElement('hr', 'Block', 'Empty', 'Common');
+        $this->addElement('sub', 'Inline', 'Inline', 'Common');
+        $this->addElement('sup', 'Inline', 'Inline', 'Common');
+        $b = $this->addElement('b', 'Inline', 'Inline', 'Common');
         $b->formatting = true;
-        $big = $this->addElement('big',    'Inline', 'Inline', 'Common');
+        $big = $this->addElement('big', 'Inline', 'Inline', 'Common');
         $big->formatting = true;
-        $i = $this->addElement('i',      'Inline', 'Inline', 'Common');
+        $i = $this->addElement('i', 'Inline', 'Inline', 'Common');
         $i->formatting = true;
-        $small = $this->addElement('small',  'Inline', 'Inline', 'Common');
+        $small = $this->addElement('small', 'Inline', 'Inline', 'Common');
         $small->formatting = true;
-        $tt = $this->addElement('tt',     'Inline', 'Inline', 'Common');
+        $tt = $this->addElement('tt', 'Inline', 'Inline', 'Common');
         $tt->formatting = true;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Proprietary.php
+++ b/library/HTMLPurifier/HTMLModule/Proprietary.php
@@ -6,12 +6,21 @@
  */
 class HTMLPurifier_HTMLModule_Proprietary extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'Proprietary';
 
-    public function setup($config) {
-
-        $this->addElement('marquee', 'Inline', 'Flow', 'Common',
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
+        $this->addElement(
+            'marquee',
+            'Inline',
+            'Flow',
+            'Common',
             array(
                 'direction' => 'Enum#left,right,up,down',
                 'behavior' => 'Enum#alternate',
@@ -25,9 +34,7 @@ class HTMLPurifier_HTMLModule_Proprietary extends HTMLPurifier_HTMLModule
                 'vspace' => 'Pixels',
             )
         );
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Ruby.php
+++ b/library/HTMLPurifier/HTMLModule/Ruby.php
@@ -7,12 +7,22 @@
 class HTMLPurifier_HTMLModule_Ruby extends HTMLPurifier_HTMLModule
 {
 
+    /**
+     * @type string
+     */
     public $name = 'Ruby';
 
-    public function setup($config) {
-        $this->addElement('ruby', 'Inline',
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
+        $this->addElement(
+            'ruby',
+            'Inline',
             'Custom: ((rb, (rt | (rp, rt, rp))) | (rbc, rtc, rtc?))',
-            'Common');
+            'Common'
+        );
         $this->addElement('rbc', false, 'Required: rb', 'Common');
         $this->addElement('rtc', false, 'Required: rt', 'Common');
         $rb = $this->addElement('rb', false, 'Inline', 'Common');
@@ -21,7 +31,6 @@ class HTMLPurifier_HTMLModule_Ruby extends HTMLPurifier_HTMLModule
         $rt->excludes = array('ruby' => true);
         $this->addElement('rp', false, 'Optional: #PCDATA', 'Common');
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/SafeEmbed.php
+++ b/library/HTMLPurifier/HTMLModule/SafeEmbed.php
@@ -5,14 +5,22 @@
  */
 class HTMLPurifier_HTMLModule_SafeEmbed extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'SafeEmbed';
 
-    public function setup($config) {
-
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         $max = $config->get('HTML.MaxImgLength');
         $embed = $this->addElement(
-            'embed', 'Inline', 'Empty', 'Common',
+            'embed',
+            'Inline',
+            'Empty',
+            'Common',
             array(
                 'src*' => 'URI#embedded',
                 'type' => 'Enum#application/x-shockwave-flash',
@@ -26,9 +34,7 @@ class HTMLPurifier_HTMLModule_SafeEmbed extends HTMLPurifier_HTMLModule
             )
         );
         $embed->attr_transform_post[] = new HTMLPurifier_AttrTransform_SafeEmbed();
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/SafeObject.php
+++ b/library/HTMLPurifier/HTMLModule/SafeObject.php
@@ -8,11 +8,16 @@
  */
 class HTMLPurifier_HTMLModule_SafeObject extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'SafeObject';
 
-    public function setup($config) {
-
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         // These definitions are not intrinsically safe: the attribute transforms
         // are a vital part of ensuring safety.
 
@@ -25,17 +30,24 @@ class HTMLPurifier_HTMLModule_SafeObject extends HTMLPurifier_HTMLModule
             array(
                 // While technically not required by the spec, we're forcing
                 // it to this value.
-                'type'   => 'Enum#application/x-shockwave-flash',
-                'width'  => 'Pixels#' . $max,
+                'type' => 'Enum#application/x-shockwave-flash',
+                'width' => 'Pixels#' . $max,
                 'height' => 'Pixels#' . $max,
-                'data'   => 'URI#embedded',
-                'codebase' => new HTMLPurifier_AttrDef_Enum(array(
-                    'http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,40,0')),
+                'data' => 'URI#embedded',
+                'codebase' => new HTMLPurifier_AttrDef_Enum(
+                    array(
+                        'http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=6,0,40,0'
+                    )
+                ),
             )
         );
         $object->attr_transform_post[] = new HTMLPurifier_AttrTransform_SafeObject();
 
-        $param = $this->addElement('param', false, 'Empty', false,
+        $param = $this->addElement(
+            'param',
+            false,
+            'Empty',
+            false,
             array(
                 'id' => 'ID',
                 'name*' => 'Text',
@@ -44,9 +56,7 @@ class HTMLPurifier_HTMLModule_SafeObject extends HTMLPurifier_HTMLModule
         );
         $param->attr_transform_post[] = new HTMLPurifier_AttrTransform_SafeParam();
         $this->info_injector[] = 'SafeObject';
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/SafeScripting.php
+++ b/library/HTMLPurifier/HTMLModule/SafeScripting.php
@@ -6,11 +6,16 @@
  */
 class HTMLPurifier_HTMLModule_SafeScripting extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'SafeScripting';
 
-    public function setup($config) {
-
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         // These definitions are not intrinsically safe: the attribute transforms
         // are a vital part of ensuring safety.
 
@@ -24,14 +29,12 @@ class HTMLPurifier_HTMLModule_SafeScripting extends HTMLPurifier_HTMLModule
                 // While technically not required by the spec, we're forcing
                 // it to this value.
                 'type' => 'Enum#text/javascript',
-                'src*'  => new HTMLPurifier_AttrDef_Enum(array_keys($allowed))
+                'src*' => new HTMLPurifier_AttrDef_Enum(array_keys($allowed))
             )
         );
         $script->attr_transform_pre[] =
         $script->attr_transform_post[] = new HTMLPurifier_AttrTransform_ScriptRequired();
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Scripting.php
+++ b/library/HTMLPurifier/HTMLModule/Scripting.php
@@ -15,12 +15,31 @@ INSIDE HTML PURIFIER DOCUMENTS. USE ONLY WITH TRUSTED USER INPUT!!!
  */
 class HTMLPurifier_HTMLModule_Scripting extends HTMLPurifier_HTMLModule
 {
+    /**
+     * @type string
+     */
     public $name = 'Scripting';
+
+    /**
+     * @type array
+     */
     public $elements = array('script', 'noscript');
+
+    /**
+     * @type array
+     */
     public $content_sets = array('Block' => 'script | noscript', 'Inline' => 'script | noscript');
+
+    /**
+     * @type bool
+     */
     public $safe = false;
 
-    public function setup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         // TODO: create custom child-definition for noscript that
         // auto-wraps stray #PCDATA in a similar manner to
         // blockquote's custom definition (we would use it but
@@ -33,15 +52,15 @@ class HTMLPurifier_HTMLModule_Scripting extends HTMLPurifier_HTMLModule
         // In theory, this could be safe, but I don't see any reason to
         // allow it.
         $this->info['noscript'] = new HTMLPurifier_ElementDef();
-        $this->info['noscript']->attr = array( 0 => array('Common') );
+        $this->info['noscript']->attr = array(0 => array('Common'));
         $this->info['noscript']->content_model = 'Heading | List | Block';
         $this->info['noscript']->content_model_type = 'required';
 
         $this->info['script'] = new HTMLPurifier_ElementDef();
         $this->info['script']->attr = array(
             'defer' => new HTMLPurifier_AttrDef_Enum(array('defer')),
-            'src'   => new HTMLPurifier_AttrDef_URI(true),
-            'type'  => new HTMLPurifier_AttrDef_Enum(array('text/javascript'))
+            'src' => new HTMLPurifier_AttrDef_URI(true),
+            'type' => new HTMLPurifier_AttrDef_Enum(array('text/javascript'))
         );
         $this->info['script']->content_model = '#PCDATA';
         $this->info['script']->content_model_type = 'optional';

--- a/library/HTMLPurifier/HTMLModule/StyleAttribute.php
+++ b/library/HTMLPurifier/HTMLModule/StyleAttribute.php
@@ -6,8 +6,14 @@
  */
 class HTMLPurifier_HTMLModule_StyleAttribute extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'StyleAttribute';
+
+    /**
+     * @type array
+     */
     public $attr_collections = array(
         // The inclusion routine differs from the Abstract Modules but
         // is in line with the DTD and XML Schemas.
@@ -15,10 +21,13 @@ class HTMLPurifier_HTMLModule_StyleAttribute extends HTMLPurifier_HTMLModule
         'Core' => array(0 => array('Style'))
     );
 
-    public function setup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         $this->attr_collections['Style']['style'] = new HTMLPurifier_AttrDef_CSS();
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Tables.php
+++ b/library/HTMLPurifier/HTMLModule/Tables.php
@@ -5,15 +5,23 @@
  */
 class HTMLPurifier_HTMLModule_Tables extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'Tables';
 
-    public function setup($config) {
-
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         $this->addElement('caption', false, 'Inline', 'Common');
 
-        $this->addElement('table', 'Block',
-            new HTMLPurifier_ChildDef_Table(),  'Common',
+        $this->addElement(
+            'table',
+            'Block',
+            new HTMLPurifier_ChildDef_Table(),
+            'Common',
             array(
                 'border' => 'Pixels',
                 'cellpadding' => 'Length',
@@ -34,12 +42,12 @@ class HTMLPurifier_HTMLModule_Tables extends HTMLPurifier_HTMLModule
 
         $cell_t = array_merge(
             array(
-                'abbr'    => 'Text',
+                'abbr' => 'Text',
                 'colspan' => 'Number',
                 'rowspan' => 'Number',
                 // Apparently, as of HTML5 this attribute only applies
                 // to 'th' elements.
-                'scope'   => 'Enum#row,col,rowgroup,colgroup',
+                'scope' => 'Enum#row,col,rowgroup,colgroup',
             ),
             $cell_align
         );
@@ -50,20 +58,18 @@ class HTMLPurifier_HTMLModule_Tables extends HTMLPurifier_HTMLModule
 
         $cell_col = array_merge(
             array(
-                'span'  => 'Number',
+                'span' => 'Number',
                 'width' => 'MultiLength',
             ),
             $cell_align
         );
-        $this->addElement('col',      false, 'Empty',         'Common', $cell_col);
+        $this->addElement('col', false, 'Empty', 'Common', $cell_col);
         $this->addElement('colgroup', false, 'Optional: col', 'Common', $cell_col);
 
         $this->addElement('tbody', false, 'Required: tr', 'Common', $cell_align);
         $this->addElement('thead', false, 'Required: tr', 'Common', $cell_align);
         $this->addElement('tfoot', false, 'Required: tr', 'Common', $cell_align);
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Target.php
+++ b/library/HTMLPurifier/HTMLModule/Target.php
@@ -5,10 +5,16 @@
  */
 class HTMLPurifier_HTMLModule_Target extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'Target';
 
-    public function setup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         $elements = array('a');
         foreach ($elements as $name) {
             $e = $this->addBlankElement($name);
@@ -17,7 +23,6 @@ class HTMLPurifier_HTMLModule_Target extends HTMLPurifier_HTMLModule
             );
         }
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/TargetBlank.php
+++ b/library/HTMLPurifier/HTMLModule/TargetBlank.php
@@ -6,14 +6,19 @@
  */
 class HTMLPurifier_HTMLModule_TargetBlank extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'TargetBlank';
 
-    public function setup($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         $a = $this->addBlankElement('a');
         $a->attr_transform_post[] = new HTMLPurifier_AttrTransform_TargetBlank();
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Text.php
+++ b/library/HTMLPurifier/HTMLModule/Text.php
@@ -14,43 +14,59 @@
  */
 class HTMLPurifier_HTMLModule_Text extends HTMLPurifier_HTMLModule
 {
-
+    /**
+     * @type string
+     */
     public $name = 'Text';
+
+    /**
+     * @type array
+     */
     public $content_sets = array(
         'Flow' => 'Heading | Block | Inline'
     );
 
-    public function setup($config) {
-
+    /**
+     * @param HTMLPurifier_Config $config
+     */
+    public function setup($config)
+    {
         // Inline Phrasal -------------------------------------------------
-        $this->addElement('abbr',    'Inline', 'Inline', 'Common');
+        $this->addElement('abbr', 'Inline', 'Inline', 'Common');
         $this->addElement('acronym', 'Inline', 'Inline', 'Common');
-        $this->addElement('cite',    'Inline', 'Inline', 'Common');
-        $this->addElement('dfn',     'Inline', 'Inline', 'Common');
-        $this->addElement('kbd',     'Inline', 'Inline', 'Common');
-        $this->addElement('q',       'Inline', 'Inline', 'Common', array('cite' => 'URI'));
-        $this->addElement('samp',    'Inline', 'Inline', 'Common');
-        $this->addElement('var',     'Inline', 'Inline', 'Common');
+        $this->addElement('cite', 'Inline', 'Inline', 'Common');
+        $this->addElement('dfn', 'Inline', 'Inline', 'Common');
+        $this->addElement('kbd', 'Inline', 'Inline', 'Common');
+        $this->addElement('q', 'Inline', 'Inline', 'Common', array('cite' => 'URI'));
+        $this->addElement('samp', 'Inline', 'Inline', 'Common');
+        $this->addElement('var', 'Inline', 'Inline', 'Common');
 
-        $em = $this->addElement('em',      'Inline', 'Inline', 'Common');
+        $em = $this->addElement('em', 'Inline', 'Inline', 'Common');
         $em->formatting = true;
 
-        $strong = $this->addElement('strong',  'Inline', 'Inline', 'Common');
+        $strong = $this->addElement('strong', 'Inline', 'Inline', 'Common');
         $strong->formatting = true;
 
-        $code = $this->addElement('code',    'Inline', 'Inline', 'Common');
+        $code = $this->addElement('code', 'Inline', 'Inline', 'Common');
         $code->formatting = true;
 
         // Inline Structural ----------------------------------------------
         $this->addElement('span', 'Inline', 'Inline', 'Common');
-        $this->addElement('br',   'Inline', 'Empty',  'Core');
+        $this->addElement('br', 'Inline', 'Empty', 'Core');
 
         // Block Phrasal --------------------------------------------------
-        $this->addElement('address',     'Block', 'Inline', 'Common');
-        $this->addElement('blockquote',  'Block', 'Optional: Heading | Block | List', 'Common', array('cite' => 'URI') );
+        $this->addElement('address', 'Block', 'Inline', 'Common');
+        $this->addElement('blockquote', 'Block', 'Optional: Heading | Block | List', 'Common', array('cite' => 'URI'));
         $pre = $this->addElement('pre', 'Block', 'Inline', 'Common');
         $pre->excludes = $this->makeLookup(
-            'img', 'big', 'small', 'object', 'applet', 'font', 'basefont' );
+            'img',
+            'big',
+            'small',
+            'object',
+            'applet',
+            'font',
+            'basefont'
+        );
         $this->addElement('h1', 'Heading', 'Inline', 'Common');
         $this->addElement('h2', 'Heading', 'Inline', 'Common');
         $this->addElement('h3', 'Heading', 'Inline', 'Common');
@@ -60,12 +76,12 @@ class HTMLPurifier_HTMLModule_Text extends HTMLPurifier_HTMLModule
 
         // Block Structural -----------------------------------------------
         $p = $this->addElement('p', 'Block', 'Inline', 'Common');
-        $p->autoclose = array_flip(array("address", "blockquote", "center", "dir", "div", "dl", "fieldset", "ol", "p", "ul"));
+        $p->autoclose = array_flip(
+            array("address", "blockquote", "center", "dir", "div", "dl", "fieldset", "ol", "p", "ul")
+        );
 
         $this->addElement('div', 'Block', 'Flow', 'Common');
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Tidy.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy.php
@@ -7,36 +7,41 @@
  */
 class HTMLPurifier_HTMLModule_Tidy extends HTMLPurifier_HTMLModule
 {
-
     /**
-     * List of supported levels. Index zero is a special case "no fixes"
-     * level.
+     * List of supported levels.
+     * Index zero is a special case "no fixes" level.
+     * @type array
      */
     public $levels = array(0 => 'none', 'light', 'medium', 'heavy');
 
     /**
-     * Default level to place all fixes in. Disabled by default
+     * Default level to place all fixes in.
+     * Disabled by default.
+     * @type string
      */
     public $defaultLevel = null;
 
     /**
-     * Lists of fixes used by getFixesForLevel(). Format is:
+     * Lists of fixes used by getFixesForLevel().
+     * Format is:
      *      HTMLModule_Tidy->fixesForLevel[$level] = array('fix-1', 'fix-2');
+     * @type array
      */
     public $fixesForLevel = array(
-        'light'  => array(),
+        'light' => array(),
         'medium' => array(),
-        'heavy'  => array()
+        'heavy' => array()
     );
 
     /**
      * Lazy load constructs the module by determining the necessary
      * fixes to create and then delegating to the populate() function.
+     * @param HTMLPurifier_Config $config
      * @todo Wildcard matching and error reporting when an added or
      *       subtracted fix has no effect.
      */
-    public function setup($config) {
-
+    public function setup($config)
+    {
         // create fixes, initialize fixesForLevel
         $fixes = $this->makeFixes();
         $this->makeFixesForLevel($fixes);
@@ -46,38 +51,38 @@ class HTMLPurifier_HTMLModule_Tidy extends HTMLPurifier_HTMLModule
         $fixes_lookup = $this->getFixesForLevel($level);
 
         // get custom fix declarations: these need namespace processing
-        $add_fixes    = $config->get('HTML.TidyAdd');
+        $add_fixes = $config->get('HTML.TidyAdd');
         $remove_fixes = $config->get('HTML.TidyRemove');
 
         foreach ($fixes as $name => $fix) {
             // needs to be refactored a little to implement globbing
-            if (
-                isset($remove_fixes[$name]) ||
-                (!isset($add_fixes[$name]) && !isset($fixes_lookup[$name]))
-            ) {
+            if (isset($remove_fixes[$name]) ||
+                (!isset($add_fixes[$name]) && !isset($fixes_lookup[$name]))) {
                 unset($fixes[$name]);
             }
         }
 
         // populate this module with necessary fixes
         $this->populate($fixes);
-
     }
 
     /**
      * Retrieves all fixes per a level, returning fixes for that specific
      * level as well as all levels below it.
-     * @param $level String level identifier, see $levels for valid values
-     * @return Lookup up table of fixes
+     * @param string $level level identifier, see $levels for valid values
+     * @return array Lookup up table of fixes
      */
-    public function getFixesForLevel($level) {
+    public function getFixesForLevel($level)
+    {
         if ($level == $this->levels[0]) {
             return array();
         }
         $activated_levels = array();
         for ($i = 1, $c = count($this->levels); $i < $c; $i++) {
             $activated_levels[] = $this->levels[$i];
-            if ($this->levels[$i] == $level) break;
+            if ($this->levels[$i] == $level) {
+                break;
+            }
         }
         if ($i == $c) {
             trigger_error(
@@ -99,9 +104,13 @@ class HTMLPurifier_HTMLModule_Tidy extends HTMLPurifier_HTMLModule
      * Dynamically populates the $fixesForLevel member variable using
      * the fixes array. It may be custom overloaded, used in conjunction
      * with $defaultLevel, or not used at all.
+     * @param array $fixes
      */
-    public function makeFixesForLevel($fixes) {
-        if (!isset($this->defaultLevel)) return;
+    public function makeFixesForLevel($fixes)
+    {
+        if (!isset($this->defaultLevel)) {
+            return;
+        }
         if (!isset($this->fixesForLevel[$this->defaultLevel])) {
             trigger_error(
                 'Default level ' . $this->defaultLevel . ' does not exist',
@@ -115,9 +124,10 @@ class HTMLPurifier_HTMLModule_Tidy extends HTMLPurifier_HTMLModule
     /**
      * Populates the module with transforms and other special-case code
      * based on a list of fixes passed to it
-     * @param $lookup Lookup table of fixes to activate
+     * @param array $fixes Lookup table of fixes to activate
      */
-    public function populate($fixes) {
+    public function populate($fixes)
+    {
         foreach ($fixes as $name => $fix) {
             // determine what the fix is for
             list($type, $params) = $this->getFixType($name);
@@ -169,20 +179,31 @@ class HTMLPurifier_HTMLModule_Tidy extends HTMLPurifier_HTMLModule
      * @note $fix_parameters is type dependant, see populate() for usage
      *       of these parameters
      */
-    public function getFixType($name) {
+    public function getFixType($name)
+    {
         // parse it
         $property = $attr = null;
-        if (strpos($name, '#') !== false) list($name, $property) = explode('#', $name);
-        if (strpos($name, '@') !== false) list($name, $attr)     = explode('@', $name);
+        if (strpos($name, '#') !== false) {
+            list($name, $property) = explode('#', $name);
+        }
+        if (strpos($name, '@') !== false) {
+            list($name, $attr) = explode('@', $name);
+        }
 
         // figure out the parameters
         $params = array();
-        if ($name !== '')    $params['element'] = $name;
-        if (!is_null($attr)) $params['attr'] = $attr;
+        if ($name !== '') {
+            $params['element'] = $name;
+        }
+        if (!is_null($attr)) {
+            $params['attr'] = $attr;
+        }
 
         // special case: attribute transform
         if (!is_null($attr)) {
-            if (is_null($property)) $property = 'pre';
+            if (is_null($property)) {
+                $property = 'pre';
+            }
             $type = 'attr_transform_' . $property;
             return array($type, $params);
         }
@@ -199,9 +220,11 @@ class HTMLPurifier_HTMLModule_Tidy extends HTMLPurifier_HTMLModule
     /**
      * Defines all fixes the module will perform in a compact
      * associative array of fix name to fix implementation.
+     * @return array
      */
-    public function makeFixes() {}
-
+    public function makeFixes()
+    {
+    }
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Tidy/Name.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy/Name.php
@@ -5,18 +5,27 @@
  */
 class HTMLPurifier_HTMLModule_Tidy_Name extends HTMLPurifier_HTMLModule_Tidy
 {
+    /**
+     * @type string
+     */
     public $name = 'Tidy_Name';
+
+    /**
+     * @type string
+     */
     public $defaultLevel = 'heavy';
-    public function makeFixes() {
 
+    /**
+     * @return array
+     */
+    public function makeFixes()
+    {
         $r = array();
-
         // @name for img, a -----------------------------------------------
         // Technically, it's allowed even on strict, so we allow authors to use
         // it. However, it's deprecated in future versions of XHTML.
         $r['img@name'] =
         $r['a@name'] = new HTMLPurifier_AttrTransform_Name();
-
         return $r;
     }
 }

--- a/library/HTMLPurifier/HTMLModule/Tidy/Proprietary.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy/Proprietary.php
@@ -3,10 +3,21 @@
 class HTMLPurifier_HTMLModule_Tidy_Proprietary extends HTMLPurifier_HTMLModule_Tidy
 {
 
+    /**
+     * @type string
+     */
     public $name = 'Tidy_Proprietary';
+
+    /**
+     * @type string
+     */
     public $defaultLevel = 'light';
 
-    public function makeFixes() {
+    /**
+     * @return array
+     */
+    public function makeFixes()
+    {
         $r = array();
         $r['table@background'] = new HTMLPurifier_AttrTransform_Background();
         $r['td@background']    = new HTMLPurifier_AttrTransform_Background();
@@ -18,7 +29,6 @@ class HTMLPurifier_HTMLModule_Tidy_Proprietary extends HTMLPurifier_HTMLModule_T
         $r['table@height']     = new HTMLPurifier_AttrTransform_Length('height');
         return $r;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Tidy/Strict.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy/Strict.php
@@ -2,18 +2,40 @@
 
 class HTMLPurifier_HTMLModule_Tidy_Strict extends HTMLPurifier_HTMLModule_Tidy_XHTMLAndHTML4
 {
+    /**
+     * @type string
+     */
     public $name = 'Tidy_Strict';
+
+    /**
+     * @type string
+     */
     public $defaultLevel = 'light';
 
-    public function makeFixes() {
+    /**
+     * @return array
+     */
+    public function makeFixes()
+    {
         $r = parent::makeFixes();
         $r['blockquote#content_model_type'] = 'strictblockquote';
         return $r;
     }
 
+    /**
+     * @type bool
+     */
     public $defines_child_def = true;
-    public function getChildDef($def) {
-        if ($def->content_model_type != 'strictblockquote') return parent::getChildDef($def);
+
+    /**
+     * @param HTMLPurifier_ElementDef $def
+     * @return HTMLPurifier_ChildDef_StrictBlockquote
+     */
+    public function getChildDef($def)
+    {
+        if ($def->content_model_type != 'strictblockquote') {
+            return parent::getChildDef($def);
+        }
         return new HTMLPurifier_ChildDef_StrictBlockquote($def->content_model);
     }
 }

--- a/library/HTMLPurifier/HTMLModule/Tidy/Transitional.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy/Transitional.php
@@ -2,7 +2,14 @@
 
 class HTMLPurifier_HTMLModule_Tidy_Transitional extends HTMLPurifier_HTMLModule_Tidy_XHTMLAndHTML4
 {
+    /**
+     * @type string
+     */
     public $name = 'Tidy_Transitional';
+
+    /**
+     * @type string
+     */
     public $defaultLevel = 'heavy';
 }
 

--- a/library/HTMLPurifier/HTMLModule/Tidy/XHTML.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy/XHTML.php
@@ -2,16 +2,25 @@
 
 class HTMLPurifier_HTMLModule_Tidy_XHTML extends HTMLPurifier_HTMLModule_Tidy
 {
-
+    /**
+     * @type string
+     */
     public $name = 'Tidy_XHTML';
+
+    /**
+     * @type string
+     */
     public $defaultLevel = 'medium';
 
-    public function makeFixes() {
+    /**
+     * @return array
+     */
+    public function makeFixes()
+    {
         $r = array();
         $r['@lang'] = new HTMLPurifier_AttrTransform_Lang();
         return $r;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/Tidy/XHTMLAndHTML4.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy/XHTMLAndHTML4.php
@@ -3,69 +3,86 @@
 class HTMLPurifier_HTMLModule_Tidy_XHTMLAndHTML4 extends HTMLPurifier_HTMLModule_Tidy
 {
 
-    public function makeFixes() {
-
+    /**
+     * @return array
+     */
+    public function makeFixes()
+    {
         $r = array();
 
         // == deprecated tag transforms ===================================
 
-        $r['font']   = new HTMLPurifier_TagTransform_Font();
-        $r['menu']   = new HTMLPurifier_TagTransform_Simple('ul');
-        $r['dir']    = new HTMLPurifier_TagTransform_Simple('ul');
-        $r['center'] = new HTMLPurifier_TagTransform_Simple('div',  'text-align:center;');
-        $r['u']      = new HTMLPurifier_TagTransform_Simple('span', 'text-decoration:underline;');
-        $r['s']      = new HTMLPurifier_TagTransform_Simple('span', 'text-decoration:line-through;');
+        $r['font'] = new HTMLPurifier_TagTransform_Font();
+        $r['menu'] = new HTMLPurifier_TagTransform_Simple('ul');
+        $r['dir'] = new HTMLPurifier_TagTransform_Simple('ul');
+        $r['center'] = new HTMLPurifier_TagTransform_Simple('div', 'text-align:center;');
+        $r['u'] = new HTMLPurifier_TagTransform_Simple('span', 'text-decoration:underline;');
+        $r['s'] = new HTMLPurifier_TagTransform_Simple('span', 'text-decoration:line-through;');
         $r['strike'] = new HTMLPurifier_TagTransform_Simple('span', 'text-decoration:line-through;');
 
         // == deprecated attribute transforms =============================
 
         $r['caption@align'] =
-            new HTMLPurifier_AttrTransform_EnumToCSS('align', array(
-                // we're following IE's behavior, not Firefox's, due
-                // to the fact that no one supports caption-side:right,
-                // W3C included (with CSS 2.1). This is a slightly
-                // unreasonable attribute!
-                'left'   => 'text-align:left;',
-                'right'  => 'text-align:right;',
-                'top'    => 'caption-side:top;',
-                'bottom' => 'caption-side:bottom;' // not supported by IE
-            ));
+            new HTMLPurifier_AttrTransform_EnumToCSS(
+                'align',
+                array(
+                    // we're following IE's behavior, not Firefox's, due
+                    // to the fact that no one supports caption-side:right,
+                    // W3C included (with CSS 2.1). This is a slightly
+                    // unreasonable attribute!
+                    'left' => 'text-align:left;',
+                    'right' => 'text-align:right;',
+                    'top' => 'caption-side:top;',
+                    'bottom' => 'caption-side:bottom;' // not supported by IE
+                )
+            );
 
         // @align for img -------------------------------------------------
         $r['img@align'] =
-            new HTMLPurifier_AttrTransform_EnumToCSS('align', array(
-                'left'   => 'float:left;',
-                'right'  => 'float:right;',
-                'top'    => 'vertical-align:top;',
-                'middle' => 'vertical-align:middle;',
-                'bottom' => 'vertical-align:baseline;',
-            ));
+            new HTMLPurifier_AttrTransform_EnumToCSS(
+                'align',
+                array(
+                    'left' => 'float:left;',
+                    'right' => 'float:right;',
+                    'top' => 'vertical-align:top;',
+                    'middle' => 'vertical-align:middle;',
+                    'bottom' => 'vertical-align:baseline;',
+                )
+            );
 
         // @align for table -----------------------------------------------
         $r['table@align'] =
-            new HTMLPurifier_AttrTransform_EnumToCSS('align', array(
-                'left'   => 'float:left;',
-                'center' => 'margin-left:auto;margin-right:auto;',
-                'right'  => 'float:right;'
-            ));
+            new HTMLPurifier_AttrTransform_EnumToCSS(
+                'align',
+                array(
+                    'left' => 'float:left;',
+                    'center' => 'margin-left:auto;margin-right:auto;',
+                    'right' => 'float:right;'
+                )
+            );
 
         // @align for hr -----------------------------------------------
         $r['hr@align'] =
-            new HTMLPurifier_AttrTransform_EnumToCSS('align', array(
-                // we use both text-align and margin because these work
-                // for different browsers (IE and Firefox, respectively)
-                // and the melange makes for a pretty cross-compatible
-                // solution
-                'left'   => 'margin-left:0;margin-right:auto;text-align:left;',
-                'center' => 'margin-left:auto;margin-right:auto;text-align:center;',
-                'right'  => 'margin-left:auto;margin-right:0;text-align:right;'
-            ));
+            new HTMLPurifier_AttrTransform_EnumToCSS(
+                'align',
+                array(
+                    // we use both text-align and margin because these work
+                    // for different browsers (IE and Firefox, respectively)
+                    // and the melange makes for a pretty cross-compatible
+                    // solution
+                    'left' => 'margin-left:0;margin-right:auto;text-align:left;',
+                    'center' => 'margin-left:auto;margin-right:auto;text-align:center;',
+                    'right' => 'margin-left:auto;margin-right:0;text-align:right;'
+                )
+            );
 
         // @align for h1, h2, h3, h4, h5, h6, p, div ----------------------
         // {{{
-            $align_lookup = array();
-            $align_values = array('left', 'right', 'center', 'justify');
-            foreach ($align_values as $v) $align_lookup[$v] = "text-align:$v;";
+        $align_lookup = array();
+        $align_values = array('left', 'right', 'center', 'justify');
+        foreach ($align_values as $v) {
+            $align_lookup[$v] = "text-align:$v;";
+        }
         // }}}
         $r['h1@align'] =
         $r['h2@align'] =
@@ -73,7 +90,7 @@ class HTMLPurifier_HTMLModule_Tidy_XHTMLAndHTML4 extends HTMLPurifier_HTMLModule
         $r['h4@align'] =
         $r['h5@align'] =
         $r['h6@align'] =
-        $r['p@align']  =
+        $r['p@align'] =
         $r['div@align'] =
             new HTMLPurifier_AttrTransform_EnumToCSS('align', $align_lookup);
 
@@ -88,12 +105,15 @@ class HTMLPurifier_HTMLModule_Tidy_XHTMLAndHTML4 extends HTMLPurifier_HTMLModule
 
         // @clear for br --------------------------------------------------
         $r['br@clear'] =
-            new HTMLPurifier_AttrTransform_EnumToCSS('clear', array(
-                'left'  => 'clear:left;',
-                'right' => 'clear:right;',
-                'all'   => 'clear:both;',
-                'none'  => 'clear:none;',
-            ));
+            new HTMLPurifier_AttrTransform_EnumToCSS(
+                'clear',
+                array(
+                    'left' => 'clear:left;',
+                    'right' => 'clear:right;',
+                    'all' => 'clear:both;',
+                    'none' => 'clear:none;',
+                )
+            );
 
         // @height for td, th ---------------------------------------------
         $r['td@height'] =
@@ -125,19 +145,19 @@ class HTMLPurifier_HTMLModule_Tidy_XHTMLAndHTML4 extends HTMLPurifier_HTMLModule
 
         // @type for li, ol, ul -------------------------------------------
         // {{{
-            $ul_types = array(
-                'disc'   => 'list-style-type:disc;',
-                'square' => 'list-style-type:square;',
-                'circle' => 'list-style-type:circle;'
-            );
-            $ol_types = array(
-                '1'   => 'list-style-type:decimal;',
-                'i'   => 'list-style-type:lower-roman;',
-                'I'   => 'list-style-type:upper-roman;',
-                'a'   => 'list-style-type:lower-alpha;',
-                'A'   => 'list-style-type:upper-alpha;'
-            );
-            $li_types = $ul_types + $ol_types;
+        $ul_types = array(
+            'disc' => 'list-style-type:disc;',
+            'square' => 'list-style-type:square;',
+            'circle' => 'list-style-type:circle;'
+        );
+        $ol_types = array(
+            '1' => 'list-style-type:decimal;',
+            'i' => 'list-style-type:lower-roman;',
+            'I' => 'list-style-type:upper-roman;',
+            'a' => 'list-style-type:lower-alpha;',
+            'A' => 'list-style-type:upper-alpha;'
+        );
+        $li_types = $ul_types + $ol_types;
         // }}}
 
         $r['ul@type'] = new HTMLPurifier_AttrTransform_EnumToCSS('type', $ul_types);
@@ -153,9 +173,7 @@ class HTMLPurifier_HTMLModule_Tidy_XHTMLAndHTML4 extends HTMLPurifier_HTMLModule
         $r['hr@width'] = new HTMLPurifier_AttrTransform_Length('width');
 
         return $r;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/HTMLModule/XMLCommonAttributes.php
+++ b/library/HTMLPurifier/HTMLModule/XMLCommonAttributes.php
@@ -2,8 +2,14 @@
 
 class HTMLPurifier_HTMLModule_XMLCommonAttributes extends HTMLPurifier_HTMLModule
 {
+    /**
+     * @type string
+     */
     public $name = 'XMLCommonAttributes';
 
+    /**
+     * @type array
+     */
     public $attr_collections = array(
         'Lang' => array(
             'xml:lang' => 'LanguageCode',

--- a/library/HTMLPurifier/IDAccumulator.php
+++ b/library/HTMLPurifier/IDAccumulator.php
@@ -17,11 +17,12 @@ class HTMLPurifier_IDAccumulator
 
     /**
      * Builds an IDAccumulator, also initializing the default blacklist
-     * @param $config Instance of HTMLPurifier_Config
-     * @param $context Instance of HTMLPurifier_Context
-     * @return Fully initialized HTMLPurifier_IDAccumulator
+     * @param HTMLPurifier_Config $config Instance of HTMLPurifier_Config
+     * @param HTMLPurifier_Context $context Instance of HTMLPurifier_Context
+     * @return HTMLPurifier_IDAccumulator Fully initialized HTMLPurifier_IDAccumulator
      */
-    public static function build($config, $context) {
+    public static function build($config, $context)
+    {
         $id_accumulator = new HTMLPurifier_IDAccumulator();
         $id_accumulator->load($config->get('Attr.IDBlacklist'));
         return $id_accumulator;
@@ -29,11 +30,14 @@ class HTMLPurifier_IDAccumulator
 
     /**
      * Add an ID to the lookup table.
-     * @param $id ID to be added.
-     * @return Bool status, true if success, false if there's a dupe
+     * @param string $id ID to be added.
+     * @return bool status, true if success, false if there's a dupe
      */
-    public function add($id) {
-        if (isset($this->ids[$id])) return false;
+    public function add($id)
+    {
+        if (isset($this->ids[$id])) {
+            return false;
+        }
         return $this->ids[$id] = true;
     }
 
@@ -42,12 +46,12 @@ class HTMLPurifier_IDAccumulator
      * @param $array_of_ids Array of IDs to load
      * @note This function doesn't care about duplicates
      */
-    public function load($array_of_ids) {
+    public function load($array_of_ids)
+    {
         foreach ($array_of_ids as $id) {
             $this->ids[$id] = true;
         }
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Injector.php
+++ b/library/HTMLPurifier/Injector.php
@@ -17,24 +17,27 @@ abstract class HTMLPurifier_Injector
 {
 
     /**
-     * Advisory name of injector, this is for friendly error messages
+     * Advisory name of injector, this is for friendly error messages.
+     * @type string
      */
     public $name;
 
     /**
-     * Instance of HTMLPurifier_HTMLDefinition
+     * @type HTMLPurifier_HTMLDefinition
      */
     protected $htmlDefinition;
 
     /**
      * Reference to CurrentNesting variable in Context. This is an array
      * list of tokens that we are currently "inside"
+     * @type array
      */
     protected $currentNesting;
 
     /**
      * Reference to InputTokens variable in Context. This is an array
      * list of the input tokens that are being processed.
+     * @type array
      */
     protected $inputTokens;
 
@@ -42,6 +45,7 @@ abstract class HTMLPurifier_Injector
      * Reference to InputIndex variable in Context. This is an integer
      * array index for $this->inputTokens that indicates what token
      * is currently being processed.
+     * @type int
      */
     protected $inputIndex;
 
@@ -49,11 +53,13 @@ abstract class HTMLPurifier_Injector
      * Array of elements and attributes this injector creates and therefore
      * need to be allowed by the definition. Takes form of
      * array('element' => array('attr', 'attr2'), 'element2')
+     * @type array
      */
     public $needed = array();
 
     /**
      * Index of inputTokens to rewind to.
+     * @type bool|int
      */
     protected $rewind = false;
 
@@ -62,17 +68,21 @@ abstract class HTMLPurifier_Injector
      * deleted a node, and now need to see if this change affected any
      * earlier nodes. Rewinding does not affect other injectors, and can
      * result in infinite loops if not used carefully.
+     * @param bool|int $index
      * @warning HTML Purifier will prevent you from fast-forwarding with this
      *          function.
      */
-    public function rewind($index) {
+    public function rewind($index)
+    {
         $this->rewind = $index;
     }
 
     /**
      * Retrieves rewind, and then unsets it.
+     * @return mixed
      */
-    public function getRewind() {
+    public function getRewind()
+    {
         $r = $this->rewind;
         $this->rewind = false;
         return $r;
@@ -83,17 +93,20 @@ abstract class HTMLPurifier_Injector
      * this allows references to important variables to be made within
      * the injector. This function also checks if the HTML environment
      * will work with the Injector (see checkNeeded()).
-     * @param $config Instance of HTMLPurifier_Config
-     * @param $context Instance of HTMLPurifier_Context
-     * @return Boolean false if success, string of missing needed element/attribute if failure
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool|string Boolean false if success, string of missing needed element/attribute if failure
      */
-    public function prepare($config, $context) {
+    public function prepare($config, $context)
+    {
         $this->htmlDefinition = $config->getHTMLDefinition();
         // Even though this might fail, some unit tests ignore this and
         // still test checkNeeded, so be careful. Maybe get rid of that
         // dependency.
         $result = $this->checkNeeded($config);
-        if ($result !== false) return $result;
+        if ($result !== false) {
+            return $result;
+        }
         $this->currentNesting =& $context->get('CurrentNesting');
         $this->inputTokens    =& $context->get('InputTokens');
         $this->inputIndex     =& $context->get('InputIndex');
@@ -104,18 +117,26 @@ abstract class HTMLPurifier_Injector
      * This function checks if the HTML environment
      * will work with the Injector: if p tags are not allowed, the
      * Auto-Paragraphing injector should not be enabled.
-     * @param $config Instance of HTMLPurifier_Config
-     * @param $context Instance of HTMLPurifier_Context
-     * @return Boolean false if success, string of missing needed element/attribute if failure
+     * @param HTMLPurifier_Config $config
+     * @return bool|string Boolean false if success, string of missing needed element/attribute if failure
      */
-    public function checkNeeded($config) {
+    public function checkNeeded($config)
+    {
         $def = $config->getHTMLDefinition();
         foreach ($this->needed as $element => $attributes) {
-            if (is_int($element)) $element = $attributes;
-            if (!isset($def->info[$element])) return $element;
-            if (!is_array($attributes)) continue;
+            if (is_int($element)) {
+                $element = $attributes;
+            }
+            if (!isset($def->info[$element])) {
+                return $element;
+            }
+            if (!is_array($attributes)) {
+                continue;
+            }
             foreach ($attributes as $name) {
-                if (!isset($def->info[$element]->attr[$name])) return "$element.$name";
+                if (!isset($def->info[$element]->attr[$name])) {
+                    return "$element.$name";
+                }
             }
         }
         return false;
@@ -123,10 +144,11 @@ abstract class HTMLPurifier_Injector
 
     /**
      * Tests if the context node allows a certain element
-     * @param $name Name of element to test for
-     * @return True if element is allowed, false if it is not
+     * @param string $name Name of element to test for
+     * @return bool True if element is allowed, false if it is not
      */
-    public function allowsElement($name) {
+    public function allowsElement($name)
+    {
         if (!empty($this->currentNesting)) {
             $parent_token = array_pop($this->currentNesting);
             $this->currentNesting[] = $parent_token;
@@ -141,7 +163,9 @@ abstract class HTMLPurifier_Injector
         for ($i = count($this->currentNesting) - 2; $i >= 0; $i--) {
             $node = $this->currentNesting[$i];
             $def  = $this->htmlDefinition->info[$node->name];
-            if (isset($def->excludes[$name])) return false;
+            if (isset($def->excludes[$name])) {
+                return false;
+            }
         }
         return true;
     }
@@ -151,13 +175,21 @@ abstract class HTMLPurifier_Injector
      * you reach the end of the input tokens.
      * @warning Please prevent previous references from interfering with this
      *          functions by setting $i = null beforehand!
-     * @param &$i Current integer index variable for inputTokens
-     * @param &$current Current token variable. Do NOT use $token, as that variable is also a reference
+     * @param int $i Current integer index variable for inputTokens
+     * @param HTMLPurifier_Token $current Current token variable.
+     *          Do NOT use $token, as that variable is also a reference
+     * @return bool
      */
-    protected function forward(&$i, &$current) {
-        if ($i === null) $i = $this->inputIndex + 1;
-        else $i++;
-        if (!isset($this->inputTokens[$i])) return false;
+    protected function forward(&$i, &$current)
+    {
+        if ($i === null) {
+            $i = $this->inputIndex + 1;
+        } else {
+            $i++;
+        }
+        if (!isset($this->inputTokens[$i])) {
+            return false;
+        }
         $current = $this->inputTokens[$i];
         return true;
     }
@@ -166,14 +198,27 @@ abstract class HTMLPurifier_Injector
      * Similar to _forward, but accepts a third parameter $nesting (which
      * should be initialized at 0) and stops when we hit the end tag
      * for the node $this->inputIndex starts in.
+     * @param int $i Current integer index variable for inputTokens
+     * @param HTMLPurifier_Token $current Current token variable.
+     *          Do NOT use $token, as that variable is also a reference
+     * @param int $nesting
+     * @return bool
      */
-    protected function forwardUntilEndToken(&$i, &$current, &$nesting) {
+    protected function forwardUntilEndToken(&$i, &$current, &$nesting)
+    {
         $result = $this->forward($i, $current);
-        if (!$result) return false;
-        if ($nesting === null) $nesting = 0;
-        if     ($current instanceof HTMLPurifier_Token_Start) $nesting++;
-        elseif ($current instanceof HTMLPurifier_Token_End) {
-            if ($nesting <= 0) return false;
+        if (!$result) {
+            return false;
+        }
+        if ($nesting === null) {
+            $nesting = 0;
+        }
+        if ($current instanceof HTMLPurifier_Token_Start) {
+            $nesting++;
+        } elseif ($current instanceof HTMLPurifier_Token_End) {
+            if ($nesting <= 0) {
+                return false;
+            }
             $nesting--;
         }
         return true;
@@ -184,13 +229,21 @@ abstract class HTMLPurifier_Injector
      * you reach the beginning of input tokens.
      * @warning Please prevent previous references from interfering with this
      *          functions by setting $i = null beforehand!
-     * @param &$i Current integer index variable for inputTokens
-     * @param &$current Current token variable. Do NOT use $token, as that variable is also a reference
+     * @param int $i Current integer index variable for inputTokens
+     * @param HTMLPurifier_Token $current Current token variable.
+     *          Do NOT use $token, as that variable is also a reference
+     * @return bool
      */
-    protected function backward(&$i, &$current) {
-        if ($i === null) $i = $this->inputIndex - 1;
-        else $i--;
-        if ($i < 0) return false;
+    protected function backward(&$i, &$current)
+    {
+        if ($i === null) {
+            $i = $this->inputIndex - 1;
+        } else {
+            $i--;
+        }
+        if ($i < 0) {
+            return false;
+        }
         $current = $this->inputTokens[$i];
         return true;
     }
@@ -201,39 +254,49 @@ abstract class HTMLPurifier_Injector
      * current location.
      * @warning Please prevent previous references from interfering with this
      *          functions by setting $i = null beforehand!
-     * @param &$i Current integer index variable for inputTokens
-     * @param &$current Current token variable. Do NOT use $token, as that variable is also a reference
+     * @param int $i Current integer index variable for inputTokens
+     * @param HTMLPurifier_Token $current Current token variable.
+     *          Do NOT use $token, as that variable is also a reference
      */
-    protected function current(&$i, &$current) {
-        if ($i === null) $i = $this->inputIndex;
+    protected function current(&$i, &$current)
+    {
+        if ($i === null) {
+            $i = $this->inputIndex;
+        }
         $current = $this->inputTokens[$i];
     }
 
     /**
      * Handler that is called when a text token is processed
      */
-    public function handleText(&$token) {}
+    public function handleText(&$token)
+    {
+    }
 
     /**
      * Handler that is called when a start or empty token is processed
      */
-    public function handleElement(&$token) {}
+    public function handleElement(&$token)
+    {
+    }
 
     /**
      * Handler that is called when an end token is processed
      */
-    public function handleEnd(&$token) {
+    public function handleEnd(&$token)
+    {
         $this->notifyEnd($token);
     }
 
     /**
      * Notifier that is called when an end token is processed
+     * @param HTMLPurifier_Token $token Current token variable.
      * @note This differs from handlers in that the token is read-only
      * @deprecated
      */
-    public function notifyEnd($token) {}
-
-
+    public function notifyEnd($token)
+    {
+    }
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Injector/AutoParagraph.php
+++ b/library/HTMLPurifier/Injector/AutoParagraph.php
@@ -8,17 +8,31 @@
  */
 class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier_Injector
 {
-
+    /**
+     * @type string
+     */
     public $name = 'AutoParagraph';
+
+    /**
+     * @type array
+     */
     public $needed = array('p');
 
-    private function _pStart() {
+    /**
+     * @return HTMLPurifier_Token_Start
+     */
+    private function _pStart()
+    {
         $par = new HTMLPurifier_Token_Start('p');
         $par->armor['MakeWellFormed_TagClosedError'] = true;
         return $par;
     }
 
-    public function handleText(&$token) {
+    /**
+     * @param HTMLPurifier_Token_Text $token
+     */
+    public function handleText(&$token)
+    {
         $text = $token->data;
         // Does the current parent allow <p> tags?
         if ($this->allowsElement('p')) {
@@ -72,11 +86,9 @@ class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier_Injector
                     //                   ----
                 }
             }
-        // Is the current parent a <p> tag?
-        } elseif (
-            !empty($this->currentNesting) &&
-            $this->currentNesting[count($this->currentNesting)-1]->name == 'p'
-        ) {
+            // Is the current parent a <p> tag?
+        } elseif (!empty($this->currentNesting) &&
+            $this->currentNesting[count($this->currentNesting) - 1]->name == 'p') {
             // State 3.1: ...<p>PAR1
             //                  ----
 
@@ -84,7 +96,7 @@ class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier_Injector
             //                  ------------
             $token = array();
             $this->_splitText($text, $token);
-        // Abort!
+            // Abort!
         } else {
             // State 4.1: ...<b>PAR1
             //                  ----
@@ -94,7 +106,11 @@ class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier_Injector
         }
     }
 
-    public function handleElement(&$token) {
+    /**
+     * @param HTMLPurifier_Token $token
+     */
+    public function handleElement(&$token)
+    {
         // We don't have to check if we're already in a <p> tag for block
         // tokens, because the tag would have been autoclosed by MakeWellFormed.
         if ($this->allowsElement('p')) {
@@ -102,7 +118,6 @@ class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier_Injector
                 if ($this->_isInline($token)) {
                     // State 1: <div>...<b>
                     //                  ---
-
                     // Check if this token is adjacent to the parent token
                     // (seek backwards until token isn't whitespace)
                     $i = null;
@@ -110,31 +125,24 @@ class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier_Injector
 
                     if (!$prev instanceof HTMLPurifier_Token_Start) {
                         // Token wasn't adjacent
-
-                        if (
-                            $prev instanceof HTMLPurifier_Token_Text &&
+                        if ($prev instanceof HTMLPurifier_Token_Text &&
                             substr($prev->data, -2) === "\n\n"
                         ) {
                             // State 1.1.4: <div><p>PAR1</p>\n\n<b>
                             //                                  ---
-
                             // Quite frankly, this should be handled by splitText
                             $token = array($this->_pStart(), $token);
                         } else {
                             // State 1.1.1: <div><p>PAR1</p><b>
                             //                              ---
-
                             // State 1.1.2: <div><br /><b>
                             //                         ---
-
                             // State 1.1.3: <div>PAR<b>
                             //                      ---
                         }
-
                     } else {
                         // State 1.2.1: <div><b>
                         //                   ---
-
                         // Lookahead to see if <p> is needed.
                         if ($this->_pLookAhead()) {
                             // State 1.3.1: <div><b>PAR1\n\nPAR2
@@ -166,24 +174,20 @@ class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier_Injector
 
                 $i = null;
                 if ($this->backward($i, $prev)) {
-                    if (
-                        !$prev instanceof HTMLPurifier_Token_Text
-                    ) {
+                    if (!$prev instanceof HTMLPurifier_Token_Text) {
                         // State 3.1.1: ...</p>{p}<b>
                         //                        ---
-
                         // State 3.2.1: ...</p><div>
                         //                     -----
-
-                        if (!is_array($token)) $token = array($token);
+                        if (!is_array($token)) {
+                            $token = array($token);
+                        }
                         array_unshift($token, new HTMLPurifier_Token_Text("\n\n"));
                     } else {
                         // State 3.1.2: ...</p>\n\n{p}<b>
                         //                            ---
-
                         // State 3.2.2: ...</p>\n\n<div>
                         //                         -----
-
                         // Note: PAR<ELEM> cannot occur because PAR would have been
                         // wrapped in <p> tags.
                     }
@@ -192,7 +196,6 @@ class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier_Injector
         } else {
             // State 2.2: <ul><li>
             //                ----
-
             // State 2.4: <p><b>
             //               ---
         }
@@ -201,18 +204,17 @@ class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier_Injector
     /**
      * Splits up a text in paragraph tokens and appends them
      * to the result stream that will replace the original
-     * @param $data String text data that will be processed
+     * @param string $data String text data that will be processed
      *    into paragraphs
-     * @param $result Reference to array of tokens that the
+     * @param HTMLPurifier_Token[] $result Reference to array of tokens that the
      *    tags will be appended onto
-     * @param $config Instance of HTMLPurifier_Config
-     * @param $context Instance of HTMLPurifier_Context
      */
-    private function _splitText($data, &$result) {
+    private function _splitText($data, &$result)
+    {
         $raw_paragraphs = explode("\n\n", $data);
-        $paragraphs  = array(); // without empty paragraphs
+        $paragraphs = array(); // without empty paragraphs
         $needs_start = false;
-        $needs_end   = false;
+        $needs_end = false;
 
         $c = count($raw_paragraphs);
         if ($c == 1) {
@@ -285,25 +287,32 @@ class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier_Injector
             array_pop($result); // removes \n\n
             array_pop($result); // removes </p>
         }
-
     }
 
     /**
      * Returns true if passed token is inline (and, ergo, allowed in
      * paragraph tags)
+     * @param HTMLPurifier_Token $token
+     * @return bool
      */
-    private function _isInline($token) {
+    private function _isInline($token)
+    {
         return isset($this->htmlDefinition->info['p']->child->elements[$token->name]);
     }
 
     /**
      * Looks ahead in the token list and determines whether or not we need
      * to insert a <p> tag.
+     * @return bool
      */
-    private function _pLookAhead() {
+    private function _pLookAhead()
+    {
         $this->current($i, $current);
-        if ($current instanceof HTMLPurifier_Token_Start) $nesting = 1;
-        else $nesting = 0;
+        if ($current instanceof HTMLPurifier_Token_Start) {
+            $nesting = 1;
+        } else {
+            $nesting = 0;
+        }
         $ok = false;
         while ($this->forwardUntilEndToken($i, $current, $nesting)) {
             $result = $this->_checkNeedsP($current);
@@ -318,9 +327,12 @@ class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier_Injector
     /**
      * Determines if a particular token requires an earlier inline token
      * to get a paragraph. This should be used with _forwardUntilEndToken
+     * @param HTMLPurifier_Token $current
+     * @return bool
      */
-    private function _checkNeedsP($current) {
-        if ($current instanceof HTMLPurifier_Token_Start){
+    private function _checkNeedsP($current)
+    {
+        if ($current instanceof HTMLPurifier_Token_Start) {
             if (!$this->_isInline($current)) {
                 // <div>PAR1<div>
                 //      ----
@@ -339,7 +351,6 @@ class HTMLPurifier_Injector_AutoParagraph extends HTMLPurifier_Injector
         }
         return null;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Injector/DisplayLinkURI.php
+++ b/library/HTMLPurifier/Injector/DisplayLinkURI.php
@@ -5,15 +5,29 @@
  */
 class HTMLPurifier_Injector_DisplayLinkURI extends HTMLPurifier_Injector
 {
-
+    /**
+     * @type string
+     */
     public $name = 'DisplayLinkURI';
+
+    /**
+     * @type array
+     */
     public $needed = array('a');
 
-    public function handleElement(&$token) {
+    /**
+     * @param $token
+     */
+    public function handleElement(&$token)
+    {
     }
 
-    public function handleEnd(&$token) {
-        if (isset($token->start->attr['href'])){
+    /**
+     * @param HTMLPurifier_Token $token
+     */
+    public function handleEnd(&$token)
+    {
+        if (isset($token->start->attr['href'])) {
             $url = $token->start->attr['href'];
             unset($token->start->attr['href']);
             $token = array($token, new HTMLPurifier_Token_Text(" ($url)"));

--- a/library/HTMLPurifier/Injector/Linkify.php
+++ b/library/HTMLPurifier/Injector/Linkify.php
@@ -5,12 +5,24 @@
  */
 class HTMLPurifier_Injector_Linkify extends HTMLPurifier_Injector
 {
-
+    /**
+     * @type string
+     */
     public $name = 'Linkify';
+
+    /**
+     * @type array
+     */
     public $needed = array('a' => array('href'));
 
-    public function handleText(&$token) {
-        if (!$this->allowsElement('a')) return;
+    /**
+     * @param HTMLPurifier_Token $token
+     */
+    public function handleText(&$token)
+    {
+        if (!$this->allowsElement('a')) {
+            return;
+        }
 
         if (strpos($token->data, '://') === false) {
             // our really quick heuristic failed, abort
@@ -31,7 +43,9 @@ class HTMLPurifier_Injector_Linkify extends HTMLPurifier_Injector
         // $l = is link
         for ($i = 0, $c = count($bits), $l = false; $i < $c; $i++, $l = !$l) {
             if (!$l) {
-                if ($bits[$i] === '') continue;
+                if ($bits[$i] === '') {
+                    continue;
+                }
                 $token[] = new HTMLPurifier_Token_Text($bits[$i]);
             } else {
                 $token[] = new HTMLPurifier_Token_Start('a', array('href' => $bits[$i]));
@@ -39,9 +53,7 @@ class HTMLPurifier_Injector_Linkify extends HTMLPurifier_Injector
                 $token[] = new HTMLPurifier_Token_End('a');
             }
         }
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Injector/PurifierLinkify.php
+++ b/library/HTMLPurifier/Injector/PurifierLinkify.php
@@ -6,19 +6,43 @@
  */
 class HTMLPurifier_Injector_PurifierLinkify extends HTMLPurifier_Injector
 {
-
+    /**
+     * @type string
+     */
     public $name = 'PurifierLinkify';
+
+    /**
+     * @type string
+     */
     public $docURL;
+
+    /**
+     * @type array
+     */
     public $needed = array('a' => array('href'));
 
-    public function prepare($config, $context) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return string
+     */
+    public function prepare($config, $context)
+    {
         $this->docURL = $config->get('AutoFormat.PurifierLinkify.DocURL');
         return parent::prepare($config, $context);
     }
 
-    public function handleText(&$token) {
-        if (!$this->allowsElement('a')) return;
-        if (strpos($token->data, '%') === false) return;
+    /**
+     * @param HTMLPurifier_Token $token
+     */
+    public function handleText(&$token)
+    {
+        if (!$this->allowsElement('a')) {
+            return;
+        }
+        if (strpos($token->data, '%') === false) {
+            return;
+        }
 
         $bits = preg_split('#%([a-z0-9]+\.[a-z0-9]+)#Si', $token->data, -1, PREG_SPLIT_DELIM_CAPTURE);
         $token = array();
@@ -28,18 +52,20 @@ class HTMLPurifier_Injector_PurifierLinkify extends HTMLPurifier_Injector
         // $l = is link
         for ($i = 0, $c = count($bits), $l = false; $i < $c; $i++, $l = !$l) {
             if (!$l) {
-                if ($bits[$i] === '') continue;
+                if ($bits[$i] === '') {
+                    continue;
+                }
                 $token[] = new HTMLPurifier_Token_Text($bits[$i]);
             } else {
-                $token[] = new HTMLPurifier_Token_Start('a',
-                    array('href' => str_replace('%s', $bits[$i], $this->docURL)));
+                $token[] = new HTMLPurifier_Token_Start(
+                    'a',
+                    array('href' => str_replace('%s', $bits[$i], $this->docURL))
+                );
                 $token[] = new HTMLPurifier_Token_Text('%' . $bits[$i]);
                 $token[] = new HTMLPurifier_Token_End('a');
             }
         }
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Injector/RemoveEmpty.php
+++ b/library/HTMLPurifier/Injector/RemoveEmpty.php
@@ -2,13 +2,44 @@
 
 class HTMLPurifier_Injector_RemoveEmpty extends HTMLPurifier_Injector
 {
+    /**
+     * @type HTMLPurifier_Context
+     */
+    private $context;
 
-    private $context, $config, $attrValidator, $removeNbsp, $removeNbspExceptions;
+    /**
+     * @type HTMLPurifier_Config
+     */
+    private $config;
 
-    // TODO: make me configurable
+    /**
+     * @type HTMLPurifier_AttrValidator
+     */
+    private $attrValidator;
+
+    /**
+     * @type bool
+     */
+    private $removeNbsp;
+
+    /**
+     * @type bool
+     */
+    private $removeNbspExceptions;
+
+    /**
+     * @type array
+     * TODO: make me configurable
+     */
     private $_exclude = array('colgroup' => 1, 'th' => 1, 'td' => 1, 'iframe' => 1);
 
-    public function prepare($config, $context) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return void
+     */
+    public function prepare($config, $context)
+    {
         parent::prepare($config, $context);
         $this->config = $config;
         $this->context = $context;
@@ -17,30 +48,46 @@ class HTMLPurifier_Injector_RemoveEmpty extends HTMLPurifier_Injector
         $this->attrValidator = new HTMLPurifier_AttrValidator();
     }
 
-    public function handleElement(&$token) {
-        if (!$token instanceof HTMLPurifier_Token_Start) return;
+    /**
+     * @param HTMLPurifier_Token $token
+     */
+    public function handleElement(&$token)
+    {
+        if (!$token instanceof HTMLPurifier_Token_Start) {
+            return;
+        }
         $next = false;
         for ($i = $this->inputIndex + 1, $c = count($this->inputTokens); $i < $c; $i++) {
             $next = $this->inputTokens[$i];
             if ($next instanceof HTMLPurifier_Token_Text) {
-                if ($next->is_whitespace) continue;
+                if ($next->is_whitespace) {
+                    continue;
+                }
                 if ($this->removeNbsp && !isset($this->removeNbspExceptions[$token->name])) {
                     $plain = str_replace("\xC2\xA0", "", $next->data);
                     $isWsOrNbsp = $plain === '' || ctype_space($plain);
-                    if ($isWsOrNbsp) continue;
+                    if ($isWsOrNbsp) {
+                        continue;
+                    }
                 }
             }
             break;
         }
         if (!$next || ($next instanceof HTMLPurifier_Token_End && $next->name == $token->name)) {
-            if (isset($this->_exclude[$token->name])) return;
+            if (isset($this->_exclude[$token->name])) {
+                return;
+            }
             $this->attrValidator->validateToken($token, $this->config, $this->context);
             $token->armor['ValidateAttributes'] = true;
-            if (isset($token->attr['id']) || isset($token->attr['name'])) return;
+            if (isset($token->attr['id']) || isset($token->attr['name'])) {
+                return;
+            }
             $token = $i - $this->inputIndex + 1;
             for ($b = $this->inputIndex - 1; $b > 0; $b--) {
                 $prev = $this->inputTokens[$b];
-                if ($prev instanceof HTMLPurifier_Token_Text && $prev->is_whitespace) continue;
+                if ($prev instanceof HTMLPurifier_Token_Text && $prev->is_whitespace) {
+                    continue;
+                }
                 break;
             }
             // This is safe because we removed the token that triggered this.
@@ -48,7 +95,6 @@ class HTMLPurifier_Injector_RemoveEmpty extends HTMLPurifier_Injector
             return;
         }
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Injector/RemoveSpansWithoutAttributes.php
+++ b/library/HTMLPurifier/Injector/RemoveSpansWithoutAttributes.php
@@ -5,25 +5,45 @@
  */
 class HTMLPurifier_Injector_RemoveSpansWithoutAttributes extends HTMLPurifier_Injector
 {
+    /**
+     * @type string
+     */
     public $name = 'RemoveSpansWithoutAttributes';
+
+    /**
+     * @type array
+     */
     public $needed = array('span');
 
+    /**
+     * @type HTMLPurifier_AttrValidator
+     */
     private $attrValidator;
 
     /**
-     * Used by AttrValidator
+     * Used by AttrValidator.
+     * @type HTMLPurifier_Config
      */
     private $config;
+
+    /**
+     * @type HTMLPurifier_Context
+     */
     private $context;
 
-    public function prepare($config, $context) {
+    public function prepare($config, $context)
+    {
         $this->attrValidator = new HTMLPurifier_AttrValidator();
         $this->config = $config;
         $this->context = $context;
         return parent::prepare($config, $context);
     }
 
-    public function handleElement(&$token) {
+    /**
+     * @param HTMLPurifier_Token $token
+     */
+    public function handleElement(&$token)
+    {
         if ($token->name !== 'span' || !$token instanceof HTMLPurifier_Token_Start) {
             return;
         }
@@ -39,8 +59,8 @@ class HTMLPurifier_Injector_RemoveSpansWithoutAttributes extends HTMLPurifier_In
         }
 
         $nesting = 0;
-        $spanContentTokens = array();
-        while ($this->forwardUntilEndToken($i, $current, $nesting)) {}
+        while ($this->forwardUntilEndToken($i, $current, $nesting)) {
+        }
 
         if ($current instanceof HTMLPurifier_Token_End && $current->name === 'span') {
             // Mark closing span tag for deletion
@@ -50,7 +70,11 @@ class HTMLPurifier_Injector_RemoveSpansWithoutAttributes extends HTMLPurifier_In
         }
     }
 
-    public function handleEnd(&$token) {
+    /**
+     * @param HTMLPurifier_Token $token
+     */
+    public function handleEnd(&$token)
+    {
         if ($token->markForDeletion) {
             $token = false;
         }

--- a/library/HTMLPurifier/Injector/SafeObject.php
+++ b/library/HTMLPurifier/Injector/SafeObject.php
@@ -6,17 +6,38 @@
  */
 class HTMLPurifier_Injector_SafeObject extends HTMLPurifier_Injector
 {
+    /**
+     * @type string
+     */
     public $name = 'SafeObject';
+
+    /**
+     * @type array
+     */
     public $needed = array('object', 'param');
 
+    /**
+     * @type array
+     */
     protected $objectStack = array();
-    protected $paramStack  = array();
 
-    // Keep this synchronized with AttrTransform/SafeParam.php
+    /**
+     * @type array
+     */
+    protected $paramStack = array();
+
+    /**
+     * Keep this synchronized with AttrTransform/SafeParam.php.
+     * @type array
+     */
     protected $addParam = array(
         'allowScriptAccess' => 'never',
         'allowNetworking' => 'internal',
     );
+
+    /**
+     * @type array
+     */
     protected $allowedParam = array(
         'wmode' => true,
         'movie' => true,
@@ -25,11 +46,21 @@ class HTMLPurifier_Injector_SafeObject extends HTMLPurifier_Injector
         'allowFullScreen' => true, // if omitted, assume to be 'false'
     );
 
-    public function prepare($config, $context) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return void
+     */
+    public function prepare($config, $context)
+    {
         parent::prepare($config, $context);
     }
 
-    public function handleElement(&$token) {
+    /**
+     * @param HTMLPurifier_Token $token
+     */
+    public function handleElement(&$token)
+    {
         if ($token->name == 'object') {
             $this->objectStack[] = $token;
             $this->paramStack[] = array();
@@ -51,16 +82,15 @@ class HTMLPurifier_Injector_SafeObject extends HTMLPurifier_Injector
                 // attribute, which we need if a type is specified. This is
                 // *very* Flash specific.
                 if (!isset($this->objectStack[$i]->attr['data']) &&
-                    ($token->attr['name'] == 'movie' || $token->attr['name'] == 'src')) {
+                    ($token->attr['name'] == 'movie' || $token->attr['name'] == 'src')
+                ) {
                     $this->objectStack[$i]->attr['data'] = $token->attr['value'];
                 }
                 // Check if the parameter is the correct value but has not
                 // already been added
-                if (
-                    !isset($this->paramStack[$i][$n]) &&
+                if (!isset($this->paramStack[$i][$n]) &&
                     isset($this->addParam[$n]) &&
-                    $token->attr['name'] === $this->addParam[$n]
-                ) {
+                    $token->attr['name'] === $this->addParam[$n]) {
                     // keep token, and add to param stack
                     $this->paramStack[$i][$n] = true;
                 } elseif (isset($this->allowedParam[$n])) {
@@ -76,7 +106,8 @@ class HTMLPurifier_Injector_SafeObject extends HTMLPurifier_Injector
         }
     }
 
-    public function handleEnd(&$token) {
+    public function handleEnd(&$token)
+    {
         // This is the WRONG way of handling the object and param stacks;
         // we should be inserting them directly on the relevant object tokens
         // so that the global stack handling handles it.
@@ -85,7 +116,6 @@ class HTMLPurifier_Injector_SafeObject extends HTMLPurifier_Injector
             array_pop($this->paramStack);
         }
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Language.php
+++ b/library/HTMLPurifier/Language.php
@@ -8,22 +8,26 @@ class HTMLPurifier_Language
 {
 
     /**
-     * ISO 639 language code of language. Prefers shortest possible version
+     * ISO 639 language code of language. Prefers shortest possible version.
+     * @type string
      */
     public $code = 'en';
 
     /**
-     * Fallback language code
+     * Fallback language code.
+     * @type bool|string
      */
     public $fallback = false;
 
     /**
-     * Array of localizable messages
+     * Array of localizable messages.
+     * @type array
      */
     public $messages = array();
 
     /**
-     * Array of localizable error codes
+     * Array of localizable error codes.
+     * @type array
      */
     public $errorNames = array();
 
@@ -31,21 +35,33 @@ class HTMLPurifier_Language
      * True if no message file was found for this language, so English
      * is being used instead. Check this if you'd like to notify the
      * user that they've used a non-supported language.
+     * @type bool
      */
     public $error = false;
 
     /**
      * Has the language object been loaded yet?
+     * @type bool
      * @todo Make it private, fix usage in HTMLPurifier_LanguageTest
      */
     public $_loaded = false;
 
     /**
-     * Instances of HTMLPurifier_Config and HTMLPurifier_Context
+     * @type HTMLPurifier_Config
      */
-    protected $config, $context;
+    protected $config;
 
-    public function __construct($config, $context) {
+    /**
+     * @type HTMLPurifier_Context
+     */
+    protected $context;
+
+    /**
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     */
+    public function __construct($config, $context)
+    {
         $this->config  = $config;
         $this->context = $context;
     }
@@ -54,8 +70,11 @@ class HTMLPurifier_Language
      * Loads language object with necessary info from factory cache
      * @note This is a lazy loader
      */
-    public function load() {
-        if ($this->_loaded) return;
+    public function load()
+    {
+        if ($this->_loaded) {
+            return;
+        }
         $factory = HTMLPurifier_LanguageFactory::instance();
         $factory->loadLanguage($this->code);
         foreach ($factory->keys as $key) {
@@ -66,31 +85,43 @@ class HTMLPurifier_Language
 
     /**
      * Retrieves a localised message.
-     * @param $key string identifier of message
+     * @param string $key string identifier of message
      * @return string localised message
      */
-    public function getMessage($key) {
-        if (!$this->_loaded) $this->load();
-        if (!isset($this->messages[$key])) return "[$key]";
+    public function getMessage($key)
+    {
+        if (!$this->_loaded) {
+            $this->load();
+        }
+        if (!isset($this->messages[$key])) {
+            return "[$key]";
+        }
         return $this->messages[$key];
     }
 
     /**
      * Retrieves a localised error name.
-     * @param $int integer error number, corresponding to PHP's error
-     *             reporting
+     * @param int $int error number, corresponding to PHP's error reporting
      * @return string localised message
      */
-    public function getErrorName($int) {
-        if (!$this->_loaded) $this->load();
-        if (!isset($this->errorNames[$int])) return "[Error: $int]";
+    public function getErrorName($int)
+    {
+        if (!$this->_loaded) {
+            $this->load();
+        }
+        if (!isset($this->errorNames[$int])) {
+            return "[Error: $int]";
+        }
         return $this->errorNames[$int];
     }
 
     /**
      * Converts an array list into a string readable representation
+     * @param array $array
+     * @return string
      */
-    public function listify($array) {
+    public function listify($array)
+    {
         $sep      = $this->getMessage('Item separator');
         $sep_last = $this->getMessage('Item separator last');
         $ret = '';
@@ -108,15 +139,20 @@ class HTMLPurifier_Language
 
     /**
      * Formats a localised message with passed parameters
-     * @param $key string identifier of message
-     * @param $args Parameters to substitute in
+     * @param string $key string identifier of message
+     * @param array $args Parameters to substitute in
      * @return string localised message
      * @todo Implement conditionals? Right now, some messages make
      *     reference to line numbers, but those aren't always available
      */
-    public function formatMessage($key, $args = array()) {
-        if (!$this->_loaded) $this->load();
-        if (!isset($this->messages[$key])) return "[$key]";
+    public function formatMessage($key, $args = array())
+    {
+        if (!$this->_loaded) {
+            $this->load();
+        }
+        if (!isset($this->messages[$key])) {
+            return "[$key]";
+        }
         $raw = $this->messages[$key];
         $subst = array();
         $generator = false;
@@ -124,9 +160,15 @@ class HTMLPurifier_Language
             if (is_object($value)) {
                 if ($value instanceof HTMLPurifier_Token) {
                     // factor this out some time
-                    if (!$generator) $generator = $this->context->get('Generator');
-                    if (isset($value->name)) $subst['$'.$i.'.Name'] = $value->name;
-                    if (isset($value->data)) $subst['$'.$i.'.Data'] = $value->data;
+                    if (!$generator) {
+                        $generator = $this->context->get('Generator');
+                    }
+                    if (isset($value->name)) {
+                        $subst['$'.$i.'.Name'] = $value->name;
+                    }
+                    if (isset($value->data)) {
+                        $subst['$'.$i.'.Data'] = $value->data;
+                    }
                     $subst['$'.$i.'.Compact'] =
                     $subst['$'.$i.'.Serialized'] = $generator->generateFromToken($value);
                     // a more complex algorithm for compact representation
@@ -157,7 +199,6 @@ class HTMLPurifier_Language
         }
         return strtr($raw, $subst);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Language/classes/en-x-test.php
+++ b/library/HTMLPurifier/Language/classes/en-x-test.php
@@ -4,9 +4,6 @@
 
 class HTMLPurifier_Language_en_x_test extends HTMLPurifier_Language
 {
-
-
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Language/messages/en.php
+++ b/library/HTMLPurifier/Language/messages/en.php
@@ -4,60 +4,52 @@ $fallback = false;
 
 $messages = array(
 
-'HTMLPurifier' => 'HTML Purifier',
-
+    'HTMLPurifier' => 'HTML Purifier',
 // for unit testing purposes
-'LanguageFactoryTest: Pizza' => 'Pizza',
-'LanguageTest: List' => '$1',
-'LanguageTest: Hash' => '$1.Keys; $1.Values',
+    'LanguageFactoryTest: Pizza' => 'Pizza',
+    'LanguageTest: List' => '$1',
+    'LanguageTest: Hash' => '$1.Keys; $1.Values',
+    'Item separator' => ', ',
+    'Item separator last' => ' and ', // non-Harvard style
 
-'Item separator' => ', ',
-'Item separator last' => ' and ', // non-Harvard style
-
-'ErrorCollector: No errors' => 'No errors detected. However, because error reporting is still incomplete, there may have been errors that the error collector was not notified of; please inspect the output HTML carefully.',
-'ErrorCollector: At line'   => ' at line $line',
-'ErrorCollector: Incidental errors'  => 'Incidental errors',
-
-'Lexer: Unclosed comment'      => 'Unclosed comment',
-'Lexer: Unescaped lt'          => 'Unescaped less-than sign (<) should be &lt;',
-'Lexer: Missing gt'            => 'Missing greater-than sign (>), previous less-than sign (<) should be escaped',
-'Lexer: Missing attribute key' => 'Attribute declaration has no key',
-'Lexer: Missing end quote'     => 'Attribute declaration has no end quote',
-'Lexer: Extracted body'        => 'Removed document metadata tags',
-
-'Strategy_RemoveForeignElements: Tag transform'              => '<$1> element transformed into $CurrentToken.Serialized',
-'Strategy_RemoveForeignElements: Missing required attribute' => '$CurrentToken.Compact element missing required attribute $1',
-'Strategy_RemoveForeignElements: Foreign element to text'    => 'Unrecognized $CurrentToken.Serialized tag converted to text',
-'Strategy_RemoveForeignElements: Foreign element removed'    => 'Unrecognized $CurrentToken.Serialized tag removed',
-'Strategy_RemoveForeignElements: Comment removed'            => 'Comment containing "$CurrentToken.Data" removed',
-'Strategy_RemoveForeignElements: Foreign meta element removed' => 'Unrecognized $CurrentToken.Serialized meta tag and all descendants removed',
-'Strategy_RemoveForeignElements: Token removed to end'       => 'Tags and text starting from $1 element where removed to end',
-'Strategy_RemoveForeignElements: Trailing hyphen in comment removed' => 'Trailing hyphen(s) in comment removed',
-'Strategy_RemoveForeignElements: Hyphens in comment collapsed' => 'Double hyphens in comments are not allowed, and were collapsed into single hyphens',
-
-'Strategy_MakeWellFormed: Unnecessary end tag removed' => 'Unnecessary $CurrentToken.Serialized tag removed',
-'Strategy_MakeWellFormed: Unnecessary end tag to text' => 'Unnecessary $CurrentToken.Serialized tag converted to text',
-'Strategy_MakeWellFormed: Tag auto closed'             => '$1.Compact started on line $1.Line auto-closed by $CurrentToken.Compact',
-'Strategy_MakeWellFormed: Tag carryover'               => '$1.Compact started on line $1.Line auto-continued into $CurrentToken.Compact',
-'Strategy_MakeWellFormed: Stray end tag removed'       => 'Stray $CurrentToken.Serialized tag removed',
-'Strategy_MakeWellFormed: Stray end tag to text'       => 'Stray $CurrentToken.Serialized tag converted to text',
-'Strategy_MakeWellFormed: Tag closed by element end'   => '$1.Compact tag started on line $1.Line closed by end of $CurrentToken.Serialized',
-'Strategy_MakeWellFormed: Tag closed by document end'  => '$1.Compact tag started on line $1.Line closed by end of document',
-
-'Strategy_FixNesting: Node removed'          => '$CurrentToken.Compact node removed',
-'Strategy_FixNesting: Node excluded'         => '$CurrentToken.Compact node removed due to descendant exclusion by ancestor element',
-'Strategy_FixNesting: Node reorganized'      => 'Contents of $CurrentToken.Compact node reorganized to enforce its content model',
-'Strategy_FixNesting: Node contents removed' => 'Contents of $CurrentToken.Compact node removed',
-
-'AttrValidator: Attributes transformed' => 'Attributes on $CurrentToken.Compact transformed from $1.Keys to $2.Keys',
-'AttrValidator: Attribute removed' => '$CurrentAttr.Name attribute on $CurrentToken.Compact removed',
-
+    'ErrorCollector: No errors' => 'No errors detected. However, because error reporting is still incomplete, there may have been errors that the error collector was not notified of; please inspect the output HTML carefully.',
+    'ErrorCollector: At line' => ' at line $line',
+    'ErrorCollector: Incidental errors' => 'Incidental errors',
+    'Lexer: Unclosed comment' => 'Unclosed comment',
+    'Lexer: Unescaped lt' => 'Unescaped less-than sign (<) should be &lt;',
+    'Lexer: Missing gt' => 'Missing greater-than sign (>), previous less-than sign (<) should be escaped',
+    'Lexer: Missing attribute key' => 'Attribute declaration has no key',
+    'Lexer: Missing end quote' => 'Attribute declaration has no end quote',
+    'Lexer: Extracted body' => 'Removed document metadata tags',
+    'Strategy_RemoveForeignElements: Tag transform' => '<$1> element transformed into $CurrentToken.Serialized',
+    'Strategy_RemoveForeignElements: Missing required attribute' => '$CurrentToken.Compact element missing required attribute $1',
+    'Strategy_RemoveForeignElements: Foreign element to text' => 'Unrecognized $CurrentToken.Serialized tag converted to text',
+    'Strategy_RemoveForeignElements: Foreign element removed' => 'Unrecognized $CurrentToken.Serialized tag removed',
+    'Strategy_RemoveForeignElements: Comment removed' => 'Comment containing "$CurrentToken.Data" removed',
+    'Strategy_RemoveForeignElements: Foreign meta element removed' => 'Unrecognized $CurrentToken.Serialized meta tag and all descendants removed',
+    'Strategy_RemoveForeignElements: Token removed to end' => 'Tags and text starting from $1 element where removed to end',
+    'Strategy_RemoveForeignElements: Trailing hyphen in comment removed' => 'Trailing hyphen(s) in comment removed',
+    'Strategy_RemoveForeignElements: Hyphens in comment collapsed' => 'Double hyphens in comments are not allowed, and were collapsed into single hyphens',
+    'Strategy_MakeWellFormed: Unnecessary end tag removed' => 'Unnecessary $CurrentToken.Serialized tag removed',
+    'Strategy_MakeWellFormed: Unnecessary end tag to text' => 'Unnecessary $CurrentToken.Serialized tag converted to text',
+    'Strategy_MakeWellFormed: Tag auto closed' => '$1.Compact started on line $1.Line auto-closed by $CurrentToken.Compact',
+    'Strategy_MakeWellFormed: Tag carryover' => '$1.Compact started on line $1.Line auto-continued into $CurrentToken.Compact',
+    'Strategy_MakeWellFormed: Stray end tag removed' => 'Stray $CurrentToken.Serialized tag removed',
+    'Strategy_MakeWellFormed: Stray end tag to text' => 'Stray $CurrentToken.Serialized tag converted to text',
+    'Strategy_MakeWellFormed: Tag closed by element end' => '$1.Compact tag started on line $1.Line closed by end of $CurrentToken.Serialized',
+    'Strategy_MakeWellFormed: Tag closed by document end' => '$1.Compact tag started on line $1.Line closed by end of document',
+    'Strategy_FixNesting: Node removed' => '$CurrentToken.Compact node removed',
+    'Strategy_FixNesting: Node excluded' => '$CurrentToken.Compact node removed due to descendant exclusion by ancestor element',
+    'Strategy_FixNesting: Node reorganized' => 'Contents of $CurrentToken.Compact node reorganized to enforce its content model',
+    'Strategy_FixNesting: Node contents removed' => 'Contents of $CurrentToken.Compact node removed',
+    'AttrValidator: Attributes transformed' => 'Attributes on $CurrentToken.Compact transformed from $1.Keys to $2.Keys',
+    'AttrValidator: Attribute removed' => '$CurrentAttr.Name attribute on $CurrentToken.Compact removed',
 );
 
 $errorNames = array(
-    E_ERROR   => 'Error',
+    E_ERROR => 'Error',
     E_WARNING => 'Warning',
-    E_NOTICE  => 'Notice'
+    E_NOTICE => 'Notice'
 );
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Length.php
+++ b/library/HTMLPurifier/Length.php
@@ -9,21 +9,25 @@ class HTMLPurifier_Length
 
     /**
      * String numeric magnitude.
+     * @type string
      */
     protected $n;
 
     /**
      * String unit. False is permitted if $n = 0.
+     * @type string|bool
      */
     protected $unit;
 
     /**
      * Whether or not this length is valid. Null if not calculated yet.
+     * @type bool
      */
     protected $isValid;
 
     /**
-     * Lookup array of units recognized by CSS 2.1
+     * Array Lookup array of units recognized by CSS 2.1
+     * @type array
      */
     protected static $allowedUnits = array(
         'em' => true, 'ex' => true, 'px' => true, 'in' => true,
@@ -31,85 +35,126 @@ class HTMLPurifier_Length
     );
 
     /**
-     * @param number $n Magnitude
-     * @param string $u Unit
+     * @param string $n Magnitude
+     * @param bool|string $u Unit
      */
-    public function __construct($n = '0', $u = false) {
+    public function __construct($n = '0', $u = false)
+    {
         $this->n = (string) $n;
         $this->unit = $u !== false ? (string) $u : false;
     }
 
     /**
      * @param string $s Unit string, like '2em' or '3.4in'
+     * @return HTMLPurifier_Length
      * @warning Does not perform validation.
      */
-    static public function make($s) {
-        if ($s instanceof HTMLPurifier_Length) return $s;
+    public static function make($s)
+    {
+        if ($s instanceof HTMLPurifier_Length) {
+            return $s;
+        }
         $n_length = strspn($s, '1234567890.+-');
         $n = substr($s, 0, $n_length);
         $unit = substr($s, $n_length);
-        if ($unit === '') $unit = false;
+        if ($unit === '') {
+            $unit = false;
+        }
         return new HTMLPurifier_Length($n, $unit);
     }
 
     /**
      * Validates the number and unit.
+     * @return bool
      */
-    protected function validate() {
+    protected function validate()
+    {
         // Special case:
-        if ($this->n === '+0' || $this->n === '-0') $this->n = '0';
-        if ($this->n === '0' && $this->unit === false) return true;
-        if (!ctype_lower($this->unit)) $this->unit = strtolower($this->unit);
-        if (!isset(HTMLPurifier_Length::$allowedUnits[$this->unit])) return false;
+        if ($this->n === '+0' || $this->n === '-0') {
+            $this->n = '0';
+        }
+        if ($this->n === '0' && $this->unit === false) {
+            return true;
+        }
+        if (!ctype_lower($this->unit)) {
+            $this->unit = strtolower($this->unit);
+        }
+        if (!isset(HTMLPurifier_Length::$allowedUnits[$this->unit])) {
+            return false;
+        }
         // Hack:
         $def = new HTMLPurifier_AttrDef_CSS_Number();
         $result = $def->validate($this->n, false, false);
-        if ($result === false) return false;
+        if ($result === false) {
+            return false;
+        }
         $this->n = $result;
         return true;
     }
 
     /**
      * Returns string representation of number.
+     * @return string
      */
-    public function toString() {
-        if (!$this->isValid()) return false;
+    public function toString()
+    {
+        if (!$this->isValid()) {
+            return false;
+        }
         return $this->n . $this->unit;
     }
 
     /**
      * Retrieves string numeric magnitude.
+     * @return string
      */
-    public function getN() {return $this->n;}
+    public function getN()
+    {
+        return $this->n;
+    }
 
     /**
      * Retrieves string unit.
+     * @return string
      */
-    public function getUnit() {return $this->unit;}
+    public function getUnit()
+    {
+        return $this->unit;
+    }
 
     /**
      * Returns true if this length unit is valid.
+     * @return bool
      */
-    public function isValid() {
-        if ($this->isValid === null) $this->isValid = $this->validate();
+    public function isValid()
+    {
+        if ($this->isValid === null) {
+            $this->isValid = $this->validate();
+        }
         return $this->isValid;
     }
 
     /**
      * Compares two lengths, and returns 1 if greater, -1 if less and 0 if equal.
+     * @param HTMLPurifier_Length $l
+     * @return int
      * @warning If both values are too large or small, this calculation will
      *          not work properly
      */
-    public function compareTo($l) {
-        if ($l === false) return false;
+    public function compareTo($l)
+    {
+        if ($l === false) {
+            return false;
+        }
         if ($l->unit !== $this->unit) {
             $converter = new HTMLPurifier_UnitConverter();
             $l = $converter->convert($l, $this->unit);
-            if ($l === false) return false;
+            if ($l === false) {
+                return false;
+            }
         }
         return $this->n - $l->n;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Lexer/DOMLex.php
+++ b/library/HTMLPurifier/Lexer/DOMLex.php
@@ -27,16 +27,26 @@
 class HTMLPurifier_Lexer_DOMLex extends HTMLPurifier_Lexer
 {
 
+    /**
+     * @type HTMLPurifier_TokenFactory
+     */
     private $factory;
 
-    public function __construct() {
+    public function __construct()
+    {
         // setup the factory
         parent::__construct();
         $this->factory = new HTMLPurifier_TokenFactory();
     }
 
-    public function tokenizeHTML($html, $config, $context) {
-
+    /**
+     * @param string $html
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return HTMLPurifier_Token[]
+     */
+    public function tokenizeHTML($html, $config, $context)
+    {
         $html = $this->normalize($html, $config, $context);
 
         // attempt to armor stray angled brackets that cannot possibly
@@ -65,21 +75,22 @@ class HTMLPurifier_Lexer_DOMLex extends HTMLPurifier_Lexer
         $tokens = array();
         $this->tokenizeDOM(
             $doc->getElementsByTagName('html')->item(0)-> // <html>
-                  getElementsByTagName('body')->item(0)-> //   <body>
-                  getElementsByTagName('div')->item(0)    //     <div>
-            , $tokens);
+            getElementsByTagName('body')->item(0)-> //   <body>
+            getElementsByTagName('div')->item(0), //     <div>
+            $tokens
+        );
         return $tokens;
     }
 
     /**
      * Iterative function that tokenizes a node, putting it into an accumulator.
      * To iterate is human, to recurse divine - L. Peter Deutsch
-     * @param $node     DOMNode to be tokenized.
-     * @param $tokens   Array-list of already tokenized tokens.
-     * @returns Tokens of node appended to previously passed tokens.
+     * @param DOMNode $node DOMNode to be tokenized.
+     * @param HTMLPurifier_Token[] $tokens   Array-list of already tokenized tokens.
+     * @return HTMLPurifier_Token of node appended to previously passed tokens.
      */
-    protected function tokenizeDOM($node, &$tokens) {
-
+    protected function tokenizeDOM($node, &$tokens)
+    {
         $level = 0;
         $nodes = array($level => array($node));
         $closingNodes = array();
@@ -101,7 +112,7 @@ class HTMLPurifier_Lexer_DOMLex extends HTMLPurifier_Lexer
             }
             $level--;
             if ($level && isset($closingNodes[$level])) {
-                while($node = array_pop($closingNodes[$level])) {
+                while ($node = array_pop($closingNodes[$level])) {
                     $this->createEndNode($node, $tokens);
                 }
             }
@@ -109,14 +120,16 @@ class HTMLPurifier_Lexer_DOMLex extends HTMLPurifier_Lexer
     }
 
     /**
-     * @param $node  DOMNode to be tokenized.
-     * @param $tokens   Array-list of already tokenized tokens.
-     * @param $collect  Says whether or start and close are collected, set to
+     * @param DOMNode $node DOMNode to be tokenized.
+     * @param HTMLPurifier_Token[] $tokens   Array-list of already tokenized tokens.
+     * @param bool $collect  Says whether or start and close are collected, set to
      *                    false at first recursion because it's the implicit DIV
      *                    tag you're dealing with.
-     * @returns bool if the token needs an endtoken
+     * @return bool if the token needs an endtoken
+     * @todo data and tagName properties don't seem to exist in DOMNode?
      */
-    protected function createStartNode($node, &$tokens, $collect) {
+    protected function createStartNode($node, &$tokens, $collect)
+    {
         // intercept non element nodes. WE MUST catch all of them,
         // but we're not getting the character reference nodes because
         // those should have been preprocessed
@@ -147,10 +160,8 @@ class HTMLPurifier_Lexer_DOMLex extends HTMLPurifier_Lexer
             // handled regularly)
             $tokens[] = $this->factory->createComment($node->data);
             return false;
-        } elseif (
+        } elseif ($node->nodeType !== XML_ELEMENT_NODE) {
             // not-well tested: there may be other nodes we have to grab
-            $node->nodeType !== XML_ELEMENT_NODE
-        ) {
             return false;
         }
 
@@ -173,7 +184,12 @@ class HTMLPurifier_Lexer_DOMLex extends HTMLPurifier_Lexer
         }
     }
 
-    protected function createEndNode($node, &$tokens) {
+    /**
+     * @param DOMNode $node
+     * @param HTMLPurifier_Token[] $tokens
+     */
+    protected function createEndNode($node, &$tokens)
+    {
         $tokens[] = $this->factory->createEnd($node->tagName);
     }
 
@@ -181,14 +197,17 @@ class HTMLPurifier_Lexer_DOMLex extends HTMLPurifier_Lexer
     /**
      * Converts a DOMNamedNodeMap of DOMAttr objects into an assoc array.
      *
-     * @param $attribute_list DOMNamedNodeMap of DOMAttr objects.
-     * @returns Associative array of attributes.
+     * @param DOMNamedNodeMap $node_map DOMNamedNodeMap of DOMAttr objects.
+     * @return array Associative array of attributes.
      */
-    protected function transformAttrToAssoc($node_map) {
+    protected function transformAttrToAssoc($node_map)
+    {
         // NamedNodeMap is documented very well, so we're using undocumented
         // features, namely, the fact that it implements Iterator and
         // has a ->length attribute
-        if ($node_map->length === 0) return array();
+        if ($node_map->length === 0) {
+            return array();
+        }
         $array = array();
         foreach ($node_map as $attr) {
             $array[$attr->name] = $attr->value;
@@ -198,46 +217,64 @@ class HTMLPurifier_Lexer_DOMLex extends HTMLPurifier_Lexer
 
     /**
      * An error handler that mutes all errors
+     * @param int $errno
+     * @param string $errstr
      */
-    public function muteErrorHandler($errno, $errstr) {}
+    public function muteErrorHandler($errno, $errstr)
+    {
+    }
 
     /**
      * Callback function for undoing escaping of stray angled brackets
      * in comments
+     * @param array $matches
+     * @return string
      */
-    public function callbackUndoCommentSubst($matches) {
-        return '<!--' . strtr($matches[1], array('&amp;'=>'&','&lt;'=>'<')) . $matches[2];
+    public function callbackUndoCommentSubst($matches)
+    {
+        return '<!--' . strtr($matches[1], array('&amp;' => '&', '&lt;' => '<')) . $matches[2];
     }
 
     /**
      * Callback function that entity-izes ampersands in comments so that
      * callbackUndoCommentSubst doesn't clobber them
+     * @param array $matches
+     * @return string
      */
-    public function callbackArmorCommentEntities($matches) {
+    public function callbackArmorCommentEntities($matches)
+    {
         return '<!--' . str_replace('&', '&amp;', $matches[1]) . $matches[2];
     }
 
     /**
      * Wraps an HTML fragment in the necessary HTML
+     * @param string $html
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return string
      */
-    protected function wrapHTML($html, $config, $context) {
+    protected function wrapHTML($html, $config, $context)
+    {
         $def = $config->getDefinition('HTML');
         $ret = '';
 
         if (!empty($def->doctype->dtdPublic) || !empty($def->doctype->dtdSystem)) {
             $ret .= '<!DOCTYPE html ';
-            if (!empty($def->doctype->dtdPublic)) $ret .= 'PUBLIC "' . $def->doctype->dtdPublic . '" ';
-            if (!empty($def->doctype->dtdSystem)) $ret .= '"' . $def->doctype->dtdSystem . '" ';
+            if (!empty($def->doctype->dtdPublic)) {
+                $ret .= 'PUBLIC "' . $def->doctype->dtdPublic . '" ';
+            }
+            if (!empty($def->doctype->dtdSystem)) {
+                $ret .= '"' . $def->doctype->dtdSystem . '" ';
+            }
             $ret .= '>';
         }
 
         $ret .= '<html><head>';
         $ret .= '<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />';
         // No protection if $html contains a stray </div>!
-        $ret .= '</head><body><div>'.$html.'</div></body></html>';
+        $ret .= '</head><body><div>' . $html . '</div></body></html>';
         return $ret;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Lexer/DirectLex.php
+++ b/library/HTMLPurifier/Lexer/DirectLex.php
@@ -12,30 +12,44 @@
  */
 class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
 {
-
+    /**
+     * @type bool
+     */
     public $tracksLineNumbers = true;
 
     /**
      * Whitespace characters for str(c)spn.
+     * @type string
      */
     protected $_whitespace = "\x20\x09\x0D\x0A";
 
     /**
      * Callback function for script CDATA fudge
-     * @param $matches, in form of array(opening tag, contents, closing tag)
+     * @param array $matches, in form of array(opening tag, contents, closing tag)
+     * @return string
      */
-    protected function scriptCallback($matches) {
+    protected function scriptCallback($matches)
+    {
         return $matches[1] . htmlspecialchars($matches[2], ENT_COMPAT, 'UTF-8') . $matches[3];
     }
 
-    public function tokenizeHTML($html, $config, $context) {
-
+    /**
+     * @param String $html
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array|HTMLPurifier_Token[]
+     */
+    public function tokenizeHTML($html, $config, $context)
+    {
         // special normalization for script tags without any armor
         // our "armor" heurstic is a < sign any number of whitespaces after
         // the first script tag
         if ($config->get('HTML.Trusted')) {
-            $html = preg_replace_callback('#(<script[^>]*>)(\s*[^<].+?)(</script>)#si',
-                array($this, 'scriptCallback'), $html);
+            $html = preg_replace_callback(
+                '#(<script[^>]*>)(\s*[^<].+?)(</script>)#si',
+                array($this, 'scriptCallback'),
+                $html
+            );
         }
 
         $html = $this->normalize($html, $config, $context);
@@ -55,15 +69,15 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
 
         if ($maintain_line_numbers) {
             $current_line = 1;
-            $current_col  = 0;
+            $current_col = 0;
             $length = strlen($html);
         } else {
             $current_line = false;
-            $current_col  = false;
+            $current_col = false;
             $length = false;
         }
         $context->register('CurrentLine', $current_line);
-        $context->register('CurrentCol',  $current_col);
+        $context->register('CurrentCol', $current_col);
         $nl = "\n";
         // how often to manually recalculate. This will ALWAYS be right,
         // but it's pretty wasteful. Set to 0 to turn off
@@ -77,16 +91,14 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
         // for testing synchronization
         $loops = 0;
 
-        while(++$loops) {
-
+        while (++$loops) {
             // $cursor is either at the start of a token, or inside of
             // a tag (i.e. there was a < immediately before it), as indicated
             // by $inside_tag
 
             if ($maintain_line_numbers) {
-
                 // $rcursor, however, is always at the start of a token.
-                $rcursor = $cursor - (int) $inside_tag;
+                $rcursor = $cursor - (int)$inside_tag;
 
                 // Column number is cheap, so we calculate it every round.
                 // We're interested at the *end* of the newline string, so
@@ -96,14 +108,11 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
                 $current_col = $rcursor - (is_bool($nl_pos) ? 0 : $nl_pos + 1);
 
                 // recalculate lines
-                if (
-                    $synchronize_interval &&  // synchronization is on
-                    $cursor > 0 &&            // cursor is further than zero
-                    $loops % $synchronize_interval === 0 // time to synchronize!
-                ) {
+                if ($synchronize_interval && // synchronization is on
+                    $cursor > 0 && // cursor is further than zero
+                    $loops % $synchronize_interval === 0) { // time to synchronize!
                     $current_line = 1 + $this->substrCount($html, $nl, 0, $cursor);
                 }
-
             }
 
             $position_next_lt = strpos($html, '<', $cursor);
@@ -119,35 +128,42 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
             if (!$inside_tag && $position_next_lt !== false) {
                 // We are not inside tag and there still is another tag to parse
                 $token = new
-                    HTMLPurifier_Token_Text(
-                        $this->parseData(
-                            substr(
-                                $html, $cursor, $position_next_lt - $cursor
-                            )
+                HTMLPurifier_Token_Text(
+                    $this->parseData(
+                        substr(
+                            $html,
+                            $cursor,
+                            $position_next_lt - $cursor
                         )
-                    );
+                    )
+                );
                 if ($maintain_line_numbers) {
                     $token->rawPosition($current_line, $current_col);
                     $current_line += $this->substrCount($html, $nl, $cursor, $position_next_lt - $cursor);
                 }
                 $array[] = $token;
-                $cursor  = $position_next_lt + 1;
+                $cursor = $position_next_lt + 1;
                 $inside_tag = true;
                 continue;
             } elseif (!$inside_tag) {
                 // We are not inside tag but there are no more tags
                 // If we're already at the end, break
-                if ($cursor === strlen($html)) break;
+                if ($cursor === strlen($html)) {
+                    break;
+                }
                 // Create Text of rest of string
                 $token = new
-                    HTMLPurifier_Token_Text(
-                        $this->parseData(
-                            substr(
-                                $html, $cursor
-                            )
+                HTMLPurifier_Token_Text(
+                    $this->parseData(
+                        substr(
+                            $html,
+                            $cursor
                         )
-                    );
-                if ($maintain_line_numbers) $token->rawPosition($current_line, $current_col);
+                    )
+                );
+                if ($maintain_line_numbers) {
+                    $token->rawPosition($current_line, $current_col);
+                }
                 $array[] = $token;
                 break;
             } elseif ($inside_tag && $position_next_gt !== false) {
@@ -171,16 +187,16 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
                 }
 
                 // Check if it's a comment
-                if (
-                    substr($segment, 0, 3) === '!--'
-                ) {
+                if (substr($segment, 0, 3) === '!--') {
                     // re-determine segment length, looking for -->
                     $position_comment_end = strpos($html, '-->', $cursor);
                     if ($position_comment_end === false) {
                         // uh oh, we have a comment that extends to
                         // infinity. Can't be helped: set comment
                         // end position to end of string
-                        if ($e) $e->send(E_WARNING, 'Lexer: Unclosed comment');
+                        if ($e) {
+                            $e->send(E_WARNING, 'Lexer: Unclosed comment');
+                        }
                         $position_comment_end = strlen($html);
                         $end = true;
                     } else {
@@ -189,11 +205,13 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
                     $strlen_segment = $position_comment_end - $cursor;
                     $segment = substr($html, $cursor, $strlen_segment);
                     $token = new
-                        HTMLPurifier_Token_Comment(
-                            substr(
-                                $segment, 3, $strlen_segment - 3
-                            )
-                        );
+                    HTMLPurifier_Token_Comment(
+                        substr(
+                            $segment,
+                            3,
+                            $strlen_segment - 3
+                        )
+                    );
                     if ($maintain_line_numbers) {
                         $token->rawPosition($current_line, $current_col);
                         $current_line += $this->substrCount($html, $nl, $cursor, $strlen_segment);
@@ -205,7 +223,7 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
                 }
 
                 // Check if it's an end tag
-                $is_end_tag = (strpos($segment,'/') === 0);
+                $is_end_tag = (strpos($segment, '/') === 0);
                 if ($is_end_tag) {
                     $type = substr($segment, 1);
                     $token = new HTMLPurifier_Token_End($type);
@@ -224,7 +242,9 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
                 // text and go our merry way
                 if (!ctype_alpha($segment[0])) {
                     // XML:  $segment[0] !== '_' && $segment[0] !== ':'
-                    if ($e) $e->send(E_NOTICE, 'Lexer: Unescaped lt');
+                    if ($e) {
+                        $e->send(E_NOTICE, 'Lexer: Unescaped lt');
+                    }
                     $token = new HTMLPurifier_Token_Text('<');
                     if ($maintain_line_numbers) {
                         $token->rawPosition($current_line, $current_col);
@@ -239,7 +259,7 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
                 // trailing slash. Remember, we could have a tag like <br>, so
                 // any later token processing scripts must convert improperly
                 // classified EmptyTags from StartTags.
-                $is_self_closing = (strrpos($segment,'/') === $strlen_segment-1);
+                $is_self_closing = (strrpos($segment, '/') === $strlen_segment - 1);
                 if ($is_self_closing) {
                     $strlen_segment--;
                     $segment = substr($segment, 0, $strlen_segment);
@@ -269,14 +289,16 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
                 $attribute_string =
                     trim(
                         substr(
-                            $segment, $position_first_space
+                            $segment,
+                            $position_first_space
                         )
                     );
                 if ($attribute_string) {
                     $attr = $this->parseAttributeString(
-                                    $attribute_string
-                                  , $config, $context
-                              );
+                        $attribute_string,
+                        $config,
+                        $context
+                    );
                 } else {
                     $attr = array();
                 }
@@ -296,15 +318,19 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
                 continue;
             } else {
                 // inside tag, but there's no ending > sign
-                if ($e) $e->send(E_WARNING, 'Lexer: Missing gt');
+                if ($e) {
+                    $e->send(E_WARNING, 'Lexer: Missing gt');
+                }
                 $token = new
-                    HTMLPurifier_Token_Text(
-                        '<' .
-                        $this->parseData(
-                            substr($html, $cursor)
-                        )
-                    );
-                if ($maintain_line_numbers) $token->rawPosition($current_line, $current_col);
+                HTMLPurifier_Token_Text(
+                    '<' .
+                    $this->parseData(
+                        substr($html, $cursor)
+                    )
+                );
+                if ($maintain_line_numbers) {
+                    $token->rawPosition($current_line, $current_col);
+                }
                 // no cursor scroll? Hmm...
                 $array[] = $token;
                 break;
@@ -319,8 +345,14 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
 
     /**
      * PHP 5.0.x compatible substr_count that implements offset and length
+     * @param string $haystack
+     * @param string $needle
+     * @param int $offset
+     * @param int $length
+     * @return int
      */
-    protected function substrCount($haystack, $needle, $offset, $length) {
+    protected function substrCount($haystack, $needle, $offset, $length)
+    {
         static $oldVersion;
         if ($oldVersion === null) {
             $oldVersion = version_compare(PHP_VERSION, '5.1', '<');
@@ -336,13 +368,18 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
     /**
      * Takes the inside of an HTML tag and makes an assoc array of attributes.
      *
-     * @param $string Inside of tag excluding name.
-     * @returns Assoc array of attributes.
+     * @param string $string Inside of tag excluding name.
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array Assoc array of attributes.
      */
-    public function parseAttributeString($string, $config, $context) {
-        $string = (string) $string; // quick typecast
+    public function parseAttributeString($string, $config, $context)
+    {
+        $string = (string)$string; // quick typecast
 
-        if ($string == '') return array(); // no attributes
+        if ($string == '') {
+            return array();
+        } // no attributes
 
         $e = false;
         if ($config->get('Core.CollectErrors')) {
@@ -361,42 +398,50 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
             list($key, $quoted_value) = explode('=', $string);
             $quoted_value = trim($quoted_value);
             if (!$key) {
-                if ($e) $e->send(E_ERROR, 'Lexer: Missing attribute key');
+                if ($e) {
+                    $e->send(E_ERROR, 'Lexer: Missing attribute key');
+                }
                 return array();
             }
-            if (!$quoted_value) return array($key => '');
+            if (!$quoted_value) {
+                return array($key => '');
+            }
             $first_char = @$quoted_value[0];
-            $last_char  = @$quoted_value[strlen($quoted_value)-1];
+            $last_char = @$quoted_value[strlen($quoted_value) - 1];
 
             $same_quote = ($first_char == $last_char);
             $open_quote = ($first_char == '"' || $first_char == "'");
 
-            if ( $same_quote && $open_quote) {
+            if ($same_quote && $open_quote) {
                 // well behaved
                 $value = substr($quoted_value, 1, strlen($quoted_value) - 2);
             } else {
                 // not well behaved
                 if ($open_quote) {
-                    if ($e) $e->send(E_ERROR, 'Lexer: Missing end quote');
+                    if ($e) {
+                        $e->send(E_ERROR, 'Lexer: Missing end quote');
+                    }
                     $value = substr($quoted_value, 1);
                 } else {
                     $value = $quoted_value;
                 }
             }
-            if ($value === false) $value = '';
+            if ($value === false) {
+                $value = '';
+            }
             return array($key => $this->parseData($value));
         }
 
         // setup loop environment
-        $array  = array(); // return assoc array of attributes
+        $array = array(); // return assoc array of attributes
         $cursor = 0; // current position in string (moves forward)
-        $size   = strlen($string); // size of the string (stays the same)
+        $size = strlen($string); // size of the string (stays the same)
 
         // if we have unquoted attributes, the parser expects a terminating
         // space, so let's guarantee that there's always a terminating space.
         $string .= ' ';
 
-        while(true) {
+        while (true) {
 
             if ($cursor >= $size) {
                 break;
@@ -415,7 +460,9 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
             $key = substr($string, $key_begin, $key_end - $key_begin);
 
             if (!$key) {
-                if ($e) $e->send(E_ERROR, 'Lexer: Missing attribute key');
+                if ($e) {
+                    $e->send(E_ERROR, 'Lexer: Missing attribute key');
+                }
                 $cursor += strcspn($string, $this->_whitespace, $cursor + 1); // prevent infinite loop
                 continue; // empty key
             }
@@ -467,24 +514,25 @@ class HTMLPurifier_Lexer_DirectLex extends HTMLPurifier_Lexer
                 }
 
                 $value = substr($string, $value_begin, $value_end - $value_begin);
-                if ($value === false) $value = '';
+                if ($value === false) {
+                    $value = '';
+                }
                 $array[$key] = $this->parseData($value);
                 $cursor++;
-
             } else {
                 // boolattr
                 if ($key !== '') {
                     $array[$key] = $key;
                 } else {
                     // purely theoretical
-                    if ($e) $e->send(E_ERROR, 'Lexer: Missing attribute key');
+                    if ($e) {
+                        $e->send(E_ERROR, 'Lexer: Missing attribute key');
+                    }
                 }
-
             }
         }
         return $array;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Lexer/PH5P.php
+++ b/library/HTMLPurifier/Lexer/PH5P.php
@@ -3,16 +3,23 @@
 /**
  * Experimental HTML5-based parser using Jeroen van der Meer's PH5P library.
  * Occupies space in the HTML5 pseudo-namespace, which may cause conflicts.
- * 
+ *
  * @note
  *    Recent changes to PHP's DOM extension have resulted in some fatal
  *    error conditions with the original version of PH5P. Pending changes,
- *    this lexer will punt to DirectLex if DOM throughs an exception.
+ *    this lexer will punt to DirectLex if DOM throws an exception.
  */
 
-class HTMLPurifier_Lexer_PH5P extends HTMLPurifier_Lexer_DOMLex {
-    
-    public function tokenizeHTML($html, $config, $context) {
+class HTMLPurifier_Lexer_PH5P extends HTMLPurifier_Lexer_DOMLex
+{
+    /**
+     * @param string $html
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return HTMLPurifier_Token[]
+     */
+    public function tokenizeHTML($html, $config, $context)
+    {
         $new_html = $this->normalize($html, $config, $context);
         $new_html = $this->wrapHTML($new_html, $config, $context);
         try {
@@ -27,40 +34,42 @@ class HTMLPurifier_Lexer_PH5P extends HTMLPurifier_Lexer_DOMLex {
         $tokens = array();
         $this->tokenizeDOM(
             $doc->getElementsByTagName('html')->item(0)-> // <html>
-                  getElementsByTagName('body')->item(0)-> //   <body>
-                  getElementsByTagName('div')->item(0)    //     <div>
-            , $tokens);
+                getElementsByTagName('body')->item(0)-> //   <body>
+                getElementsByTagName('div')->item(0) //     <div>
+            ,
+            $tokens
+        );
         return $tokens;
     }
-    
 }
 
 /*
 
-Copyright 2007 Jeroen van der Meer <http://jero.net/> 
+Copyright 2007 Jeroen van der Meer <http://jero.net/>
 
-Permission is hereby granted, free of charge, to any person obtaining a 
-copy of this software and associated documentation files (the 
-"Software"), to deal in the Software without restriction, including 
-without limitation the rights to use, copy, modify, merge, publish, 
-distribute, sublicense, and/or sell copies of the Software, and to 
-permit persons to whom the Software is furnished to do so, subject to 
-the following conditions: 
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-The above copyright notice and this permission notice shall be included 
-in all copies or substantial portions of the Software. 
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 */
 
-class HTML5 {
+class HTML5
+{
     private $data;
     private $char;
     private $EOF;
@@ -69,89 +78,418 @@ class HTML5 {
     private $token;
     private $content_model;
     private $escape = false;
-    private $entities = array('AElig;','AElig','AMP;','AMP','Aacute;','Aacute',
-    'Acirc;','Acirc','Agrave;','Agrave','Alpha;','Aring;','Aring','Atilde;',
-    'Atilde','Auml;','Auml','Beta;','COPY;','COPY','Ccedil;','Ccedil','Chi;',
-    'Dagger;','Delta;','ETH;','ETH','Eacute;','Eacute','Ecirc;','Ecirc','Egrave;',
-    'Egrave','Epsilon;','Eta;','Euml;','Euml','GT;','GT','Gamma;','Iacute;',
-    'Iacute','Icirc;','Icirc','Igrave;','Igrave','Iota;','Iuml;','Iuml','Kappa;',
-    'LT;','LT','Lambda;','Mu;','Ntilde;','Ntilde','Nu;','OElig;','Oacute;',
-    'Oacute','Ocirc;','Ocirc','Ograve;','Ograve','Omega;','Omicron;','Oslash;',
-    'Oslash','Otilde;','Otilde','Ouml;','Ouml','Phi;','Pi;','Prime;','Psi;',
-    'QUOT;','QUOT','REG;','REG','Rho;','Scaron;','Sigma;','THORN;','THORN',
-    'TRADE;','Tau;','Theta;','Uacute;','Uacute','Ucirc;','Ucirc','Ugrave;',
-    'Ugrave','Upsilon;','Uuml;','Uuml','Xi;','Yacute;','Yacute','Yuml;','Zeta;',
-    'aacute;','aacute','acirc;','acirc','acute;','acute','aelig;','aelig',
-    'agrave;','agrave','alefsym;','alpha;','amp;','amp','and;','ang;','apos;',
-    'aring;','aring','asymp;','atilde;','atilde','auml;','auml','bdquo;','beta;',
-    'brvbar;','brvbar','bull;','cap;','ccedil;','ccedil','cedil;','cedil',
-    'cent;','cent','chi;','circ;','clubs;','cong;','copy;','copy','crarr;',
-    'cup;','curren;','curren','dArr;','dagger;','darr;','deg;','deg','delta;',
-    'diams;','divide;','divide','eacute;','eacute','ecirc;','ecirc','egrave;',
-    'egrave','empty;','emsp;','ensp;','epsilon;','equiv;','eta;','eth;','eth',
-    'euml;','euml','euro;','exist;','fnof;','forall;','frac12;','frac12',
-    'frac14;','frac14','frac34;','frac34','frasl;','gamma;','ge;','gt;','gt',
-    'hArr;','harr;','hearts;','hellip;','iacute;','iacute','icirc;','icirc',
-    'iexcl;','iexcl','igrave;','igrave','image;','infin;','int;','iota;',
-    'iquest;','iquest','isin;','iuml;','iuml','kappa;','lArr;','lambda;','lang;',
-    'laquo;','laquo','larr;','lceil;','ldquo;','le;','lfloor;','lowast;','loz;',
-    'lrm;','lsaquo;','lsquo;','lt;','lt','macr;','macr','mdash;','micro;','micro',
-    'middot;','middot','minus;','mu;','nabla;','nbsp;','nbsp','ndash;','ne;',
-    'ni;','not;','not','notin;','nsub;','ntilde;','ntilde','nu;','oacute;',
-    'oacute','ocirc;','ocirc','oelig;','ograve;','ograve','oline;','omega;',
-    'omicron;','oplus;','or;','ordf;','ordf','ordm;','ordm','oslash;','oslash',
-    'otilde;','otilde','otimes;','ouml;','ouml','para;','para','part;','permil;',
-    'perp;','phi;','pi;','piv;','plusmn;','plusmn','pound;','pound','prime;',
-    'prod;','prop;','psi;','quot;','quot','rArr;','radic;','rang;','raquo;',
-    'raquo','rarr;','rceil;','rdquo;','real;','reg;','reg','rfloor;','rho;',
-    'rlm;','rsaquo;','rsquo;','sbquo;','scaron;','sdot;','sect;','sect','shy;',
-    'shy','sigma;','sigmaf;','sim;','spades;','sub;','sube;','sum;','sup1;',
-    'sup1','sup2;','sup2','sup3;','sup3','sup;','supe;','szlig;','szlig','tau;',
-    'there4;','theta;','thetasym;','thinsp;','thorn;','thorn','tilde;','times;',
-    'times','trade;','uArr;','uacute;','uacute','uarr;','ucirc;','ucirc',
-    'ugrave;','ugrave','uml;','uml','upsih;','upsilon;','uuml;','uuml','weierp;',
-    'xi;','yacute;','yacute','yen;','yen','yuml;','yuml','zeta;','zwj;','zwnj;');
+    private $entities = array(
+        'AElig;',
+        'AElig',
+        'AMP;',
+        'AMP',
+        'Aacute;',
+        'Aacute',
+        'Acirc;',
+        'Acirc',
+        'Agrave;',
+        'Agrave',
+        'Alpha;',
+        'Aring;',
+        'Aring',
+        'Atilde;',
+        'Atilde',
+        'Auml;',
+        'Auml',
+        'Beta;',
+        'COPY;',
+        'COPY',
+        'Ccedil;',
+        'Ccedil',
+        'Chi;',
+        'Dagger;',
+        'Delta;',
+        'ETH;',
+        'ETH',
+        'Eacute;',
+        'Eacute',
+        'Ecirc;',
+        'Ecirc',
+        'Egrave;',
+        'Egrave',
+        'Epsilon;',
+        'Eta;',
+        'Euml;',
+        'Euml',
+        'GT;',
+        'GT',
+        'Gamma;',
+        'Iacute;',
+        'Iacute',
+        'Icirc;',
+        'Icirc',
+        'Igrave;',
+        'Igrave',
+        'Iota;',
+        'Iuml;',
+        'Iuml',
+        'Kappa;',
+        'LT;',
+        'LT',
+        'Lambda;',
+        'Mu;',
+        'Ntilde;',
+        'Ntilde',
+        'Nu;',
+        'OElig;',
+        'Oacute;',
+        'Oacute',
+        'Ocirc;',
+        'Ocirc',
+        'Ograve;',
+        'Ograve',
+        'Omega;',
+        'Omicron;',
+        'Oslash;',
+        'Oslash',
+        'Otilde;',
+        'Otilde',
+        'Ouml;',
+        'Ouml',
+        'Phi;',
+        'Pi;',
+        'Prime;',
+        'Psi;',
+        'QUOT;',
+        'QUOT',
+        'REG;',
+        'REG',
+        'Rho;',
+        'Scaron;',
+        'Sigma;',
+        'THORN;',
+        'THORN',
+        'TRADE;',
+        'Tau;',
+        'Theta;',
+        'Uacute;',
+        'Uacute',
+        'Ucirc;',
+        'Ucirc',
+        'Ugrave;',
+        'Ugrave',
+        'Upsilon;',
+        'Uuml;',
+        'Uuml',
+        'Xi;',
+        'Yacute;',
+        'Yacute',
+        'Yuml;',
+        'Zeta;',
+        'aacute;',
+        'aacute',
+        'acirc;',
+        'acirc',
+        'acute;',
+        'acute',
+        'aelig;',
+        'aelig',
+        'agrave;',
+        'agrave',
+        'alefsym;',
+        'alpha;',
+        'amp;',
+        'amp',
+        'and;',
+        'ang;',
+        'apos;',
+        'aring;',
+        'aring',
+        'asymp;',
+        'atilde;',
+        'atilde',
+        'auml;',
+        'auml',
+        'bdquo;',
+        'beta;',
+        'brvbar;',
+        'brvbar',
+        'bull;',
+        'cap;',
+        'ccedil;',
+        'ccedil',
+        'cedil;',
+        'cedil',
+        'cent;',
+        'cent',
+        'chi;',
+        'circ;',
+        'clubs;',
+        'cong;',
+        'copy;',
+        'copy',
+        'crarr;',
+        'cup;',
+        'curren;',
+        'curren',
+        'dArr;',
+        'dagger;',
+        'darr;',
+        'deg;',
+        'deg',
+        'delta;',
+        'diams;',
+        'divide;',
+        'divide',
+        'eacute;',
+        'eacute',
+        'ecirc;',
+        'ecirc',
+        'egrave;',
+        'egrave',
+        'empty;',
+        'emsp;',
+        'ensp;',
+        'epsilon;',
+        'equiv;',
+        'eta;',
+        'eth;',
+        'eth',
+        'euml;',
+        'euml',
+        'euro;',
+        'exist;',
+        'fnof;',
+        'forall;',
+        'frac12;',
+        'frac12',
+        'frac14;',
+        'frac14',
+        'frac34;',
+        'frac34',
+        'frasl;',
+        'gamma;',
+        'ge;',
+        'gt;',
+        'gt',
+        'hArr;',
+        'harr;',
+        'hearts;',
+        'hellip;',
+        'iacute;',
+        'iacute',
+        'icirc;',
+        'icirc',
+        'iexcl;',
+        'iexcl',
+        'igrave;',
+        'igrave',
+        'image;',
+        'infin;',
+        'int;',
+        'iota;',
+        'iquest;',
+        'iquest',
+        'isin;',
+        'iuml;',
+        'iuml',
+        'kappa;',
+        'lArr;',
+        'lambda;',
+        'lang;',
+        'laquo;',
+        'laquo',
+        'larr;',
+        'lceil;',
+        'ldquo;',
+        'le;',
+        'lfloor;',
+        'lowast;',
+        'loz;',
+        'lrm;',
+        'lsaquo;',
+        'lsquo;',
+        'lt;',
+        'lt',
+        'macr;',
+        'macr',
+        'mdash;',
+        'micro;',
+        'micro',
+        'middot;',
+        'middot',
+        'minus;',
+        'mu;',
+        'nabla;',
+        'nbsp;',
+        'nbsp',
+        'ndash;',
+        'ne;',
+        'ni;',
+        'not;',
+        'not',
+        'notin;',
+        'nsub;',
+        'ntilde;',
+        'ntilde',
+        'nu;',
+        'oacute;',
+        'oacute',
+        'ocirc;',
+        'ocirc',
+        'oelig;',
+        'ograve;',
+        'ograve',
+        'oline;',
+        'omega;',
+        'omicron;',
+        'oplus;',
+        'or;',
+        'ordf;',
+        'ordf',
+        'ordm;',
+        'ordm',
+        'oslash;',
+        'oslash',
+        'otilde;',
+        'otilde',
+        'otimes;',
+        'ouml;',
+        'ouml',
+        'para;',
+        'para',
+        'part;',
+        'permil;',
+        'perp;',
+        'phi;',
+        'pi;',
+        'piv;',
+        'plusmn;',
+        'plusmn',
+        'pound;',
+        'pound',
+        'prime;',
+        'prod;',
+        'prop;',
+        'psi;',
+        'quot;',
+        'quot',
+        'rArr;',
+        'radic;',
+        'rang;',
+        'raquo;',
+        'raquo',
+        'rarr;',
+        'rceil;',
+        'rdquo;',
+        'real;',
+        'reg;',
+        'reg',
+        'rfloor;',
+        'rho;',
+        'rlm;',
+        'rsaquo;',
+        'rsquo;',
+        'sbquo;',
+        'scaron;',
+        'sdot;',
+        'sect;',
+        'sect',
+        'shy;',
+        'shy',
+        'sigma;',
+        'sigmaf;',
+        'sim;',
+        'spades;',
+        'sub;',
+        'sube;',
+        'sum;',
+        'sup1;',
+        'sup1',
+        'sup2;',
+        'sup2',
+        'sup3;',
+        'sup3',
+        'sup;',
+        'supe;',
+        'szlig;',
+        'szlig',
+        'tau;',
+        'there4;',
+        'theta;',
+        'thetasym;',
+        'thinsp;',
+        'thorn;',
+        'thorn',
+        'tilde;',
+        'times;',
+        'times',
+        'trade;',
+        'uArr;',
+        'uacute;',
+        'uacute',
+        'uarr;',
+        'ucirc;',
+        'ucirc',
+        'ugrave;',
+        'ugrave',
+        'uml;',
+        'uml',
+        'upsih;',
+        'upsilon;',
+        'uuml;',
+        'uuml',
+        'weierp;',
+        'xi;',
+        'yacute;',
+        'yacute',
+        'yen;',
+        'yen',
+        'yuml;',
+        'yuml',
+        'zeta;',
+        'zwj;',
+        'zwnj;'
+    );
 
-    const PCDATA    = 0;
-    const RCDATA    = 1;
-    const CDATA     = 2;
+    const PCDATA = 0;
+    const RCDATA = 1;
+    const CDATA = 2;
     const PLAINTEXT = 3;
 
-    const DOCTYPE  = 0;
+    const DOCTYPE = 0;
     const STARTTAG = 1;
-    const ENDTAG   = 2;
-    const COMMENT  = 3;
+    const ENDTAG = 2;
+    const COMMENT = 3;
     const CHARACTR = 4;
-    const EOF      = 5;
+    const EOF = 5;
 
-    public function __construct($data) {
-
+    public function __construct($data)
+    {
         $this->data = $data;
         $this->char = -1;
-        $this->EOF  = strlen($data);
+        $this->EOF = strlen($data);
         $this->tree = new HTML5TreeConstructer;
         $this->content_model = self::PCDATA;
 
         $this->state = 'data';
 
-        while($this->state !== null) {
-            $this->{$this->state.'State'}();
+        while ($this->state !== null) {
+            $this->{$this->state . 'State'}();
         }
     }
 
-    public function save() {
+    public function save()
+    {
         return $this->tree->save();
     }
 
-    private function char() {
+    private function char()
+    {
         return ($this->char < $this->EOF)
             ? $this->data[$this->char]
             : false;
     }
 
-    private function character($s, $l = 0) {
-        if($s + $l < $this->EOF) {
-            if($l === 0) {
+    private function character($s, $l = 0)
+    {
+        if ($s + $l < $this->EOF) {
+            if ($l === 0) {
                 return $this->data[$s];
             } else {
                 return substr($this->data, $s, $l);
@@ -159,46 +497,52 @@ class HTML5 {
         }
     }
 
-    private function characters($char_class, $start) {
-        return preg_replace('#^(['.$char_class.']+).*#s', '\\1', substr($this->data, $start));
+    private function characters($char_class, $start)
+    {
+        return preg_replace('#^([' . $char_class . ']+).*#s', '\\1', substr($this->data, $start));
     }
 
-    private function dataState() {
+    private function dataState()
+    {
         // Consume the next input character
         $this->char++;
         $char = $this->char();
 
-        if($char === '&' && ($this->content_model === self::PCDATA || $this->content_model === self::RCDATA)) {
+        if ($char === '&' && ($this->content_model === self::PCDATA || $this->content_model === self::RCDATA)) {
             /* U+0026 AMPERSAND (&)
             When the content model flag is set to one of the PCDATA or RCDATA
             states: switch to the entity data state. Otherwise: treat it as per
             the "anything else"    entry below. */
             $this->state = 'entityData';
 
-        } elseif($char === '-') {
+        } elseif ($char === '-') {
             /* If the content model flag is set to either the RCDATA state or
             the CDATA state, and the escape flag is false, and there are at
             least three characters before this one in the input stream, and the
             last four characters in the input stream, including this one, are
             U+003C LESS-THAN SIGN, U+0021 EXCLAMATION MARK, U+002D HYPHEN-MINUS,
             and U+002D HYPHEN-MINUS ("<!--"), then set the escape flag to true. */
-            if(($this->content_model === self::RCDATA || $this->content_model ===
-            self::CDATA) && $this->escape === false &&
-            $this->char >= 3 && $this->character($this->char - 4, 4) === '<!--') {
+            if (($this->content_model === self::RCDATA || $this->content_model ===
+                    self::CDATA) && $this->escape === false &&
+                $this->char >= 3 && $this->character($this->char - 4, 4) === '<!--'
+            ) {
                 $this->escape = true;
             }
 
             /* In any case, emit the input character as a character token. Stay
             in the data state. */
-            $this->emitToken(array(
-                'type' => self::CHARACTR,
-                'data' => $char
-            ));
+            $this->emitToken(
+                array(
+                    'type' => self::CHARACTR,
+                    'data' => $char
+                )
+            );
 
-        /* U+003C LESS-THAN SIGN (<) */
-        } elseif($char === '<' && ($this->content_model === self::PCDATA ||
-        (($this->content_model === self::RCDATA ||
-        $this->content_model === self::CDATA) && $this->escape === false))) {
+            /* U+003C LESS-THAN SIGN (<) */
+        } elseif ($char === '<' && ($this->content_model === self::PCDATA ||
+                (($this->content_model === self::RCDATA ||
+                        $this->content_model === self::CDATA) && $this->escape === false))
+        ) {
             /* When the content model flag is set to the PCDATA state: switch
             to the tag open state.
 
@@ -209,39 +553,44 @@ class HTML5 {
             Otherwise: treat it as per the "anything else" entry below. */
             $this->state = 'tagOpen';
 
-        /* U+003E GREATER-THAN SIGN (>) */
-        } elseif($char === '>') {
+            /* U+003E GREATER-THAN SIGN (>) */
+        } elseif ($char === '>') {
             /* If the content model flag is set to either the RCDATA state or
             the CDATA state, and the escape flag is true, and the last three
             characters in the input stream including this one are U+002D
             HYPHEN-MINUS, U+002D HYPHEN-MINUS, U+003E GREATER-THAN SIGN ("-->"),
             set the escape flag to false. */
-            if(($this->content_model === self::RCDATA ||
-            $this->content_model === self::CDATA) && $this->escape === true &&
-            $this->character($this->char, 3) === '-->') {
+            if (($this->content_model === self::RCDATA ||
+                    $this->content_model === self::CDATA) && $this->escape === true &&
+                $this->character($this->char, 3) === '-->'
+            ) {
                 $this->escape = false;
             }
 
             /* In any case, emit the input character as a character token.
             Stay in the data state. */
-            $this->emitToken(array(
-                'type' => self::CHARACTR,
-                'data' => $char
-            ));
+            $this->emitToken(
+                array(
+                    'type' => self::CHARACTR,
+                    'data' => $char
+                )
+            );
 
-        } elseif($this->char === $this->EOF) {
+        } elseif ($this->char === $this->EOF) {
             /* EOF
             Emit an end-of-file token. */
             $this->EOF();
 
-        } elseif($this->content_model === self::PLAINTEXT) {
+        } elseif ($this->content_model === self::PLAINTEXT) {
             /* When the content model flag is set to the PLAINTEXT state
             THIS DIFFERS GREATLY FROM THE SPEC: Get the remaining characters of
             the text and emit it as a character token. */
-            $this->emitToken(array(
-                'type' => self::CHARACTR,
-                'data' => substr($this->data, $this->char)
-            ));
+            $this->emitToken(
+                array(
+                    'type' => self::CHARACTR,
+                    'data' => substr($this->data, $this->char)
+                )
+            );
 
             $this->EOF();
 
@@ -250,37 +599,43 @@ class HTML5 {
             THIS DIFFERS GREATLY FROM THE SPEC: Get as many character that
             otherwise would also be treated as a character token and emit it
             as a single character token. Stay in the data state. */
-            $len  = strcspn($this->data, '<&', $this->char);
+            $len = strcspn($this->data, '<&', $this->char);
             $char = substr($this->data, $this->char, $len);
             $this->char += $len - 1;
 
-            $this->emitToken(array(
-                'type' => self::CHARACTR,
-                'data' => $char
-            ));
+            $this->emitToken(
+                array(
+                    'type' => self::CHARACTR,
+                    'data' => $char
+                )
+            );
 
             $this->state = 'data';
         }
     }
 
-    private function entityDataState() {
+    private function entityDataState()
+    {
         // Attempt to consume an entity.
         $entity = $this->entity();
 
         // If nothing is returned, emit a U+0026 AMPERSAND character token.
         // Otherwise, emit the character token that was returned.
         $char = (!$entity) ? '&' : $entity;
-        $this->emitToken(array(
-            'type' => self::CHARACTR,
-            'data' => $char
-        ));
+        $this->emitToken(
+            array(
+                'type' => self::CHARACTR,
+                'data' => $char
+            )
+        );
 
         // Finally, switch to the data state.
         $this->state = 'data';
     }
 
-    private function tagOpenState() {
-        switch($this->content_model) {
+    private function tagOpenState()
+    {
+        switch ($this->content_model) {
             case self::RCDATA:
             case self::CDATA:
                 /* If the next input character is a U+002F SOLIDUS (/) character,
@@ -288,19 +643,21 @@ class HTML5 {
                 input character is not a U+002F SOLIDUS (/) character, emit a
                 U+003C LESS-THAN SIGN character token and switch to the data
                 state to process the next input character. */
-                if($this->character($this->char + 1) === '/') {
+                if ($this->character($this->char + 1) === '/') {
                     $this->char++;
                     $this->state = 'closeTagOpen';
 
                 } else {
-                    $this->emitToken(array(
-                        'type' => self::CHARACTR,
-                        'data' => '<'
-                    ));
+                    $this->emitToken(
+                        array(
+                            'type' => self::CHARACTR,
+                            'data' => '<'
+                        )
+                    );
 
                     $this->state = 'data';
                 }
-            break;
+                break;
 
             case self::PCDATA:
                 // If the content model flag is set to the PCDATA state
@@ -308,42 +665,44 @@ class HTML5 {
                 $this->char++;
                 $char = $this->char();
 
-                if($char === '!') {
+                if ($char === '!') {
                     /* U+0021 EXCLAMATION MARK (!)
                     Switch to the markup declaration open state. */
                     $this->state = 'markupDeclarationOpen';
 
-                } elseif($char === '/') {
+                } elseif ($char === '/') {
                     /* U+002F SOLIDUS (/)
                     Switch to the close tag open state. */
                     $this->state = 'closeTagOpen';
 
-                } elseif(preg_match('/^[A-Za-z]$/', $char)) {
+                } elseif (preg_match('/^[A-Za-z]$/', $char)) {
                     /* U+0041 LATIN LETTER A through to U+005A LATIN LETTER Z
                     Create a new start tag token, set its tag name to the lowercase
                     version of the input character (add 0x0020 to the character's code
                     point), then switch to the tag name state. (Don't emit the token
                     yet; further details will be filled in before it is emitted.) */
                     $this->token = array(
-                        'name'  => strtolower($char),
-                        'type'  => self::STARTTAG,
-                        'attr'  => array()
+                        'name' => strtolower($char),
+                        'type' => self::STARTTAG,
+                        'attr' => array()
                     );
 
                     $this->state = 'tagName';
 
-                } elseif($char === '>') {
+                } elseif ($char === '>') {
                     /* U+003E GREATER-THAN SIGN (>)
                     Parse error. Emit a U+003C LESS-THAN SIGN character token and a
                     U+003E GREATER-THAN SIGN character token. Switch to the data state. */
-                    $this->emitToken(array(
-                        'type' => self::CHARACTR,
-                        'data' => '<>'
-                    ));
+                    $this->emitToken(
+                        array(
+                            'type' => self::CHARACTR,
+                            'data' => '<>'
+                        )
+                    );
 
                     $this->state = 'data';
 
-                } elseif($char === '?') {
+                } elseif ($char === '?') {
                     /* U+003F QUESTION MARK (?)
                     Parse error. Switch to the bogus comment state. */
                     $this->state = 'bogusComment';
@@ -352,25 +711,31 @@ class HTML5 {
                     /* Anything else
                     Parse error. Emit a U+003C LESS-THAN SIGN character token and
                     reconsume the current input character in the data state. */
-                    $this->emitToken(array(
-                        'type' => self::CHARACTR,
-                        'data' => '<'
-                    ));
+                    $this->emitToken(
+                        array(
+                            'type' => self::CHARACTR,
+                            'data' => '<'
+                        )
+                    );
 
                     $this->char--;
                     $this->state = 'data';
                 }
-            break;
+                break;
         }
     }
 
-    private function closeTagOpenState() {
+    private function closeTagOpenState()
+    {
         $next_node = strtolower($this->characters('A-Za-z', $this->char + 1));
         $the_same = count($this->tree->stack) > 0 && $next_node === end($this->tree->stack)->nodeName;
 
-        if(($this->content_model === self::RCDATA || $this->content_model === self::CDATA) &&
-        (!$the_same || ($the_same && (!preg_match('/[\t\n\x0b\x0c >\/]/',
-        $this->character($this->char + 1 + strlen($next_node))) || $this->EOF === $this->char)))) {
+        if (($this->content_model === self::RCDATA || $this->content_model === self::CDATA) &&
+            (!$the_same || ($the_same && (!preg_match(
+                            '/[\t\n\x0b\x0c >\/]/',
+                            $this->character($this->char + 1 + strlen($next_node))
+                        ) || $this->EOF === $this->char)))
+        ) {
             /* If the content model flag is set to the RCDATA or CDATA states then
             examine the next few characters. If they do not match the tag name of
             the last start tag token emitted (case insensitively), or if they do but
@@ -386,10 +751,12 @@ class HTML5 {
             ...then there is a parse error. Emit a U+003C LESS-THAN SIGN character
             token, a U+002F SOLIDUS character token, and switch to the data state
             to process the next input character. */
-            $this->emitToken(array(
-                'type' => self::CHARACTR,
-                'data' => '</'
-            ));
+            $this->emitToken(
+                array(
+                    'type' => self::CHARACTR,
+                    'data' => '</'
+                )
+            );
 
             $this->state = 'data';
 
@@ -400,32 +767,34 @@ class HTML5 {
             $this->char++;
             $char = $this->char();
 
-            if(preg_match('/^[A-Za-z]$/', $char)) {
+            if (preg_match('/^[A-Za-z]$/', $char)) {
                 /* U+0041 LATIN LETTER A through to U+005A LATIN LETTER Z
                 Create a new end tag token, set its tag name to the lowercase version
                 of the input character (add 0x0020 to the character's code point), then
                 switch to the tag name state. (Don't emit the token yet; further details
                 will be filled in before it is emitted.) */
                 $this->token = array(
-                    'name'  => strtolower($char),
-                    'type'  => self::ENDTAG
+                    'name' => strtolower($char),
+                    'type' => self::ENDTAG
                 );
 
                 $this->state = 'tagName';
 
-            } elseif($char === '>') {
+            } elseif ($char === '>') {
                 /* U+003E GREATER-THAN SIGN (>)
                 Parse error. Switch to the data state. */
                 $this->state = 'data';
 
-            } elseif($this->char === $this->EOF) {
+            } elseif ($this->char === $this->EOF) {
                 /* EOF
                 Parse error. Emit a U+003C LESS-THAN SIGN character token and a U+002F
                 SOLIDUS character token. Reconsume the EOF character in the data state. */
-                $this->emitToken(array(
-                    'type' => self::CHARACTR,
-                    'data' => '</'
-                ));
+                $this->emitToken(
+                    array(
+                        'type' => self::CHARACTR,
+                        'data' => '</'
+                    )
+                );
 
                 $this->char--;
                 $this->state = 'data';
@@ -437,12 +806,13 @@ class HTML5 {
         }
     }
 
-    private function tagNameState() {
+    private function tagNameState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
 
-        if(preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
+        if (preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
             /* U+0009 CHARACTER TABULATION
             U+000A LINE FEED (LF)
             U+000B LINE TABULATION
@@ -451,13 +821,13 @@ class HTML5 {
             Switch to the before attribute name state. */
             $this->state = 'beforeAttributeName';
 
-        } elseif($char === '>') {
+        } elseif ($char === '>') {
             /* U+003E GREATER-THAN SIGN (>)
             Emit the current tag token. Switch to the data state. */
             $this->emitToken($this->token);
             $this->state = 'data';
 
-        } elseif($this->char === $this->EOF) {
+        } elseif ($this->char === $this->EOF) {
             /* EOF
             Parse error. Emit the current tag token. Reconsume the EOF
             character in the data state. */
@@ -466,7 +836,7 @@ class HTML5 {
             $this->char--;
             $this->state = 'data';
 
-        } elseif($char === '/') {
+        } elseif ($char === '/') {
             /* U+002F SOLIDUS (/)
             Parse error unless this is a permitted slash. Switch to the before
             attribute name state. */
@@ -481,12 +851,13 @@ class HTML5 {
         }
     }
 
-    private function beforeAttributeNameState() {
+    private function beforeAttributeNameState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
 
-        if(preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
+        if (preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
             /* U+0009 CHARACTER TABULATION
             U+000A LINE FEED (LF)
             U+000B LINE TABULATION
@@ -495,19 +866,19 @@ class HTML5 {
             Stay in the before attribute name state. */
             $this->state = 'beforeAttributeName';
 
-        } elseif($char === '>') {
+        } elseif ($char === '>') {
             /* U+003E GREATER-THAN SIGN (>)
             Emit the current tag token. Switch to the data state. */
             $this->emitToken($this->token);
             $this->state = 'data';
 
-        } elseif($char === '/') {
+        } elseif ($char === '/') {
             /* U+002F SOLIDUS (/)
             Parse error unless this is a permitted slash. Stay in the before
             attribute name state. */
             $this->state = 'beforeAttributeName';
 
-        } elseif($this->char === $this->EOF) {
+        } elseif ($this->char === $this->EOF) {
             /* EOF
             Parse error. Emit the current tag token. Reconsume the EOF
             character in the data state. */
@@ -522,7 +893,7 @@ class HTML5 {
             name to the current input character, and its value to the empty string.
             Switch to the attribute name state. */
             $this->token['attr'][] = array(
-                'name'  => strtolower($char),
+                'name' => strtolower($char),
                 'value' => null
             );
 
@@ -530,12 +901,13 @@ class HTML5 {
         }
     }
 
-    private function attributeNameState() {
+    private function attributeNameState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
 
-        if(preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
+        if (preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
             /* U+0009 CHARACTER TABULATION
             U+000A LINE FEED (LF)
             U+000B LINE TABULATION
@@ -544,24 +916,24 @@ class HTML5 {
             Stay in the before attribute name state. */
             $this->state = 'afterAttributeName';
 
-        } elseif($char === '=') {
+        } elseif ($char === '=') {
             /* U+003D EQUALS SIGN (=)
             Switch to the before attribute value state. */
             $this->state = 'beforeAttributeValue';
 
-        } elseif($char === '>') {
+        } elseif ($char === '>') {
             /* U+003E GREATER-THAN SIGN (>)
             Emit the current tag token. Switch to the data state. */
             $this->emitToken($this->token);
             $this->state = 'data';
 
-        } elseif($char === '/' && $this->character($this->char + 1) !== '>') {
+        } elseif ($char === '/' && $this->character($this->char + 1) !== '>') {
             /* U+002F SOLIDUS (/)
             Parse error unless this is a permitted slash. Switch to the before
             attribute name state. */
             $this->state = 'beforeAttributeName';
 
-        } elseif($this->char === $this->EOF) {
+        } elseif ($this->char === $this->EOF) {
             /* EOF
             Parse error. Emit the current tag token. Reconsume the EOF
             character in the data state. */
@@ -581,12 +953,13 @@ class HTML5 {
         }
     }
 
-    private function afterAttributeNameState() {
+    private function afterAttributeNameState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
 
-        if(preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
+        if (preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
             /* U+0009 CHARACTER TABULATION
             U+000A LINE FEED (LF)
             U+000B LINE TABULATION
@@ -595,24 +968,24 @@ class HTML5 {
             Stay in the after attribute name state. */
             $this->state = 'afterAttributeName';
 
-        } elseif($char === '=') {
+        } elseif ($char === '=') {
             /* U+003D EQUALS SIGN (=)
             Switch to the before attribute value state. */
             $this->state = 'beforeAttributeValue';
 
-        } elseif($char === '>') {
+        } elseif ($char === '>') {
             /* U+003E GREATER-THAN SIGN (>)
             Emit the current tag token. Switch to the data state. */
             $this->emitToken($this->token);
             $this->state = 'data';
 
-        } elseif($char === '/' && $this->character($this->char + 1) !== '>') {
+        } elseif ($char === '/' && $this->character($this->char + 1) !== '>') {
             /* U+002F SOLIDUS (/)
             Parse error unless this is a permitted slash. Switch to the
             before attribute name state. */
             $this->state = 'beforeAttributeName';
 
-        } elseif($this->char === $this->EOF) {
+        } elseif ($this->char === $this->EOF) {
             /* EOF
             Parse error. Emit the current tag token. Reconsume the EOF
             character in the data state. */
@@ -627,7 +1000,7 @@ class HTML5 {
             name to the current input character, and its value to the empty string.
             Switch to the attribute name state. */
             $this->token['attr'][] = array(
-                'name'  => strtolower($char),
+                'name' => strtolower($char),
                 'value' => null
             );
 
@@ -635,12 +1008,13 @@ class HTML5 {
         }
     }
 
-    private function beforeAttributeValueState() {
+    private function beforeAttributeValueState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
 
-        if(preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
+        if (preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
             /* U+0009 CHARACTER TABULATION
             U+000A LINE FEED (LF)
             U+000B LINE TABULATION
@@ -649,24 +1023,24 @@ class HTML5 {
             Stay in the before attribute value state. */
             $this->state = 'beforeAttributeValue';
 
-        } elseif($char === '"') {
+        } elseif ($char === '"') {
             /* U+0022 QUOTATION MARK (")
             Switch to the attribute value (double-quoted) state. */
             $this->state = 'attributeValueDoubleQuoted';
 
-        } elseif($char === '&') {
+        } elseif ($char === '&') {
             /* U+0026 AMPERSAND (&)
             Switch to the attribute value (unquoted) state and reconsume
             this input character. */
             $this->char--;
             $this->state = 'attributeValueUnquoted';
 
-        } elseif($char === '\'') {
+        } elseif ($char === '\'') {
             /* U+0027 APOSTROPHE (')
             Switch to the attribute value (single-quoted) state. */
             $this->state = 'attributeValueSingleQuoted';
 
-        } elseif($char === '>') {
+        } elseif ($char === '>') {
             /* U+003E GREATER-THAN SIGN (>)
             Emit the current tag token. Switch to the data state. */
             $this->emitToken($this->token);
@@ -683,22 +1057,23 @@ class HTML5 {
         }
     }
 
-    private function attributeValueDoubleQuotedState() {
+    private function attributeValueDoubleQuotedState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
 
-        if($char === '"') {
+        if ($char === '"') {
             /* U+0022 QUOTATION MARK (")
             Switch to the before attribute name state. */
             $this->state = 'beforeAttributeName';
 
-        } elseif($char === '&') {
+        } elseif ($char === '&') {
             /* U+0026 AMPERSAND (&)
             Switch to the entity in attribute value state. */
             $this->entityInAttributeValueState('double');
 
-        } elseif($this->char === $this->EOF) {
+        } elseif ($this->char === $this->EOF) {
             /* EOF
             Parse error. Emit the current tag token. Reconsume the character
             in the data state. */
@@ -718,22 +1093,23 @@ class HTML5 {
         }
     }
 
-    private function attributeValueSingleQuotedState() {
+    private function attributeValueSingleQuotedState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
 
-        if($char === '\'') {
+        if ($char === '\'') {
             /* U+0022 QUOTATION MARK (')
             Switch to the before attribute name state. */
             $this->state = 'beforeAttributeName';
 
-        } elseif($char === '&') {
+        } elseif ($char === '&') {
             /* U+0026 AMPERSAND (&)
             Switch to the entity in attribute value state. */
             $this->entityInAttributeValueState('single');
 
-        } elseif($this->char === $this->EOF) {
+        } elseif ($this->char === $this->EOF) {
             /* EOF
             Parse error. Emit the current tag token. Reconsume the character
             in the data state. */
@@ -753,12 +1129,13 @@ class HTML5 {
         }
     }
 
-    private function attributeValueUnquotedState() {
+    private function attributeValueUnquotedState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
 
-        if(preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
+        if (preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
             /* U+0009 CHARACTER TABULATION
             U+000A LINE FEED (LF)
             U+000B LINE TABULATION
@@ -767,12 +1144,12 @@ class HTML5 {
             Switch to the before attribute name state. */
             $this->state = 'beforeAttributeName';
 
-        } elseif($char === '&') {
+        } elseif ($char === '&') {
             /* U+0026 AMPERSAND (&)
             Switch to the entity in attribute value state. */
             $this->entityInAttributeValueState();
 
-        } elseif($char === '>') {
+        } elseif ($char === '>') {
             /* U+003E GREATER-THAN SIGN (>)
             Emit the current tag token. Switch to the data state. */
             $this->emitToken($this->token);
@@ -789,7 +1166,8 @@ class HTML5 {
         }
     }
 
-    private function entityInAttributeValueState() {
+    private function entityInAttributeValueState()
+    {
         // Attempt to consume an entity.
         $entity = $this->entity();
 
@@ -804,7 +1182,8 @@ class HTML5 {
         $this->token['attr'][$last]['value'] .= $char;
     }
 
-    private function bogusCommentState() {
+    private function bogusCommentState()
+    {
         /* Consume every character up to the first U+003E GREATER-THAN SIGN
         character (>) or the end of the file (EOF), whichever comes first. Emit
         a comment token whose data is the concatenation of all the characters
@@ -814,10 +1193,12 @@ class HTML5 {
         end of the file otherwise. (If the comment was started by the end of
         the file (EOF), the token is empty.) */
         $data = $this->characters('^>', $this->char);
-        $this->emitToken(array(
-            'data' => $data,
-            'type' => self::COMMENT
-        ));
+        $this->emitToken(
+            array(
+                'data' => $data,
+                'type' => self::COMMENT
+            )
+        );
 
         $this->char += strlen($data);
 
@@ -825,16 +1206,17 @@ class HTML5 {
         $this->state = 'data';
 
         /* If the end of the file was reached, reconsume the EOF character. */
-        if($this->char === $this->EOF) {
+        if ($this->char === $this->EOF) {
             $this->char = $this->EOF - 1;
         }
     }
 
-    private function markupDeclarationOpenState() {
+    private function markupDeclarationOpenState()
+    {
         /* If the next two characters are both U+002D HYPHEN-MINUS (-)
         characters, consume those two characters, create a comment token whose
         data is the empty string, and switch to the comment state. */
-        if($this->character($this->char + 1, 2) === '--') {
+        if ($this->character($this->char + 1, 2) === '--') {
             $this->char += 2;
             $this->state = 'comment';
             $this->token = array(
@@ -842,41 +1224,42 @@ class HTML5 {
                 'type' => self::COMMENT
             );
 
-        /* Otherwise if the next seven chacacters are a case-insensitive match
-        for the word "DOCTYPE", then consume those characters and switch to the
-        DOCTYPE state. */
-        } elseif(strtolower($this->character($this->char + 1, 7)) === 'doctype') {
+            /* Otherwise if the next seven chacacters are a case-insensitive match
+            for the word "DOCTYPE", then consume those characters and switch to the
+            DOCTYPE state. */
+        } elseif (strtolower($this->character($this->char + 1, 7)) === 'doctype') {
             $this->char += 7;
             $this->state = 'doctype';
 
-        /* Otherwise, is is a parse error. Switch to the bogus comment state.
-        The next character that is consumed, if any, is the first character
-        that will be in the comment. */
+            /* Otherwise, is is a parse error. Switch to the bogus comment state.
+            The next character that is consumed, if any, is the first character
+            that will be in the comment. */
         } else {
             $this->char++;
             $this->state = 'bogusComment';
         }
     }
 
-    private function commentState() {
+    private function commentState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
 
         /* U+002D HYPHEN-MINUS (-) */
-        if($char === '-') {
+        if ($char === '-') {
             /* Switch to the comment dash state  */
             $this->state = 'commentDash';
 
-        /* EOF */
-        } elseif($this->char === $this->EOF) {
+            /* EOF */
+        } elseif ($this->char === $this->EOF) {
             /* Parse error. Emit the comment token. Reconsume the EOF character
             in the data state. */
             $this->emitToken($this->token);
             $this->char--;
             $this->state = 'data';
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Append the input character to the comment token's data. Stay in
             the comment state. */
@@ -884,62 +1267,65 @@ class HTML5 {
         }
     }
 
-    private function commentDashState() {
+    private function commentDashState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
 
         /* U+002D HYPHEN-MINUS (-) */
-        if($char === '-') {
+        if ($char === '-') {
             /* Switch to the comment end state  */
             $this->state = 'commentEnd';
 
-        /* EOF */
-        } elseif($this->char === $this->EOF) {
+            /* EOF */
+        } elseif ($this->char === $this->EOF) {
             /* Parse error. Emit the comment token. Reconsume the EOF character
             in the data state. */
             $this->emitToken($this->token);
             $this->char--;
             $this->state = 'data';
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Append a U+002D HYPHEN-MINUS (-) character and the input
             character to the comment token's data. Switch to the comment state. */
-            $this->token['data'] .= '-'.$char;
+            $this->token['data'] .= '-' . $char;
             $this->state = 'comment';
         }
     }
 
-    private function commentEndState() {
+    private function commentEndState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
 
-        if($char === '>') {
+        if ($char === '>') {
             $this->emitToken($this->token);
             $this->state = 'data';
 
-        } elseif($char === '-') {
+        } elseif ($char === '-') {
             $this->token['data'] .= '-';
 
-        } elseif($this->char === $this->EOF) {
+        } elseif ($this->char === $this->EOF) {
             $this->emitToken($this->token);
             $this->char--;
             $this->state = 'data';
 
         } else {
-            $this->token['data'] .= '--'.$char;
+            $this->token['data'] .= '--' . $char;
             $this->state = 'comment';
         }
     }
 
-    private function doctypeState() {
+    private function doctypeState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
 
-        if(preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
+        if (preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
             $this->state = 'beforeDoctypeName';
 
         } else {
@@ -948,15 +1334,16 @@ class HTML5 {
         }
     }
 
-    private function beforeDoctypeNameState() {
+    private function beforeDoctypeNameState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
 
-        if(preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
+        if (preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
             // Stay in the before DOCTYPE name state.
 
-        } elseif(preg_match('/^[a-z]$/', $char)) {
+        } elseif (preg_match('/^[a-z]$/', $char)) {
             $this->token = array(
                 'name' => strtoupper($char),
                 'type' => self::DOCTYPE,
@@ -965,21 +1352,25 @@ class HTML5 {
 
             $this->state = 'doctypeName';
 
-        } elseif($char === '>') {
-            $this->emitToken(array(
-                'name' => null,
-                'type' => self::DOCTYPE,
-                'error' => true
-            ));
+        } elseif ($char === '>') {
+            $this->emitToken(
+                array(
+                    'name' => null,
+                    'type' => self::DOCTYPE,
+                    'error' => true
+                )
+            );
 
             $this->state = 'data';
 
-        } elseif($this->char === $this->EOF) {
-            $this->emitToken(array(
-                'name' => null,
-                'type' => self::DOCTYPE,
-                'error' => true
-            ));
+        } elseif ($this->char === $this->EOF) {
+            $this->emitToken(
+                array(
+                    'name' => null,
+                    'type' => self::DOCTYPE,
+                    'error' => true
+                )
+            );
 
             $this->char--;
             $this->state = 'data';
@@ -995,22 +1386,23 @@ class HTML5 {
         }
     }
 
-    private function doctypeNameState() {
+    private function doctypeNameState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
 
-        if(preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
+        if (preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
             $this->state = 'AfterDoctypeName';
 
-        } elseif($char === '>') {
+        } elseif ($char === '>') {
             $this->emitToken($this->token);
             $this->state = 'data';
 
-        } elseif(preg_match('/^[a-z]$/', $char)) {
+        } elseif (preg_match('/^[a-z]$/', $char)) {
             $this->token['name'] .= strtoupper($char);
 
-        } elseif($this->char === $this->EOF) {
+        } elseif ($this->char === $this->EOF) {
             $this->emitToken($this->token);
             $this->char--;
             $this->state = 'data';
@@ -1024,19 +1416,20 @@ class HTML5 {
             : true;
     }
 
-    private function afterDoctypeNameState() {
+    private function afterDoctypeNameState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
 
-        if(preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
+        if (preg_match('/^[\t\n\x0b\x0c ]$/', $char)) {
             // Stay in the DOCTYPE name state.
 
-        } elseif($char === '>') {
+        } elseif ($char === '>') {
             $this->emitToken($this->token);
             $this->state = 'data';
 
-        } elseif($this->char === $this->EOF) {
+        } elseif ($this->char === $this->EOF) {
             $this->emitToken($this->token);
             $this->char--;
             $this->state = 'data';
@@ -1047,16 +1440,17 @@ class HTML5 {
         }
     }
 
-    private function bogusDoctypeState() {
+    private function bogusDoctypeState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
 
-        if($char === '>') {
+        if ($char === '>') {
             $this->emitToken($this->token);
             $this->state = 'data';
 
-        } elseif($this->char === $this->EOF) {
+        } elseif ($this->char === $this->EOF) {
             $this->emitToken($this->token);
             $this->char--;
             $this->state = 'data';
@@ -1066,22 +1460,23 @@ class HTML5 {
         }
     }
 
-    private function entity() {
+    private function entity()
+    {
         $start = $this->char;
 
         // This section defines how to consume an entity. This definition is
         // used when parsing entities in text and in attributes.
 
         // The behaviour depends on the identity of the next character (the
-        // one immediately after the U+0026 AMPERSAND character): 
+        // one immediately after the U+0026 AMPERSAND character):
 
-        switch($this->character($this->char + 1)) {
+        switch ($this->character($this->char + 1)) {
             // U+0023 NUMBER SIGN (#)
             case '#':
 
                 // The behaviour further depends on the character after the
                 // U+0023 NUMBER SIGN:
-                switch($this->character($this->char + 1)) {
+                switch ($this->character($this->char + 1)) {
                     // U+0078 LATIN SMALL LETTER X
                     // U+0058 LATIN CAPITAL LETTER X
                     case 'x':
@@ -1094,7 +1489,7 @@ class HTML5 {
                         // words, 0-9, A-F, a-f).
                         $char = 1;
                         $char_class = '0-9A-Fa-f';
-                    break;
+                        break;
 
                     // Anything else
                     default:
@@ -1103,7 +1498,7 @@ class HTML5 {
                         // NINE (i.e. just 0-9).
                         $char = 0;
                         $char_class = '0-9';
-                    break;
+                        break;
                 }
 
                 // Consume as many characters as match the range of characters
@@ -1114,7 +1509,7 @@ class HTML5 {
                 $cond = strlen($e_name) > 0;
 
                 // The rest of the parsing happens bellow.
-            break;
+                break;
 
             // Anything else
             default:
@@ -1124,12 +1519,12 @@ class HTML5 {
                 $e_name = $this->characters('0-9A-Za-z;', $this->char + 1);
                 $len = strlen($e_name);
 
-                for($c = 1; $c <= $len; $c++) {
+                for ($c = 1; $c <= $len; $c++) {
                     $id = substr($e_name, 0, $c);
                     $this->char++;
 
-                    if(in_array($id, $this->entities)) {
-                        if ($e_name[$c-1] !== ';') {
+                    if (in_array($id, $this->entities)) {
+                        if ($e_name[$c - 1] !== ';') {
                             if ($c < $len && $e_name[$c] == ';') {
                                 $this->char++; // consume extra semicolon
                             }
@@ -1141,10 +1536,10 @@ class HTML5 {
 
                 $cond = isset($entity);
                 // The rest of the parsing happens bellow.
-            break;
+                break;
         }
 
-        if(!$cond) {
+        if (!$cond) {
             // If no match can be made, then this is a parse error. No
             // characters are consumed, and nothing is returned.
             $this->char = $start;
@@ -1153,81 +1548,157 @@ class HTML5 {
 
         // Return a character token for the character corresponding to the
         // entity name (as given by the second column of the entities table).
-        return html_entity_decode('&'.$entity.';', ENT_QUOTES, 'UTF-8');
+        return html_entity_decode('&' . $entity . ';', ENT_QUOTES, 'UTF-8');
     }
 
-    private function emitToken($token) {
+    private function emitToken($token)
+    {
         $emit = $this->tree->emitToken($token);
 
-        if(is_int($emit)) {
+        if (is_int($emit)) {
             $this->content_model = $emit;
 
-        } elseif($token['type'] === self::ENDTAG) {
+        } elseif ($token['type'] === self::ENDTAG) {
             $this->content_model = self::PCDATA;
         }
     }
 
-    private function EOF() {
+    private function EOF()
+    {
         $this->state = null;
-        $this->tree->emitToken(array(
-            'type' => self::EOF
-        ));
+        $this->tree->emitToken(
+            array(
+                'type' => self::EOF
+            )
+        );
     }
 }
 
-class HTML5TreeConstructer {
+class HTML5TreeConstructer
+{
     public $stack = array();
 
     private $phase;
     private $mode;
     private $dom;
     private $foster_parent = null;
-    private $a_formatting  = array();
+    private $a_formatting = array();
 
     private $head_pointer = null;
     private $form_pointer = null;
 
-    private $scoping = array('button','caption','html','marquee','object','table','td','th');
-    private $formatting = array('a','b','big','em','font','i','nobr','s','small','strike','strong','tt','u');
-    private $special = array('address','area','base','basefont','bgsound',
-    'blockquote','body','br','center','col','colgroup','dd','dir','div','dl',
-    'dt','embed','fieldset','form','frame','frameset','h1','h2','h3','h4','h5',
-    'h6','head','hr','iframe','image','img','input','isindex','li','link',
-    'listing','menu','meta','noembed','noframes','noscript','ol','optgroup',
-    'option','p','param','plaintext','pre','script','select','spacer','style',
-    'tbody','textarea','tfoot','thead','title','tr','ul','wbr');
+    private $scoping = array('button', 'caption', 'html', 'marquee', 'object', 'table', 'td', 'th');
+    private $formatting = array(
+        'a',
+        'b',
+        'big',
+        'em',
+        'font',
+        'i',
+        'nobr',
+        's',
+        'small',
+        'strike',
+        'strong',
+        'tt',
+        'u'
+    );
+    private $special = array(
+        'address',
+        'area',
+        'base',
+        'basefont',
+        'bgsound',
+        'blockquote',
+        'body',
+        'br',
+        'center',
+        'col',
+        'colgroup',
+        'dd',
+        'dir',
+        'div',
+        'dl',
+        'dt',
+        'embed',
+        'fieldset',
+        'form',
+        'frame',
+        'frameset',
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'head',
+        'hr',
+        'iframe',
+        'image',
+        'img',
+        'input',
+        'isindex',
+        'li',
+        'link',
+        'listing',
+        'menu',
+        'meta',
+        'noembed',
+        'noframes',
+        'noscript',
+        'ol',
+        'optgroup',
+        'option',
+        'p',
+        'param',
+        'plaintext',
+        'pre',
+        'script',
+        'select',
+        'spacer',
+        'style',
+        'tbody',
+        'textarea',
+        'tfoot',
+        'thead',
+        'title',
+        'tr',
+        'ul',
+        'wbr'
+    );
 
     // The different phases.
     const INIT_PHASE = 0;
     const ROOT_PHASE = 1;
     const MAIN_PHASE = 2;
-    const END_PHASE  = 3;
+    const END_PHASE = 3;
 
     // The different insertion modes for the main phase.
     const BEFOR_HEAD = 0;
-    const IN_HEAD    = 1;
+    const IN_HEAD = 1;
     const AFTER_HEAD = 2;
-    const IN_BODY    = 3;
-    const IN_TABLE   = 4;
+    const IN_BODY = 3;
+    const IN_TABLE = 4;
     const IN_CAPTION = 5;
-    const IN_CGROUP  = 6;
-    const IN_TBODY   = 7;
-    const IN_ROW     = 8;
-    const IN_CELL    = 9;
-    const IN_SELECT  = 10;
+    const IN_CGROUP = 6;
+    const IN_TBODY = 7;
+    const IN_ROW = 8;
+    const IN_CELL = 9;
+    const IN_SELECT = 10;
     const AFTER_BODY = 11;
-    const IN_FRAME   = 12;
+    const IN_FRAME = 12;
     const AFTR_FRAME = 13;
 
     // The different types of elements.
-    const SPECIAL    = 0;
-    const SCOPING    = 1;
+    const SPECIAL = 0;
+    const SCOPING = 1;
     const FORMATTING = 2;
-    const PHRASING   = 3;
+    const PHRASING = 3;
 
-    const MARKER     = 0;
+    const MARKER = 0;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->phase = self::INIT_PHASE;
         $this->mode = self::BEFOR_HEAD;
         $this->dom = new DOMDocument;
@@ -1239,16 +1710,26 @@ class HTML5TreeConstructer {
     }
 
     // Process tag tokens
-    public function emitToken($token) {
-        switch($this->phase) {
-            case self::INIT_PHASE: return $this->initPhase($token); break;
-            case self::ROOT_PHASE: return $this->rootElementPhase($token); break;
-            case self::MAIN_PHASE: return $this->mainPhase($token); break;
-            case self::END_PHASE : return $this->trailingEndPhase($token); break;
+    public function emitToken($token)
+    {
+        switch ($this->phase) {
+            case self::INIT_PHASE:
+                return $this->initPhase($token);
+                break;
+            case self::ROOT_PHASE:
+                return $this->rootElementPhase($token);
+                break;
+            case self::MAIN_PHASE:
+                return $this->mainPhase($token);
+                break;
+            case self::END_PHASE :
+                return $this->trailingEndPhase($token);
+                break;
         }
     }
 
-    private function initPhase($token) {
+    private function initPhase($token)
+    {
         /* Initially, the tree construction stage must handle each token
         emitted from the tokenisation stage as follows: */
 
@@ -1260,13 +1741,14 @@ class HTML5TreeConstructer {
             U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
             or U+0020 SPACE
         An end-of-file token */
-        if((isset($token['error']) && $token['error']) ||
-        $token['type'] === HTML5::COMMENT ||
-        $token['type'] === HTML5::STARTTAG ||
-        $token['type'] === HTML5::ENDTAG ||
-        $token['type'] === HTML5::EOF ||
-        ($token['type'] === HTML5::CHARACTR && isset($token['data']) &&
-        !preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data']))) {
+        if ((isset($token['error']) && $token['error']) ||
+            $token['type'] === HTML5::COMMENT ||
+            $token['type'] === HTML5::STARTTAG ||
+            $token['type'] === HTML5::ENDTAG ||
+            $token['type'] === HTML5::EOF ||
+            ($token['type'] === HTML5::CHARACTR && isset($token['data']) &&
+                !preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data']))
+        ) {
             /* This specification does not define how to handle this case. In
             particular, user agents may ignore the entirety of this specification
             altogether for such documents, and instead invoke special parse modes
@@ -1275,8 +1757,8 @@ class HTML5TreeConstructer {
             $this->phase = self::ROOT_PHASE;
             return $this->rootElementPhase($token);
 
-        /* A DOCTYPE token marked as being correct */
-        } elseif(isset($token['error']) && !$token['error']) {
+            /* A DOCTYPE token marked as being correct */
+        } elseif (isset($token['error']) && !$token['error']) {
             /* Append a DocumentType node to the Document  node, with the name
             attribute set to the name given in the DOCTYPE token (which will be
             "HTML"), and the other attributes specific to DocumentType objects
@@ -1287,52 +1769,58 @@ class HTML5TreeConstructer {
             stage. */
             $this->phase = self::ROOT_PHASE;
 
-        /* A character token that is one of one of U+0009 CHARACTER TABULATION,
-        U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
-        or U+0020 SPACE */
-        } elseif(isset($token['data']) && preg_match('/^[\t\n\x0b\x0c ]+$/',
-        $token['data'])) {
+            /* A character token that is one of one of U+0009 CHARACTER TABULATION,
+            U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
+            or U+0020 SPACE */
+        } elseif (isset($token['data']) && preg_match(
+                '/^[\t\n\x0b\x0c ]+$/',
+                $token['data']
+            )
+        ) {
             /* Append that character  to the Document node. */
             $text = $this->dom->createTextNode($token['data']);
             $this->dom->appendChild($text);
         }
     }
 
-    private function rootElementPhase($token) {
+    private function rootElementPhase($token)
+    {
         /* After the initial phase, as each token is emitted from the tokenisation
         stage, it must be processed as described in this section. */
 
         /* A DOCTYPE token */
-        if($token['type'] === HTML5::DOCTYPE) {
+        if ($token['type'] === HTML5::DOCTYPE) {
             // Parse error. Ignore the token.
 
-        /* A comment token */
-        } elseif($token['type'] === HTML5::COMMENT) {
+            /* A comment token */
+        } elseif ($token['type'] === HTML5::COMMENT) {
             /* Append a Comment node to the Document object with the data
             attribute set to the data given in the comment token. */
             $comment = $this->dom->createComment($token['data']);
             $this->dom->appendChild($comment);
 
-        /* A character token that is one of one of U+0009 CHARACTER TABULATION,
-        U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
-        or U+0020 SPACE */
-        } elseif($token['type'] === HTML5::CHARACTR &&
-        preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) {
+            /* A character token that is one of one of U+0009 CHARACTER TABULATION,
+            U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
+            or U+0020 SPACE */
+        } elseif ($token['type'] === HTML5::CHARACTR &&
+            preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])
+        ) {
             /* Append that character  to the Document node. */
             $text = $this->dom->createTextNode($token['data']);
             $this->dom->appendChild($text);
 
-        /* A character token that is not one of U+0009 CHARACTER TABULATION,
-            U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED
-            (FF), or U+0020 SPACE
-        A start tag token
-        An end tag token
-        An end-of-file token */
-        } elseif(($token['type'] === HTML5::CHARACTR &&
-        !preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) ||
-        $token['type'] === HTML5::STARTTAG ||
-        $token['type'] === HTML5::ENDTAG ||
-        $token['type'] === HTML5::EOF) {
+            /* A character token that is not one of U+0009 CHARACTER TABULATION,
+                U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED
+                (FF), or U+0020 SPACE
+            A start tag token
+            An end tag token
+            An end-of-file token */
+        } elseif (($token['type'] === HTML5::CHARACTR &&
+                !preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) ||
+            $token['type'] === HTML5::STARTTAG ||
+            $token['type'] === HTML5::ENDTAG ||
+            $token['type'] === HTML5::EOF
+        ) {
             /* Create an HTMLElement node with the tag name html, in the HTML
             namespace. Append it to the Document object. Switch to the main
             phase and reprocess the current token. */
@@ -1345,15 +1833,16 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function mainPhase($token) {
+    private function mainPhase($token)
+    {
         /* Tokens in the main phase must be handled as follows: */
 
         /* A DOCTYPE token */
-        if($token['type'] === HTML5::DOCTYPE) {
+        if ($token['type'] === HTML5::DOCTYPE) {
             // Parse error. Ignore the token.
 
-        /* A start tag token with the tag name "html" */
-        } elseif($token['type'] === HTML5::STARTTAG && $token['name'] === 'html') {
+            /* A start tag token with the tag name "html" */
+        } elseif ($token['type'] === HTML5::STARTTAG && $token['name'] === 'html') {
             /* If this start tag token was not the first start tag token, then
             it is a parse error. */
 
@@ -1361,59 +1850,91 @@ class HTML5TreeConstructer {
             is already present on the top element of the stack of open elements.
             If it is not, add the attribute and its corresponding value to that
             element. */
-            foreach($token['attr'] as $attr) {
-                if(!$this->stack[0]->hasAttribute($attr['name'])) {
+            foreach ($token['attr'] as $attr) {
+                if (!$this->stack[0]->hasAttribute($attr['name'])) {
                     $this->stack[0]->setAttribute($attr['name'], $attr['value']);
                 }
             }
 
-        /* An end-of-file token */
-        } elseif($token['type'] === HTML5::EOF) {
+            /* An end-of-file token */
+        } elseif ($token['type'] === HTML5::EOF) {
             /* Generate implied end tags. */
             $this->generateImpliedEndTags();
 
-        /* Anything else. */
+            /* Anything else. */
         } else {
             /* Depends on the insertion mode: */
-            switch($this->mode) {
-                case self::BEFOR_HEAD: return $this->beforeHead($token); break;
-                case self::IN_HEAD:    return $this->inHead($token); break;
-                case self::AFTER_HEAD: return $this->afterHead($token); break;
-                case self::IN_BODY:    return $this->inBody($token); break;
-                case self::IN_TABLE:   return $this->inTable($token); break;
-                case self::IN_CAPTION: return $this->inCaption($token); break;
-                case self::IN_CGROUP:  return $this->inColumnGroup($token); break;
-                case self::IN_TBODY:   return $this->inTableBody($token); break;
-                case self::IN_ROW:     return $this->inRow($token); break;
-                case self::IN_CELL:    return $this->inCell($token); break;
-                case self::IN_SELECT:  return $this->inSelect($token); break;
-                case self::AFTER_BODY: return $this->afterBody($token); break;
-                case self::IN_FRAME:   return $this->inFrameset($token); break;
-                case self::AFTR_FRAME: return $this->afterFrameset($token); break;
-                case self::END_PHASE:  return $this->trailingEndPhase($token); break;
+            switch ($this->mode) {
+                case self::BEFOR_HEAD:
+                    return $this->beforeHead($token);
+                    break;
+                case self::IN_HEAD:
+                    return $this->inHead($token);
+                    break;
+                case self::AFTER_HEAD:
+                    return $this->afterHead($token);
+                    break;
+                case self::IN_BODY:
+                    return $this->inBody($token);
+                    break;
+                case self::IN_TABLE:
+                    return $this->inTable($token);
+                    break;
+                case self::IN_CAPTION:
+                    return $this->inCaption($token);
+                    break;
+                case self::IN_CGROUP:
+                    return $this->inColumnGroup($token);
+                    break;
+                case self::IN_TBODY:
+                    return $this->inTableBody($token);
+                    break;
+                case self::IN_ROW:
+                    return $this->inRow($token);
+                    break;
+                case self::IN_CELL:
+                    return $this->inCell($token);
+                    break;
+                case self::IN_SELECT:
+                    return $this->inSelect($token);
+                    break;
+                case self::AFTER_BODY:
+                    return $this->afterBody($token);
+                    break;
+                case self::IN_FRAME:
+                    return $this->inFrameset($token);
+                    break;
+                case self::AFTR_FRAME:
+                    return $this->afterFrameset($token);
+                    break;
+                case self::END_PHASE:
+                    return $this->trailingEndPhase($token);
+                    break;
             }
         }
     }
 
-    private function beforeHead($token) {
+    private function beforeHead($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
         U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
         or U+0020 SPACE */
-        if($token['type'] === HTML5::CHARACTR &&
-        preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) {
+        if ($token['type'] === HTML5::CHARACTR &&
+            preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])
+        ) {
             /* Append the character to the current node. */
             $this->insertText($token['data']);
 
-        /* A comment token */
-        } elseif($token['type'] === HTML5::COMMENT) {
+            /* A comment token */
+        } elseif ($token['type'] === HTML5::COMMENT) {
             /* Append a Comment node to the current node with the data attribute
             set to the data given in the comment token. */
             $this->insertComment($token['data']);
 
-        /* A start tag token with the tag name "head" */
-        } elseif($token['type'] === HTML5::STARTTAG && $token['name'] === 'head') {
+            /* A start tag token with the tag name "head" */
+        } elseif ($token['type'] === HTML5::STARTTAG && $token['name'] === 'head') {
             /* Create an element for the token, append the new element to the
             current node and push it onto the stack of open elements. */
             $element = $this->insertElement($token);
@@ -1424,32 +1945,38 @@ class HTML5TreeConstructer {
             /* Change the insertion mode to "in head". */
             $this->mode = self::IN_HEAD;
 
-        /* A start tag token whose tag name is one of: "base", "link", "meta",
-        "script", "style", "title". Or an end tag with the tag name "html".
-        Or a character token that is not one of U+0009 CHARACTER TABULATION,
-        U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
-        or U+0020 SPACE. Or any other start tag token */
-        } elseif($token['type'] === HTML5::STARTTAG ||
-        ($token['type'] === HTML5::ENDTAG && $token['name'] === 'html') ||
-        ($token['type'] === HTML5::CHARACTR && !preg_match('/^[\t\n\x0b\x0c ]$/',
-        $token['data']))) {
+            /* A start tag token whose tag name is one of: "base", "link", "meta",
+            "script", "style", "title". Or an end tag with the tag name "html".
+            Or a character token that is not one of U+0009 CHARACTER TABULATION,
+            U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
+            or U+0020 SPACE. Or any other start tag token */
+        } elseif ($token['type'] === HTML5::STARTTAG ||
+            ($token['type'] === HTML5::ENDTAG && $token['name'] === 'html') ||
+            ($token['type'] === HTML5::CHARACTR && !preg_match(
+                    '/^[\t\n\x0b\x0c ]$/',
+                    $token['data']
+                ))
+        ) {
             /* Act as if a start tag token with the tag name "head" and no
             attributes had been seen, then reprocess the current token. */
-            $this->beforeHead(array(
-                'name' => 'head',
-                'type' => HTML5::STARTTAG,
-                'attr' => array()
-            ));
+            $this->beforeHead(
+                array(
+                    'name' => 'head',
+                    'type' => HTML5::STARTTAG,
+                    'attr' => array()
+                )
+            );
 
             return $this->inHead($token);
 
-        /* Any other end tag */
-        } elseif($token['type'] === HTML5::ENDTAG) {
+            /* Any other end tag */
+        } elseif ($token['type'] === HTML5::ENDTAG) {
             /* Parse error. Ignore the token. */
         }
     }
 
-    private function inHead($token) {
+    private function inHead($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
@@ -1459,30 +1986,34 @@ class HTML5TreeConstructer {
         THIS DIFFERS FROM THE SPEC: If the current node is either a title, style
         or script element, append the character to the current node regardless
         of its content. */
-        if(($token['type'] === HTML5::CHARACTR &&
-        preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) || (
-        $token['type'] === HTML5::CHARACTR && in_array(end($this->stack)->nodeName,
-        array('title', 'style', 'script')))) {
+        if (($token['type'] === HTML5::CHARACTR &&
+                preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) || (
+                $token['type'] === HTML5::CHARACTR && in_array(
+                    end($this->stack)->nodeName,
+                    array('title', 'style', 'script')
+                ))
+        ) {
             /* Append the character to the current node. */
             $this->insertText($token['data']);
 
-        /* A comment token */
-        } elseif($token['type'] === HTML5::COMMENT) {
+            /* A comment token */
+        } elseif ($token['type'] === HTML5::COMMENT) {
             /* Append a Comment node to the current node with the data attribute
             set to the data given in the comment token. */
             $this->insertComment($token['data']);
 
-        } elseif($token['type'] === HTML5::ENDTAG &&
-        in_array($token['name'], array('title', 'style', 'script'))) {
+        } elseif ($token['type'] === HTML5::ENDTAG &&
+            in_array($token['name'], array('title', 'style', 'script'))
+        ) {
             array_pop($this->stack);
             return HTML5::PCDATA;
 
-        /* A start tag with the tag name "title" */
-        } elseif($token['type'] === HTML5::STARTTAG && $token['name'] === 'title') {
+            /* A start tag with the tag name "title" */
+        } elseif ($token['type'] === HTML5::STARTTAG && $token['name'] === 'title') {
             /* Create an element for the token and append the new element to the
             node pointed to by the head element pointer, or, if that is null
             (innerHTML case), to the current node. */
-            if($this->head_pointer !== null) {
+            if ($this->head_pointer !== null) {
                 $element = $this->insertElement($token, false);
                 $this->head_pointer->appendChild($element);
 
@@ -1493,12 +2024,12 @@ class HTML5TreeConstructer {
             /* Switch the tokeniser's content model flag  to the RCDATA state. */
             return HTML5::RCDATA;
 
-        /* A start tag with the tag name "style" */
-        } elseif($token['type'] === HTML5::STARTTAG && $token['name'] === 'style') {
+            /* A start tag with the tag name "style" */
+        } elseif ($token['type'] === HTML5::STARTTAG && $token['name'] === 'style') {
             /* Create an element for the token and append the new element to the
             node pointed to by the head element pointer, or, if that is null
             (innerHTML case), to the current node. */
-            if($this->head_pointer !== null) {
+            if ($this->head_pointer !== null) {
                 $element = $this->insertElement($token, false);
                 $this->head_pointer->appendChild($element);
 
@@ -1509,8 +2040,8 @@ class HTML5TreeConstructer {
             /* Switch the tokeniser's content model flag  to the CDATA state. */
             return HTML5::CDATA;
 
-        /* A start tag with the tag name "script" */
-        } elseif($token['type'] === HTML5::STARTTAG && $token['name'] === 'script') {
+            /* A start tag with the tag name "script" */
+        } elseif ($token['type'] === HTML5::STARTTAG && $token['name'] === 'script') {
             /* Create an element for the token. */
             $element = $this->insertElement($token, false);
             $this->head_pointer->appendChild($element);
@@ -1518,13 +2049,16 @@ class HTML5TreeConstructer {
             /* Switch the tokeniser's content model flag  to the CDATA state. */
             return HTML5::CDATA;
 
-        /* A start tag with the tag name "base", "link", or "meta" */
-        } elseif($token['type'] === HTML5::STARTTAG && in_array($token['name'],
-        array('base', 'link', 'meta'))) {
+            /* A start tag with the tag name "base", "link", or "meta" */
+        } elseif ($token['type'] === HTML5::STARTTAG && in_array(
+                $token['name'],
+                array('base', 'link', 'meta')
+            )
+        ) {
             /* Create an element for the token and append the new element to the
             node pointed to by the head element pointer, or, if that is null
             (innerHTML case), to the current node. */
-            if($this->head_pointer !== null) {
+            if ($this->head_pointer !== null) {
                 $element = $this->insertElement($token, false);
                 $this->head_pointer->appendChild($element);
                 array_pop($this->stack);
@@ -1533,14 +2067,14 @@ class HTML5TreeConstructer {
                 $this->insertElement($token);
             }
 
-        /* An end tag with the tag name "head" */
-        } elseif($token['type'] === HTML5::ENDTAG && $token['name'] === 'head') {
+            /* An end tag with the tag name "head" */
+        } elseif ($token['type'] === HTML5::ENDTAG && $token['name'] === 'head') {
             /* If the current node is a head element, pop the current node off
             the stack of open elements. */
-            if($this->head_pointer->isSameNode(end($this->stack))) {
+            if ($this->head_pointer->isSameNode(end($this->stack))) {
                 array_pop($this->stack);
 
-            /* Otherwise, this is a parse error. */
+                /* Otherwise, this is a parse error. */
             } else {
                 // k
             }
@@ -1548,22 +2082,25 @@ class HTML5TreeConstructer {
             /* Change the insertion mode to "after head". */
             $this->mode = self::AFTER_HEAD;
 
-        /* A start tag with the tag name "head" or an end tag except "html". */
-        } elseif(($token['type'] === HTML5::STARTTAG && $token['name'] === 'head') ||
-        ($token['type'] === HTML5::ENDTAG && $token['name'] !== 'html')) {
+            /* A start tag with the tag name "head" or an end tag except "html". */
+        } elseif (($token['type'] === HTML5::STARTTAG && $token['name'] === 'head') ||
+            ($token['type'] === HTML5::ENDTAG && $token['name'] !== 'html')
+        ) {
             // Parse error. Ignore the token.
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* If the current node is a head element, act as if an end tag
             token with the tag name "head" had been seen. */
-            if($this->head_pointer->isSameNode(end($this->stack))) {
-                $this->inHead(array(
-                    'name' => 'head',
-                    'type' => HTML5::ENDTAG
-                ));
+            if ($this->head_pointer->isSameNode(end($this->stack))) {
+                $this->inHead(
+                    array(
+                        'name' => 'head',
+                        'type' => HTML5::ENDTAG
+                    )
+                );
 
-            /* Otherwise, change the insertion mode to "after head". */
+                /* Otherwise, change the insertion mode to "after head". */
             } else {
                 $this->mode = self::AFTER_HEAD;
             }
@@ -1573,66 +2110,74 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function afterHead($token) {
+    private function afterHead($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
         U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
         or U+0020 SPACE */
-        if($token['type'] === HTML5::CHARACTR &&
-        preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) {
+        if ($token['type'] === HTML5::CHARACTR &&
+            preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])
+        ) {
             /* Append the character to the current node. */
             $this->insertText($token['data']);
 
-        /* A comment token */
-        } elseif($token['type'] === HTML5::COMMENT) {
+            /* A comment token */
+        } elseif ($token['type'] === HTML5::COMMENT) {
             /* Append a Comment node to the current node with the data attribute
             set to the data given in the comment token. */
             $this->insertComment($token['data']);
 
-        /* A start tag token with the tag name "body" */
-        } elseif($token['type'] === HTML5::STARTTAG && $token['name'] === 'body') {
+            /* A start tag token with the tag name "body" */
+        } elseif ($token['type'] === HTML5::STARTTAG && $token['name'] === 'body') {
             /* Insert a body element for the token. */
             $this->insertElement($token);
 
             /* Change the insertion mode to "in body". */
             $this->mode = self::IN_BODY;
 
-        /* A start tag token with the tag name "frameset" */
-        } elseif($token['type'] === HTML5::STARTTAG && $token['name'] === 'frameset') {
+            /* A start tag token with the tag name "frameset" */
+        } elseif ($token['type'] === HTML5::STARTTAG && $token['name'] === 'frameset') {
             /* Insert a frameset element for the token. */
             $this->insertElement($token);
 
             /* Change the insertion mode to "in frameset". */
             $this->mode = self::IN_FRAME;
 
-        /* A start tag token whose tag name is one of: "base", "link", "meta",
-        "script", "style", "title" */
-        } elseif($token['type'] === HTML5::STARTTAG && in_array($token['name'],
-        array('base', 'link', 'meta', 'script', 'style', 'title'))) {
+            /* A start tag token whose tag name is one of: "base", "link", "meta",
+            "script", "style", "title" */
+        } elseif ($token['type'] === HTML5::STARTTAG && in_array(
+                $token['name'],
+                array('base', 'link', 'meta', 'script', 'style', 'title')
+            )
+        ) {
             /* Parse error. Switch the insertion mode back to "in head" and
             reprocess the token. */
             $this->mode = self::IN_HEAD;
             return $this->inHead($token);
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Act as if a start tag token with the tag name "body" and no
             attributes had been seen, and then reprocess the current token. */
-            $this->afterHead(array(
-                'name' => 'body',
-                'type' => HTML5::STARTTAG,
-                'attr' => array()
-            ));
+            $this->afterHead(
+                array(
+                    'name' => 'body',
+                    'type' => HTML5::STARTTAG,
+                    'attr' => array()
+                )
+            );
 
             return $this->inBody($token);
         }
     }
 
-    private function inBody($token) {
+    private function inBody($token)
+    {
         /* Handle the token as follows: */
 
-        switch($token['type']) {
+        switch ($token['type']) {
             /* A character token */
             case HTML5::CHARACTR:
                 /* Reconstruct the active formatting elements, if any. */
@@ -1640,1015 +2185,1159 @@ class HTML5TreeConstructer {
 
                 /* Append the token's character to the current node. */
                 $this->insertText($token['data']);
-            break;
+                break;
 
             /* A comment token */
             case HTML5::COMMENT:
                 /* Append a Comment node to the current node with the data
                 attribute set to the data given in the comment token. */
                 $this->insertComment($token['data']);
-            break;
+                break;
 
             case HTML5::STARTTAG:
-            switch($token['name']) {
-                /* A start tag token whose tag name is one of: "script",
-                "style" */
-                case 'script': case 'style':
-                    /* Process the token as if the insertion mode had been "in
-                    head". */
-                    return $this->inHead($token);
-                break;
+                switch ($token['name']) {
+                    /* A start tag token whose tag name is one of: "script",
+                    "style" */
+                    case 'script':
+                    case 'style':
+                        /* Process the token as if the insertion mode had been "in
+                        head". */
+                        return $this->inHead($token);
+                        break;
 
-                /* A start tag token whose tag name is one of: "base", "link",
-                "meta", "title" */
-                case 'base': case 'link': case 'meta': case 'title':
-                    /* Parse error. Process the token as if the insertion mode
-                    had    been "in head". */
-                    return $this->inHead($token);
-                break;
+                    /* A start tag token whose tag name is one of: "base", "link",
+                    "meta", "title" */
+                    case 'base':
+                    case 'link':
+                    case 'meta':
+                    case 'title':
+                        /* Parse error. Process the token as if the insertion mode
+                        had    been "in head". */
+                        return $this->inHead($token);
+                        break;
 
-                /* A start tag token with the tag name "body" */
-                case 'body':
-                    /* Parse error. If the second element on the stack of open
-                    elements is not a body element, or, if the stack of open
-                    elements has only one node on it, then ignore the token.
-                    (innerHTML case) */
-                    if(count($this->stack) === 1 || $this->stack[1]->nodeName !== 'body') {
-                        // Ignore
+                    /* A start tag token with the tag name "body" */
+                    case 'body':
+                        /* Parse error. If the second element on the stack of open
+                        elements is not a body element, or, if the stack of open
+                        elements has only one node on it, then ignore the token.
+                        (innerHTML case) */
+                        if (count($this->stack) === 1 || $this->stack[1]->nodeName !== 'body') {
+                            // Ignore
 
-                    /* Otherwise, for each attribute on the token, check to see
-                    if the attribute is already present on the body element (the
-                    second element)    on the stack of open elements. If it is not,
-                    add the attribute and its corresponding value to that
-                    element. */
-                    } else {
-                        foreach($token['attr'] as $attr) {
-                            if(!$this->stack[1]->hasAttribute($attr['name'])) {
-                                $this->stack[1]->setAttribute($attr['name'], $attr['value']);
+                            /* Otherwise, for each attribute on the token, check to see
+                            if the attribute is already present on the body element (the
+                            second element)    on the stack of open elements. If it is not,
+                            add the attribute and its corresponding value to that
+                            element. */
+                        } else {
+                            foreach ($token['attr'] as $attr) {
+                                if (!$this->stack[1]->hasAttribute($attr['name'])) {
+                                    $this->stack[1]->setAttribute($attr['name'], $attr['value']);
+                                }
                             }
                         }
-                    }
-                break;
+                        break;
 
-                /* A start tag whose tag name is one of: "address",
-                "blockquote", "center", "dir", "div", "dl", "fieldset",
-                "listing", "menu", "ol", "p", "ul" */
-                case 'address': case 'blockquote': case 'center': case 'dir':
-                case 'div': case 'dl': case 'fieldset': case 'listing':
-                case 'menu': case 'ol': case 'p': case 'ul':
-                    /* If the stack of open elements has a p element in scope,
-                    then act as if an end tag with the tag name p had been
-                    seen. */
-                    if($this->elementInScope('p')) {
-                        $this->emitToken(array(
-                            'name' => 'p',
-                            'type' => HTML5::ENDTAG
-                        ));
-                    }
-
-                    /* Insert an HTML element for the token. */
-                    $this->insertElement($token);
-                break;
-
-                /* A start tag whose tag name is "form" */
-                case 'form':
-                    /* If the form element pointer is not null, ignore the
-                    token with a parse error. */
-                    if($this->form_pointer !== null) {
-                        // Ignore.
-
-                    /* Otherwise: */
-                    } else {
-                        /* If the stack of open elements has a p element in
-                        scope, then act as if an end tag with the tag name p
-                        had been seen. */
-                        if($this->elementInScope('p')) {
-                            $this->emitToken(array(
-                                'name' => 'p',
-                                'type' => HTML5::ENDTAG
-                            ));
+                    /* A start tag whose tag name is one of: "address",
+                    "blockquote", "center", "dir", "div", "dl", "fieldset",
+                    "listing", "menu", "ol", "p", "ul" */
+                    case 'address':
+                    case 'blockquote':
+                    case 'center':
+                    case 'dir':
+                    case 'div':
+                    case 'dl':
+                    case 'fieldset':
+                    case 'listing':
+                    case 'menu':
+                    case 'ol':
+                    case 'p':
+                    case 'ul':
+                        /* If the stack of open elements has a p element in scope,
+                        then act as if an end tag with the tag name p had been
+                        seen. */
+                        if ($this->elementInScope('p')) {
+                            $this->emitToken(
+                                array(
+                                    'name' => 'p',
+                                    'type' => HTML5::ENDTAG
+                                )
+                            );
                         }
 
-                        /* Insert an HTML element for the token, and set the
-                        form element pointer to point to the element created. */
-                        $element = $this->insertElement($token);
-                        $this->form_pointer = $element;
-                    }
-                break;
+                        /* Insert an HTML element for the token. */
+                        $this->insertElement($token);
+                        break;
 
-                /* A start tag whose tag name is "li", "dd" or "dt" */
-                case 'li': case 'dd': case 'dt':
-                    /* If the stack of open elements has a p  element in scope,
-                    then act as if an end tag with the tag name p had been
-                    seen. */
-                    if($this->elementInScope('p')) {
-                        $this->emitToken(array(
-                            'name' => 'p',
-                            'type' => HTML5::ENDTAG
-                        ));
-                    }
+                    /* A start tag whose tag name is "form" */
+                    case 'form':
+                        /* If the form element pointer is not null, ignore the
+                        token with a parse error. */
+                        if ($this->form_pointer !== null) {
+                            // Ignore.
 
-                    $stack_length = count($this->stack) - 1;
-
-                    for($n = $stack_length; 0 <= $n; $n--) {
-                        /* 1. Initialise node to be the current node (the
-                        bottommost node of the stack). */
-                        $stop = false;
-                        $node = $this->stack[$n];
-                        $cat  = $this->getElementCategory($node->tagName);
-
-                        /* 2. If node is an li, dd or dt element, then pop all
-                        the    nodes from the current node up to node, including
-                        node, then stop this algorithm. */
-                        if($token['name'] === $node->tagName ||    ($token['name'] !== 'li'
-                        && ($node->tagName === 'dd' || $node->tagName === 'dt'))) {
-                            for($x = $stack_length; $x >= $n ; $x--) {
-                                array_pop($this->stack);
+                            /* Otherwise: */
+                        } else {
+                            /* If the stack of open elements has a p element in
+                            scope, then act as if an end tag with the tag name p
+                            had been seen. */
+                            if ($this->elementInScope('p')) {
+                                $this->emitToken(
+                                    array(
+                                        'name' => 'p',
+                                        'type' => HTML5::ENDTAG
+                                    )
+                                );
                             }
 
-                            break;
+                            /* Insert an HTML element for the token, and set the
+                            form element pointer to point to the element created. */
+                            $element = $this->insertElement($token);
+                            $this->form_pointer = $element;
+                        }
+                        break;
+
+                    /* A start tag whose tag name is "li", "dd" or "dt" */
+                    case 'li':
+                    case 'dd':
+                    case 'dt':
+                        /* If the stack of open elements has a p  element in scope,
+                        then act as if an end tag with the tag name p had been
+                        seen. */
+                        if ($this->elementInScope('p')) {
+                            $this->emitToken(
+                                array(
+                                    'name' => 'p',
+                                    'type' => HTML5::ENDTAG
+                                )
+                            );
                         }
 
-                        /* 3. If node is not in the formatting category, and is
-                        not    in the phrasing category, and is not an address or
-                        div element, then stop this algorithm. */
-                        if($cat !== self::FORMATTING && $cat !== self::PHRASING &&
-                        $node->tagName !== 'address' && $node->tagName !== 'div') {
-                            break;
+                        $stack_length = count($this->stack) - 1;
+
+                        for ($n = $stack_length; 0 <= $n; $n--) {
+                            /* 1. Initialise node to be the current node (the
+                            bottommost node of the stack). */
+                            $stop = false;
+                            $node = $this->stack[$n];
+                            $cat = $this->getElementCategory($node->tagName);
+
+                            /* 2. If node is an li, dd or dt element, then pop all
+                            the    nodes from the current node up to node, including
+                            node, then stop this algorithm. */
+                            if ($token['name'] === $node->tagName || ($token['name'] !== 'li'
+                                    && ($node->tagName === 'dd' || $node->tagName === 'dt'))
+                            ) {
+                                for ($x = $stack_length; $x >= $n; $x--) {
+                                    array_pop($this->stack);
+                                }
+
+                                break;
+                            }
+
+                            /* 3. If node is not in the formatting category, and is
+                            not    in the phrasing category, and is not an address or
+                            div element, then stop this algorithm. */
+                            if ($cat !== self::FORMATTING && $cat !== self::PHRASING &&
+                                $node->tagName !== 'address' && $node->tagName !== 'div'
+                            ) {
+                                break;
+                            }
                         }
-                    }
 
-                    /* Finally, insert an HTML element with the same tag
-                    name as the    token's. */
-                    $this->insertElement($token);
-                break;
+                        /* Finally, insert an HTML element with the same tag
+                        name as the    token's. */
+                        $this->insertElement($token);
+                        break;
 
-                /* A start tag token whose tag name is "plaintext" */
-                case 'plaintext':
-                    /* If the stack of open elements has a p  element in scope,
-                    then act as if an end tag with the tag name p had been
-                    seen. */
-                    if($this->elementInScope('p')) {
-                        $this->emitToken(array(
-                            'name' => 'p',
-                            'type' => HTML5::ENDTAG
-                        ));
-                    }
+                    /* A start tag token whose tag name is "plaintext" */
+                    case 'plaintext':
+                        /* If the stack of open elements has a p  element in scope,
+                        then act as if an end tag with the tag name p had been
+                        seen. */
+                        if ($this->elementInScope('p')) {
+                            $this->emitToken(
+                                array(
+                                    'name' => 'p',
+                                    'type' => HTML5::ENDTAG
+                                )
+                            );
+                        }
 
-                    /* Insert an HTML element for the token. */
-                    $this->insertElement($token);
+                        /* Insert an HTML element for the token. */
+                        $this->insertElement($token);
 
-                    return HTML5::PLAINTEXT;
-                break;
+                        return HTML5::PLAINTEXT;
+                        break;
 
-                /* A start tag whose tag name is one of: "h1", "h2", "h3", "h4",
-                "h5", "h6" */
-                case 'h1': case 'h2': case 'h3': case 'h4': case 'h5': case 'h6':
-                    /* If the stack of open elements has a p  element in scope,
-                    then act as if an end tag with the tag name p had been seen. */
-                    if($this->elementInScope('p')) {
-                        $this->emitToken(array(
-                            'name' => 'p',
-                            'type' => HTML5::ENDTAG
-                        ));
-                    }
+                    /* A start tag whose tag name is one of: "h1", "h2", "h3", "h4",
+                    "h5", "h6" */
+                    case 'h1':
+                    case 'h2':
+                    case 'h3':
+                    case 'h4':
+                    case 'h5':
+                    case 'h6':
+                        /* If the stack of open elements has a p  element in scope,
+                        then act as if an end tag with the tag name p had been seen. */
+                        if ($this->elementInScope('p')) {
+                            $this->emitToken(
+                                array(
+                                    'name' => 'p',
+                                    'type' => HTML5::ENDTAG
+                                )
+                            );
+                        }
 
-                    /* If the stack of open elements has in scope an element whose
-                    tag name is one of "h1", "h2", "h3", "h4", "h5", or "h6", then
-                    this is a parse error; pop elements from the stack until an
-                    element with one of those tag names has been popped from the
-                    stack. */
-                    while($this->elementInScope(array('h1', 'h2', 'h3', 'h4', 'h5', 'h6'))) {
+                        /* If the stack of open elements has in scope an element whose
+                        tag name is one of "h1", "h2", "h3", "h4", "h5", or "h6", then
+                        this is a parse error; pop elements from the stack until an
+                        element with one of those tag names has been popped from the
+                        stack. */
+                        while ($this->elementInScope(array('h1', 'h2', 'h3', 'h4', 'h5', 'h6'))) {
+                            array_pop($this->stack);
+                        }
+
+                        /* Insert an HTML element for the token. */
+                        $this->insertElement($token);
+                        break;
+
+                    /* A start tag whose tag name is "a" */
+                    case 'a':
+                        /* If the list of active formatting elements contains
+                        an element whose tag name is "a" between the end of the
+                        list and the last marker on the list (or the start of
+                        the list if there is no marker on the list), then this
+                        is a parse error; act as if an end tag with the tag name
+                        "a" had been seen, then remove that element from the list
+                        of active formatting elements and the stack of open
+                        elements if the end tag didn't already remove it (it
+                        might not have if the element is not in table scope). */
+                        $leng = count($this->a_formatting);
+
+                        for ($n = $leng - 1; $n >= 0; $n--) {
+                            if ($this->a_formatting[$n] === self::MARKER) {
+                                break;
+
+                            } elseif ($this->a_formatting[$n]->nodeName === 'a') {
+                                $this->emitToken(
+                                    array(
+                                        'name' => 'a',
+                                        'type' => HTML5::ENDTAG
+                                    )
+                                );
+                                break;
+                            }
+                        }
+
+                        /* Reconstruct the active formatting elements, if any. */
+                        $this->reconstructActiveFormattingElements();
+
+                        /* Insert an HTML element for the token. */
+                        $el = $this->insertElement($token);
+
+                        /* Add that element to the list of active formatting
+                        elements. */
+                        $this->a_formatting[] = $el;
+                        break;
+
+                    /* A start tag whose tag name is one of: "b", "big", "em", "font",
+                    "i", "nobr", "s", "small", "strike", "strong", "tt", "u" */
+                    case 'b':
+                    case 'big':
+                    case 'em':
+                    case 'font':
+                    case 'i':
+                    case 'nobr':
+                    case 's':
+                    case 'small':
+                    case 'strike':
+                    case 'strong':
+                    case 'tt':
+                    case 'u':
+                        /* Reconstruct the active formatting elements, if any. */
+                        $this->reconstructActiveFormattingElements();
+
+                        /* Insert an HTML element for the token. */
+                        $el = $this->insertElement($token);
+
+                        /* Add that element to the list of active formatting
+                        elements. */
+                        $this->a_formatting[] = $el;
+                        break;
+
+                    /* A start tag token whose tag name is "button" */
+                    case 'button':
+                        /* If the stack of open elements has a button element in scope,
+                        then this is a parse error; act as if an end tag with the tag
+                        name "button" had been seen, then reprocess the token. (We don't
+                        do that. Unnecessary.) */
+                        if ($this->elementInScope('button')) {
+                            $this->inBody(
+                                array(
+                                    'name' => 'button',
+                                    'type' => HTML5::ENDTAG
+                                )
+                            );
+                        }
+
+                        /* Reconstruct the active formatting elements, if any. */
+                        $this->reconstructActiveFormattingElements();
+
+                        /* Insert an HTML element for the token. */
+                        $this->insertElement($token);
+
+                        /* Insert a marker at the end of the list of active
+                        formatting elements. */
+                        $this->a_formatting[] = self::MARKER;
+                        break;
+
+                    /* A start tag token whose tag name is one of: "marquee", "object" */
+                    case 'marquee':
+                    case 'object':
+                        /* Reconstruct the active formatting elements, if any. */
+                        $this->reconstructActiveFormattingElements();
+
+                        /* Insert an HTML element for the token. */
+                        $this->insertElement($token);
+
+                        /* Insert a marker at the end of the list of active
+                        formatting elements. */
+                        $this->a_formatting[] = self::MARKER;
+                        break;
+
+                    /* A start tag token whose tag name is "xmp" */
+                    case 'xmp':
+                        /* Reconstruct the active formatting elements, if any. */
+                        $this->reconstructActiveFormattingElements();
+
+                        /* Insert an HTML element for the token. */
+                        $this->insertElement($token);
+
+                        /* Switch the content model flag to the CDATA state. */
+                        return HTML5::CDATA;
+                        break;
+
+                    /* A start tag whose tag name is "table" */
+                    case 'table':
+                        /* If the stack of open elements has a p element in scope,
+                        then act as if an end tag with the tag name p had been seen. */
+                        if ($this->elementInScope('p')) {
+                            $this->emitToken(
+                                array(
+                                    'name' => 'p',
+                                    'type' => HTML5::ENDTAG
+                                )
+                            );
+                        }
+
+                        /* Insert an HTML element for the token. */
+                        $this->insertElement($token);
+
+                        /* Change the insertion mode to "in table". */
+                        $this->mode = self::IN_TABLE;
+                        break;
+
+                    /* A start tag whose tag name is one of: "area", "basefont",
+                    "bgsound", "br", "embed", "img", "param", "spacer", "wbr" */
+                    case 'area':
+                    case 'basefont':
+                    case 'bgsound':
+                    case 'br':
+                    case 'embed':
+                    case 'img':
+                    case 'param':
+                    case 'spacer':
+                    case 'wbr':
+                        /* Reconstruct the active formatting elements, if any. */
+                        $this->reconstructActiveFormattingElements();
+
+                        /* Insert an HTML element for the token. */
+                        $this->insertElement($token);
+
+                        /* Immediately pop the current node off the stack of open elements. */
                         array_pop($this->stack);
-                    }
+                        break;
 
-                    /* Insert an HTML element for the token. */
-                    $this->insertElement($token);
-                break;
-
-                /* A start tag whose tag name is "a" */
-                case 'a':
-                    /* If the list of active formatting elements contains
-                    an element whose tag name is "a" between the end of the
-                    list and the last marker on the list (or the start of
-                    the list if there is no marker on the list), then this
-                    is a parse error; act as if an end tag with the tag name
-                    "a" had been seen, then remove that element from the list
-                    of active formatting elements and the stack of open
-                    elements if the end tag didn't already remove it (it
-                    might not have if the element is not in table scope). */
-                    $leng = count($this->a_formatting);
-
-                    for($n = $leng - 1; $n >= 0; $n--) {
-                        if($this->a_formatting[$n] === self::MARKER) {
-                            break;
-
-                        } elseif($this->a_formatting[$n]->nodeName === 'a') {
-                            $this->emitToken(array(
-                                'name' => 'a',
-                                'type' => HTML5::ENDTAG
-                            ));
-                            break;
+                    /* A start tag whose tag name is "hr" */
+                    case 'hr':
+                        /* If the stack of open elements has a p element in scope,
+                        then act as if an end tag with the tag name p had been seen. */
+                        if ($this->elementInScope('p')) {
+                            $this->emitToken(
+                                array(
+                                    'name' => 'p',
+                                    'type' => HTML5::ENDTAG
+                                )
+                            );
                         }
-                    }
 
-                    /* Reconstruct the active formatting elements, if any. */
-                    $this->reconstructActiveFormattingElements();
+                        /* Insert an HTML element for the token. */
+                        $this->insertElement($token);
 
-                    /* Insert an HTML element for the token. */
-                    $el = $this->insertElement($token);
+                        /* Immediately pop the current node off the stack of open elements. */
+                        array_pop($this->stack);
+                        break;
 
-                    /* Add that element to the list of active formatting
-                    elements. */
-                    $this->a_formatting[] = $el;
+                    /* A start tag whose tag name is "image" */
+                    case 'image':
+                        /* Parse error. Change the token's tag name to "img" and
+                        reprocess it. (Don't ask.) */
+                        $token['name'] = 'img';
+                        return $this->inBody($token);
+                        break;
+
+                    /* A start tag whose tag name is "input" */
+                    case 'input':
+                        /* Reconstruct the active formatting elements, if any. */
+                        $this->reconstructActiveFormattingElements();
+
+                        /* Insert an input element for the token. */
+                        $element = $this->insertElement($token, false);
+
+                        /* If the form element pointer is not null, then associate the
+                        input element with the form element pointed to by the form
+                        element pointer. */
+                        $this->form_pointer !== null
+                            ? $this->form_pointer->appendChild($element)
+                            : end($this->stack)->appendChild($element);
+
+                        /* Pop that input element off the stack of open elements. */
+                        array_pop($this->stack);
+                        break;
+
+                    /* A start tag whose tag name is "isindex" */
+                    case 'isindex':
+                        /* Parse error. */
+                        // w/e
+
+                        /* If the form element pointer is not null,
+                        then ignore the token. */
+                        if ($this->form_pointer === null) {
+                            /* Act as if a start tag token with the tag name "form" had
+                            been seen. */
+                            $this->inBody(
+                                array(
+                                    'name' => 'body',
+                                    'type' => HTML5::STARTTAG,
+                                    'attr' => array()
+                                )
+                            );
+
+                            /* Act as if a start tag token with the tag name "hr" had
+                            been seen. */
+                            $this->inBody(
+                                array(
+                                    'name' => 'hr',
+                                    'type' => HTML5::STARTTAG,
+                                    'attr' => array()
+                                )
+                            );
+
+                            /* Act as if a start tag token with the tag name "p" had
+                            been seen. */
+                            $this->inBody(
+                                array(
+                                    'name' => 'p',
+                                    'type' => HTML5::STARTTAG,
+                                    'attr' => array()
+                                )
+                            );
+
+                            /* Act as if a start tag token with the tag name "label"
+                            had been seen. */
+                            $this->inBody(
+                                array(
+                                    'name' => 'label',
+                                    'type' => HTML5::STARTTAG,
+                                    'attr' => array()
+                                )
+                            );
+
+                            /* Act as if a stream of character tokens had been seen. */
+                            $this->insertText(
+                                'This is a searchable index. ' .
+                                'Insert your search keywords here: '
+                            );
+
+                            /* Act as if a start tag token with the tag name "input"
+                            had been seen, with all the attributes from the "isindex"
+                            token, except with the "name" attribute set to the value
+                            "isindex" (ignoring any explicit "name" attribute). */
+                            $attr = $token['attr'];
+                            $attr[] = array('name' => 'name', 'value' => 'isindex');
+
+                            $this->inBody(
+                                array(
+                                    'name' => 'input',
+                                    'type' => HTML5::STARTTAG,
+                                    'attr' => $attr
+                                )
+                            );
+
+                            /* Act as if a stream of character tokens had been seen
+                            (see below for what they should say). */
+                            $this->insertText(
+                                'This is a searchable index. ' .
+                                'Insert your search keywords here: '
+                            );
+
+                            /* Act as if an end tag token with the tag name "label"
+                            had been seen. */
+                            $this->inBody(
+                                array(
+                                    'name' => 'label',
+                                    'type' => HTML5::ENDTAG
+                                )
+                            );
+
+                            /* Act as if an end tag token with the tag name "p" had
+                            been seen. */
+                            $this->inBody(
+                                array(
+                                    'name' => 'p',
+                                    'type' => HTML5::ENDTAG
+                                )
+                            );
+
+                            /* Act as if a start tag token with the tag name "hr" had
+                            been seen. */
+                            $this->inBody(
+                                array(
+                                    'name' => 'hr',
+                                    'type' => HTML5::ENDTAG
+                                )
+                            );
+
+                            /* Act as if an end tag token with the tag name "form" had
+                            been seen. */
+                            $this->inBody(
+                                array(
+                                    'name' => 'form',
+                                    'type' => HTML5::ENDTAG
+                                )
+                            );
+                        }
+                        break;
+
+                    /* A start tag whose tag name is "textarea" */
+                    case 'textarea':
+                        $this->insertElement($token);
+
+                        /* Switch the tokeniser's content model flag to the
+                        RCDATA state. */
+                        return HTML5::RCDATA;
+                        break;
+
+                    /* A start tag whose tag name is one of: "iframe", "noembed",
+                    "noframes" */
+                    case 'iframe':
+                    case 'noembed':
+                    case 'noframes':
+                        $this->insertElement($token);
+
+                        /* Switch the tokeniser's content model flag to the CDATA state. */
+                        return HTML5::CDATA;
+                        break;
+
+                    /* A start tag whose tag name is "select" */
+                    case 'select':
+                        /* Reconstruct the active formatting elements, if any. */
+                        $this->reconstructActiveFormattingElements();
+
+                        /* Insert an HTML element for the token. */
+                        $this->insertElement($token);
+
+                        /* Change the insertion mode to "in select". */
+                        $this->mode = self::IN_SELECT;
+                        break;
+
+                    /* A start or end tag whose tag name is one of: "caption", "col",
+                    "colgroup", "frame", "frameset", "head", "option", "optgroup",
+                    "tbody", "td", "tfoot", "th", "thead", "tr". */
+                    case 'caption':
+                    case 'col':
+                    case 'colgroup':
+                    case 'frame':
+                    case 'frameset':
+                    case 'head':
+                    case 'option':
+                    case 'optgroup':
+                    case 'tbody':
+                    case 'td':
+                    case 'tfoot':
+                    case 'th':
+                    case 'thead':
+                    case 'tr':
+                        // Parse error. Ignore the token.
+                        break;
+
+                    /* A start or end tag whose tag name is one of: "event-source",
+                    "section", "nav", "article", "aside", "header", "footer",
+                    "datagrid", "command" */
+                    case 'event-source':
+                    case 'section':
+                    case 'nav':
+                    case 'article':
+                    case 'aside':
+                    case 'header':
+                    case 'footer':
+                    case 'datagrid':
+                    case 'command':
+                        // Work in progress!
+                        break;
+
+                    /* A start tag token not covered by the previous entries */
+                    default:
+                        /* Reconstruct the active formatting elements, if any. */
+                        $this->reconstructActiveFormattingElements();
+
+                        $this->insertElement($token, true, true);
+                        break;
+                }
                 break;
-
-                /* A start tag whose tag name is one of: "b", "big", "em", "font",
-                "i", "nobr", "s", "small", "strike", "strong", "tt", "u" */
-                case 'b': case 'big': case 'em': case 'font': case 'i':
-                case 'nobr': case 's': case 'small': case 'strike':
-                case 'strong': case 'tt': case 'u':
-                    /* Reconstruct the active formatting elements, if any. */
-                    $this->reconstructActiveFormattingElements();
-
-                    /* Insert an HTML element for the token. */
-                    $el = $this->insertElement($token);
-
-                    /* Add that element to the list of active formatting
-                    elements. */
-                    $this->a_formatting[] = $el;
-                break;
-
-                /* A start tag token whose tag name is "button" */
-                case 'button':
-                    /* If the stack of open elements has a button element in scope,
-                    then this is a parse error; act as if an end tag with the tag
-                    name "button" had been seen, then reprocess the token. (We don't
-                    do that. Unnecessary.) */
-                    if($this->elementInScope('button')) {
-                        $this->inBody(array(
-                            'name' => 'button',
-                            'type' => HTML5::ENDTAG
-                        ));
-                    }
-
-                    /* Reconstruct the active formatting elements, if any. */
-                    $this->reconstructActiveFormattingElements();
-
-                    /* Insert an HTML element for the token. */
-                    $this->insertElement($token);
-
-                    /* Insert a marker at the end of the list of active
-                    formatting elements. */
-                    $this->a_formatting[] = self::MARKER;
-                break;
-
-                /* A start tag token whose tag name is one of: "marquee", "object" */
-                case 'marquee': case 'object':
-                    /* Reconstruct the active formatting elements, if any. */
-                    $this->reconstructActiveFormattingElements();
-
-                    /* Insert an HTML element for the token. */
-                    $this->insertElement($token);
-
-                    /* Insert a marker at the end of the list of active
-                    formatting elements. */
-                    $this->a_formatting[] = self::MARKER;
-                break;
-
-                /* A start tag token whose tag name is "xmp" */
-                case 'xmp':
-                    /* Reconstruct the active formatting elements, if any. */
-                    $this->reconstructActiveFormattingElements();
-
-                    /* Insert an HTML element for the token. */
-                    $this->insertElement($token);
-
-                    /* Switch the content model flag to the CDATA state. */
-                    return HTML5::CDATA;
-                break;
-
-                /* A start tag whose tag name is "table" */
-                case 'table':
-                    /* If the stack of open elements has a p element in scope,
-                    then act as if an end tag with the tag name p had been seen. */
-                    if($this->elementInScope('p')) {
-                        $this->emitToken(array(
-                            'name' => 'p',
-                            'type' => HTML5::ENDTAG
-                        ));
-                    }
-
-                    /* Insert an HTML element for the token. */
-                    $this->insertElement($token);
-
-                    /* Change the insertion mode to "in table". */
-                    $this->mode = self::IN_TABLE;
-                break;
-
-                /* A start tag whose tag name is one of: "area", "basefont",
-                "bgsound", "br", "embed", "img", "param", "spacer", "wbr" */
-                case 'area': case 'basefont': case 'bgsound': case 'br':
-                case 'embed': case 'img': case 'param': case 'spacer':
-                case 'wbr':
-                    /* Reconstruct the active formatting elements, if any. */
-                    $this->reconstructActiveFormattingElements();
-
-                    /* Insert an HTML element for the token. */
-                    $this->insertElement($token);
-
-                    /* Immediately pop the current node off the stack of open elements. */
-                    array_pop($this->stack);
-                break;
-
-                /* A start tag whose tag name is "hr" */
-                case 'hr':
-                    /* If the stack of open elements has a p element in scope,
-                    then act as if an end tag with the tag name p had been seen. */
-                    if($this->elementInScope('p')) {
-                        $this->emitToken(array(
-                            'name' => 'p',
-                            'type' => HTML5::ENDTAG
-                        ));
-                    }
-
-                    /* Insert an HTML element for the token. */
-                    $this->insertElement($token);
-
-                    /* Immediately pop the current node off the stack of open elements. */
-                    array_pop($this->stack);
-                break;
-
-                /* A start tag whose tag name is "image" */
-                case 'image':
-                    /* Parse error. Change the token's tag name to "img" and
-                    reprocess it. (Don't ask.) */
-                    $token['name'] = 'img';
-                    return $this->inBody($token);
-                break;
-
-                /* A start tag whose tag name is "input" */
-                case 'input':
-                    /* Reconstruct the active formatting elements, if any. */
-                    $this->reconstructActiveFormattingElements();
-
-                    /* Insert an input element for the token. */
-                    $element = $this->insertElement($token, false);
-
-                    /* If the form element pointer is not null, then associate the
-                    input element with the form element pointed to by the form
-                    element pointer. */
-                    $this->form_pointer !== null
-                        ? $this->form_pointer->appendChild($element)
-                        : end($this->stack)->appendChild($element);
-
-                    /* Pop that input element off the stack of open elements. */
-                    array_pop($this->stack);
-                break;
-
-                /* A start tag whose tag name is "isindex" */
-                case 'isindex':
-                    /* Parse error. */
-                    // w/e
-
-                    /* If the form element pointer is not null,
-                    then ignore the token. */
-                    if($this->form_pointer === null) {
-                        /* Act as if a start tag token with the tag name "form" had
-                        been seen. */
-                        $this->inBody(array(
-                            'name' => 'body',
-                            'type' => HTML5::STARTTAG,
-                            'attr' => array()
-                        ));
-
-                        /* Act as if a start tag token with the tag name "hr" had
-                        been seen. */
-                        $this->inBody(array(
-                            'name' => 'hr',
-                            'type' => HTML5::STARTTAG,
-                            'attr' => array()
-                        ));
-
-                        /* Act as if a start tag token with the tag name "p" had
-                        been seen. */
-                        $this->inBody(array(
-                            'name' => 'p',
-                            'type' => HTML5::STARTTAG,
-                            'attr' => array()
-                        ));
-
-                        /* Act as if a start tag token with the tag name "label"
-                        had been seen. */
-                        $this->inBody(array(
-                            'name' => 'label',
-                            'type' => HTML5::STARTTAG,
-                            'attr' => array()
-                        ));
-
-                        /* Act as if a stream of character tokens had been seen. */
-                        $this->insertText('This is a searchable index. '.
-                        'Insert your search keywords here: ');
-
-                        /* Act as if a start tag token with the tag name "input"
-                        had been seen, with all the attributes from the "isindex"
-                        token, except with the "name" attribute set to the value
-                        "isindex" (ignoring any explicit "name" attribute). */
-                        $attr = $token['attr'];
-                        $attr[] = array('name' => 'name', 'value' => 'isindex');
-
-                        $this->inBody(array(
-                            'name' => 'input',
-                            'type' => HTML5::STARTTAG,
-                            'attr' => $attr
-                        ));
-
-                        /* Act as if a stream of character tokens had been seen
-                        (see below for what they should say). */
-                        $this->insertText('This is a searchable index. '.
-                        'Insert your search keywords here: ');
-
-                        /* Act as if an end tag token with the tag name "label"
-                        had been seen. */
-                        $this->inBody(array(
-                            'name' => 'label',
-                            'type' => HTML5::ENDTAG
-                        ));
-
-                        /* Act as if an end tag token with the tag name "p" had
-                        been seen. */
-                        $this->inBody(array(
-                            'name' => 'p',
-                            'type' => HTML5::ENDTAG
-                        ));
-
-                        /* Act as if a start tag token with the tag name "hr" had
-                        been seen. */
-                        $this->inBody(array(
-                            'name' => 'hr',
-                            'type' => HTML5::ENDTAG
-                        ));
-
-                        /* Act as if an end tag token with the tag name "form" had
-                        been seen. */
-                        $this->inBody(array(
-                            'name' => 'form',
-                            'type' => HTML5::ENDTAG
-                        ));
-                    }
-                break;
-
-                /* A start tag whose tag name is "textarea" */
-                case 'textarea':
-                    $this->insertElement($token);
-
-                    /* Switch the tokeniser's content model flag to the
-                    RCDATA state. */
-                    return HTML5::RCDATA;
-                break;
-
-                /* A start tag whose tag name is one of: "iframe", "noembed",
-                "noframes" */
-                case 'iframe': case 'noembed': case 'noframes':
-                    $this->insertElement($token);
-
-                    /* Switch the tokeniser's content model flag to the CDATA state. */
-                    return HTML5::CDATA;
-                break;
-
-                /* A start tag whose tag name is "select" */
-                case 'select':
-                    /* Reconstruct the active formatting elements, if any. */
-                    $this->reconstructActiveFormattingElements();
-
-                    /* Insert an HTML element for the token. */
-                    $this->insertElement($token);
-
-                    /* Change the insertion mode to "in select". */
-                    $this->mode = self::IN_SELECT;
-                break;
-
-                /* A start or end tag whose tag name is one of: "caption", "col",
-                "colgroup", "frame", "frameset", "head", "option", "optgroup",
-                "tbody", "td", "tfoot", "th", "thead", "tr". */
-                case 'caption': case 'col': case 'colgroup': case 'frame':
-                case 'frameset': case 'head': case 'option': case 'optgroup':
-                case 'tbody': case 'td': case 'tfoot': case 'th': case 'thead':
-                case 'tr':
-                    // Parse error. Ignore the token.
-                break;
-
-                /* A start or end tag whose tag name is one of: "event-source",
-                "section", "nav", "article", "aside", "header", "footer",
-                "datagrid", "command" */
-                case 'event-source': case 'section': case 'nav': case 'article':
-                case 'aside': case 'header': case 'footer': case 'datagrid':
-                case 'command':
-                    // Work in progress!
-                break;
-
-                /* A start tag token not covered by the previous entries */
-                default:
-                    /* Reconstruct the active formatting elements, if any. */
-                    $this->reconstructActiveFormattingElements();
-
-                    $this->insertElement($token, true, true);
-                break;
-            }
-            break;
 
             case HTML5::ENDTAG:
-            switch($token['name']) {
-                /* An end tag with the tag name "body" */
-                case 'body':
-                    /* If the second element in the stack of open elements is
-                    not a body element, this is a parse error. Ignore the token.
-                    (innerHTML case) */
-                    if(count($this->stack) < 2 || $this->stack[1]->nodeName !== 'body') {
-                        // Ignore.
+                switch ($token['name']) {
+                    /* An end tag with the tag name "body" */
+                    case 'body':
+                        /* If the second element in the stack of open elements is
+                        not a body element, this is a parse error. Ignore the token.
+                        (innerHTML case) */
+                        if (count($this->stack) < 2 || $this->stack[1]->nodeName !== 'body') {
+                            // Ignore.
 
-                    /* If the current node is not the body element, then this
-                    is a parse error. */
-                    } elseif(end($this->stack)->nodeName !== 'body') {
-                        // Parse error.
-                    }
-
-                    /* Change the insertion mode to "after body". */
-                    $this->mode = self::AFTER_BODY;
-                break;
-
-                /* An end tag with the tag name "html" */
-                case 'html':
-                    /* Act as if an end tag with tag name "body" had been seen,
-                    then, if that token wasn't ignored, reprocess the current
-                    token. */
-                    $this->inBody(array(
-                        'name' => 'body',
-                        'type' => HTML5::ENDTAG
-                    ));
-
-                    return $this->afterBody($token);
-                break;
-
-                /* An end tag whose tag name is one of: "address", "blockquote",
-                "center", "dir", "div", "dl", "fieldset", "listing", "menu",
-                "ol", "pre", "ul" */
-                case 'address': case 'blockquote': case 'center': case 'dir':
-                case 'div': case 'dl': case 'fieldset': case 'listing':
-                case 'menu': case 'ol': case 'pre': case 'ul':
-                    /* If the stack of open elements has an element in scope
-                    with the same tag name as that of the token, then generate
-                    implied end tags. */
-                    if($this->elementInScope($token['name'])) {
-                        $this->generateImpliedEndTags();
-
-                        /* Now, if the current node is not an element with
-                        the same tag name as that of the token, then this
-                        is a parse error. */
-                        // w/e
-
-                        /* If the stack of open elements has an element in
-                        scope with the same tag name as that of the token,
-                        then pop elements from this stack until an element
-                        with that tag name has been popped from the stack. */
-                        for($n = count($this->stack) - 1; $n >= 0; $n--) {
-                            if($this->stack[$n]->nodeName === $token['name']) {
-                                $n = -1;
-                            }
-
-                            array_pop($this->stack);
+                            /* If the current node is not the body element, then this
+                            is a parse error. */
+                        } elseif (end($this->stack)->nodeName !== 'body') {
+                            // Parse error.
                         }
-                    }
-                break;
 
-                /* An end tag whose tag name is "form" */
-                case 'form':
-                    /* If the stack of open elements has an element in scope
-                    with the same tag name as that of the token, then generate
-                    implied    end tags. */
-                    if($this->elementInScope($token['name'])) {
-                        $this->generateImpliedEndTags();
+                        /* Change the insertion mode to "after body". */
+                        $this->mode = self::AFTER_BODY;
+                        break;
 
-                    } 
+                    /* An end tag with the tag name "html" */
+                    case 'html':
+                        /* Act as if an end tag with tag name "body" had been seen,
+                        then, if that token wasn't ignored, reprocess the current
+                        token. */
+                        $this->inBody(
+                            array(
+                                'name' => 'body',
+                                'type' => HTML5::ENDTAG
+                            )
+                        );
 
-                    if(end($this->stack)->nodeName !== $token['name']) {
-                        /* Now, if the current node is not an element with the
-                        same tag name as that of the token, then this is a parse
-                        error. */
-                        // w/e
+                        return $this->afterBody($token);
+                        break;
 
-                    } else {
-                        /* Otherwise, if the current node is an element with
-                        the same tag name as that of the token pop that element
-                        from the stack. */
-                        array_pop($this->stack);
-                    }
-
-                    /* In any case, set the form element pointer to null. */
-                    $this->form_pointer = null;
-                break;
-
-                /* An end tag whose tag name is "p" */
-                case 'p':
-                    /* If the stack of open elements has a p element in scope,
-                    then generate implied end tags, except for p elements. */
-                    if($this->elementInScope('p')) {
-                        $this->generateImpliedEndTags(array('p'));
-
-                        /* If the current node is not a p element, then this is
-                        a parse error. */
-                        // k
-
-                        /* If the stack of open elements has a p element in
-                        scope, then pop elements from this stack until the stack
-                        no longer has a p element in scope. */
-                        for($n = count($this->stack) - 1; $n >= 0; $n--) {
-                            if($this->elementInScope('p')) {
-                                array_pop($this->stack);
-
-                            } else {
-                                break;
-                            }
-                        }
-                    }
-                break;
-
-                /* An end tag whose tag name is "dd", "dt", or "li" */
-                case 'dd': case 'dt': case 'li':
-                    /* If the stack of open elements has an element in scope
-                    whose tag name matches the tag name of the token, then
-                    generate implied end tags, except for elements with the
-                    same tag name as the token. */
-                    if($this->elementInScope($token['name'])) {
-                        $this->generateImpliedEndTags(array($token['name']));
-
-                        /* If the current node is not an element with the same
-                        tag name as the token, then this is a parse error. */
-                        // w/e
-
+                    /* An end tag whose tag name is one of: "address", "blockquote",
+                    "center", "dir", "div", "dl", "fieldset", "listing", "menu",
+                    "ol", "pre", "ul" */
+                    case 'address':
+                    case 'blockquote':
+                    case 'center':
+                    case 'dir':
+                    case 'div':
+                    case 'dl':
+                    case 'fieldset':
+                    case 'listing':
+                    case 'menu':
+                    case 'ol':
+                    case 'pre':
+                    case 'ul':
                         /* If the stack of open elements has an element in scope
-                        whose tag name matches the tag name of the token, then
-                        pop elements from this stack until an element with that
-                        tag name has been popped from the stack. */
-                        for($n = count($this->stack) - 1; $n >= 0; $n--) {
-                            if($this->stack[$n]->nodeName === $token['name']) {
-                                $n = -1;
-                            }
+                        with the same tag name as that of the token, then generate
+                        implied end tags. */
+                        if ($this->elementInScope($token['name'])) {
+                            $this->generateImpliedEndTags();
 
-                            array_pop($this->stack);
-                        }
-                    }
-                break;
+                            /* Now, if the current node is not an element with
+                            the same tag name as that of the token, then this
+                            is a parse error. */
+                            // w/e
 
-                /* An end tag whose tag name is one of: "h1", "h2", "h3", "h4",
-                "h5", "h6" */
-                case 'h1': case 'h2': case 'h3': case 'h4': case 'h5': case 'h6':
-                    $elements = array('h1', 'h2', 'h3', 'h4', 'h5', 'h6');
+                            /* If the stack of open elements has an element in
+                            scope with the same tag name as that of the token,
+                            then pop elements from this stack until an element
+                            with that tag name has been popped from the stack. */
+                            for ($n = count($this->stack) - 1; $n >= 0; $n--) {
+                                if ($this->stack[$n]->nodeName === $token['name']) {
+                                    $n = -1;
+                                }
 
-                    /* If the stack of open elements has in scope an element whose
-                    tag name is one of "h1", "h2", "h3", "h4", "h5", or "h6", then
-                    generate implied end tags. */
-                    if($this->elementInScope($elements)) {
-                        $this->generateImpliedEndTags();
-
-                        /* Now, if the current node is not an element with the same
-                        tag name as that of the token, then this is a parse error. */
-                        // w/e
-
-                        /* If the stack of open elements has in scope an element
-                        whose tag name is one of "h1", "h2", "h3", "h4", "h5", or
-                        "h6", then pop elements from the stack until an element
-                        with one of those tag names has been popped from the stack. */
-                        while($this->elementInScope($elements)) {
-                            array_pop($this->stack);
-                        }
-                    }
-                break;
-
-                /* An end tag whose tag name is one of: "a", "b", "big", "em",
-                "font", "i", "nobr", "s", "small", "strike", "strong", "tt", "u" */
-                case 'a': case 'b': case 'big': case 'em': case 'font':
-                case 'i': case 'nobr': case 's': case 'small': case 'strike':
-                case 'strong': case 'tt': case 'u':
-                    /* 1. Let the formatting element be the last element in
-                    the list of active formatting elements that:
-                        * is between the end of the list and the last scope
-                        marker in the list, if any, or the start of the list
-                        otherwise, and
-                        * has the same tag name as the token.
-                    */
-                    while(true) {
-                        for($a = count($this->a_formatting) - 1; $a >= 0; $a--) {
-                            if($this->a_formatting[$a] === self::MARKER) {
-                                break;
-
-                            } elseif($this->a_formatting[$a]->tagName === $token['name']) {
-                                $formatting_element = $this->a_formatting[$a];
-                                $in_stack = in_array($formatting_element, $this->stack, true);
-                                $fe_af_pos = $a;
-                                break;
-                            }
-                        }
-
-                        /* If there is no such node, or, if that node is
-                        also in the stack of open elements but the element
-                        is not in scope, then this is a parse error. Abort
-                        these steps. The token is ignored. */
-                        if(!isset($formatting_element) || ($in_stack &&
-                        !$this->elementInScope($token['name']))) {
-                            break;
-
-                        /* Otherwise, if there is such a node, but that node
-                        is not in the stack of open elements, then this is a
-                        parse error; remove the element from the list, and
-                        abort these steps. */
-                        } elseif(isset($formatting_element) && !$in_stack) {
-                            unset($this->a_formatting[$fe_af_pos]);
-                            $this->a_formatting = array_merge($this->a_formatting);
-                            break;
-                        }
-
-                        /* 2. Let the furthest block be the topmost node in the
-                        stack of open elements that is lower in the stack
-                        than the formatting element, and is not an element in
-                        the phrasing or formatting categories. There might
-                        not be one. */
-                        $fe_s_pos = array_search($formatting_element, $this->stack, true);
-                        $length = count($this->stack);
-
-                        for($s = $fe_s_pos + 1; $s < $length; $s++) {
-                            $category = $this->getElementCategory($this->stack[$s]->nodeName);
-
-                            if($category !== self::PHRASING && $category !== self::FORMATTING) {
-                                $furthest_block = $this->stack[$s];
-                            }
-                        }
-
-                        /* 3. If there is no furthest block, then the UA must
-                        skip the subsequent steps and instead just pop all
-                        the nodes from the bottom of the stack of open
-                        elements, from the current node up to the formatting
-                        element, and remove the formatting element from the
-                        list of active formatting elements. */
-                        if(!isset($furthest_block)) {
-                            for($n = $length - 1; $n >= $fe_s_pos; $n--) {
                                 array_pop($this->stack);
                             }
+                        }
+                        break;
 
-                            unset($this->a_formatting[$fe_af_pos]);
-                            $this->a_formatting = array_merge($this->a_formatting);
-                            break;
+                    /* An end tag whose tag name is "form" */
+                    case 'form':
+                        /* If the stack of open elements has an element in scope
+                        with the same tag name as that of the token, then generate
+                        implied    end tags. */
+                        if ($this->elementInScope($token['name'])) {
+                            $this->generateImpliedEndTags();
+
                         }
 
-                        /* 4. Let the common ancestor be the element
-                        immediately above the formatting element in the stack
-                        of open elements. */
-                        $common_ancestor = $this->stack[$fe_s_pos - 1];
+                        if (end($this->stack)->nodeName !== $token['name']) {
+                            /* Now, if the current node is not an element with the
+                            same tag name as that of the token, then this is a parse
+                            error. */
+                            // w/e
 
-                        /* 5. If the furthest block has a parent node, then
-                        remove the furthest block from its parent node. */
-                        if($furthest_block->parentNode !== null) {
-                            $furthest_block->parentNode->removeChild($furthest_block);
+                        } else {
+                            /* Otherwise, if the current node is an element with
+                            the same tag name as that of the token pop that element
+                            from the stack. */
+                            array_pop($this->stack);
                         }
 
-                        /* 6. Let a bookmark note the position of the
-                        formatting element in the list of active formatting
-                        elements relative to the elements on either side
-                        of it in the list. */
-                        $bookmark = $fe_af_pos;
+                        /* In any case, set the form element pointer to null. */
+                        $this->form_pointer = null;
+                        break;
 
-                        /* 7. Let node and last node  be the furthest block.
-                        Follow these steps: */
-                        $node = $furthest_block;
-                        $last_node = $furthest_block;
+                    /* An end tag whose tag name is "p" */
+                    case 'p':
+                        /* If the stack of open elements has a p element in scope,
+                        then generate implied end tags, except for p elements. */
+                        if ($this->elementInScope('p')) {
+                            $this->generateImpliedEndTags(array('p'));
 
-                        while(true) {
-                            for($n = array_search($node, $this->stack, true) - 1; $n >= 0; $n--) {
-                                /* 7.1 Let node be the element immediately
-                                prior to node in the stack of open elements. */
-                                $node = $this->stack[$n];
+                            /* If the current node is not a p element, then this is
+                            a parse error. */
+                            // k
 
-                                /* 7.2 If node is not in the list of active
-                                formatting elements, then remove node from
-                                the stack of open elements and then go back
-                                to step 1. */
-                                if(!in_array($node, $this->a_formatting, true)) {
-                                    unset($this->stack[$n]);
-                                    $this->stack = array_merge($this->stack);
+                            /* If the stack of open elements has a p element in
+                            scope, then pop elements from this stack until the stack
+                            no longer has a p element in scope. */
+                            for ($n = count($this->stack) - 1; $n >= 0; $n--) {
+                                if ($this->elementInScope('p')) {
+                                    array_pop($this->stack);
 
                                 } else {
                                     break;
                                 }
                             }
+                        }
+                        break;
 
-                            /* 7.3 Otherwise, if node is the formatting
-                            element, then go to the next step in the overall
-                            algorithm. */
-                            if($node === $formatting_element) {
+                    /* An end tag whose tag name is "dd", "dt", or "li" */
+                    case 'dd':
+                    case 'dt':
+                    case 'li':
+                        /* If the stack of open elements has an element in scope
+                        whose tag name matches the tag name of the token, then
+                        generate implied end tags, except for elements with the
+                        same tag name as the token. */
+                        if ($this->elementInScope($token['name'])) {
+                            $this->generateImpliedEndTags(array($token['name']));
+
+                            /* If the current node is not an element with the same
+                            tag name as the token, then this is a parse error. */
+                            // w/e
+
+                            /* If the stack of open elements has an element in scope
+                            whose tag name matches the tag name of the token, then
+                            pop elements from this stack until an element with that
+                            tag name has been popped from the stack. */
+                            for ($n = count($this->stack) - 1; $n >= 0; $n--) {
+                                if ($this->stack[$n]->nodeName === $token['name']) {
+                                    $n = -1;
+                                }
+
+                                array_pop($this->stack);
+                            }
+                        }
+                        break;
+
+                    /* An end tag whose tag name is one of: "h1", "h2", "h3", "h4",
+                    "h5", "h6" */
+                    case 'h1':
+                    case 'h2':
+                    case 'h3':
+                    case 'h4':
+                    case 'h5':
+                    case 'h6':
+                        $elements = array('h1', 'h2', 'h3', 'h4', 'h5', 'h6');
+
+                        /* If the stack of open elements has in scope an element whose
+                        tag name is one of "h1", "h2", "h3", "h4", "h5", or "h6", then
+                        generate implied end tags. */
+                        if ($this->elementInScope($elements)) {
+                            $this->generateImpliedEndTags();
+
+                            /* Now, if the current node is not an element with the same
+                            tag name as that of the token, then this is a parse error. */
+                            // w/e
+
+                            /* If the stack of open elements has in scope an element
+                            whose tag name is one of "h1", "h2", "h3", "h4", "h5", or
+                            "h6", then pop elements from the stack until an element
+                            with one of those tag names has been popped from the stack. */
+                            while ($this->elementInScope($elements)) {
+                                array_pop($this->stack);
+                            }
+                        }
+                        break;
+
+                    /* An end tag whose tag name is one of: "a", "b", "big", "em",
+                    "font", "i", "nobr", "s", "small", "strike", "strong", "tt", "u" */
+                    case 'a':
+                    case 'b':
+                    case 'big':
+                    case 'em':
+                    case 'font':
+                    case 'i':
+                    case 'nobr':
+                    case 's':
+                    case 'small':
+                    case 'strike':
+                    case 'strong':
+                    case 'tt':
+                    case 'u':
+                        /* 1. Let the formatting element be the last element in
+                        the list of active formatting elements that:
+                            * is between the end of the list and the last scope
+                            marker in the list, if any, or the start of the list
+                            otherwise, and
+                            * has the same tag name as the token.
+                        */
+                        while (true) {
+                            for ($a = count($this->a_formatting) - 1; $a >= 0; $a--) {
+                                if ($this->a_formatting[$a] === self::MARKER) {
+                                    break;
+
+                                } elseif ($this->a_formatting[$a]->tagName === $token['name']) {
+                                    $formatting_element = $this->a_formatting[$a];
+                                    $in_stack = in_array($formatting_element, $this->stack, true);
+                                    $fe_af_pos = $a;
+                                    break;
+                                }
+                            }
+
+                            /* If there is no such node, or, if that node is
+                            also in the stack of open elements but the element
+                            is not in scope, then this is a parse error. Abort
+                            these steps. The token is ignored. */
+                            if (!isset($formatting_element) || ($in_stack &&
+                                    !$this->elementInScope($token['name']))
+                            ) {
                                 break;
 
-                            /* 7.4 Otherwise, if last node is the furthest
-                            block, then move the aforementioned bookmark to
-                            be immediately after the node in the list of
-                            active formatting elements. */
-                            } elseif($last_node === $furthest_block) {
-                                $bookmark = array_search($node, $this->a_formatting, true) + 1;
+                                /* Otherwise, if there is such a node, but that node
+                                is not in the stack of open elements, then this is a
+                                parse error; remove the element from the list, and
+                                abort these steps. */
+                            } elseif (isset($formatting_element) && !$in_stack) {
+                                unset($this->a_formatting[$fe_af_pos]);
+                                $this->a_formatting = array_merge($this->a_formatting);
+                                break;
                             }
 
-                            /* 7.5 If node has any children, perform a
-                            shallow clone of node, replace the entry for
-                            node in the list of active formatting elements
-                            with an entry for the clone, replace the entry
-                            for node in the stack of open elements with an
-                            entry for the clone, and let node be the clone. */
-                            if($node->hasChildNodes()) {
-                                $clone = $node->cloneNode();
-                                $s_pos = array_search($node, $this->stack, true);
-                                $a_pos = array_search($node, $this->a_formatting, true);
+                            /* 2. Let the furthest block be the topmost node in the
+                            stack of open elements that is lower in the stack
+                            than the formatting element, and is not an element in
+                            the phrasing or formatting categories. There might
+                            not be one. */
+                            $fe_s_pos = array_search($formatting_element, $this->stack, true);
+                            $length = count($this->stack);
 
-                                $this->stack[$s_pos] = $clone;
-                                $this->a_formatting[$a_pos] = $clone;
-                                $node = $clone;
+                            for ($s = $fe_s_pos + 1; $s < $length; $s++) {
+                                $category = $this->getElementCategory($this->stack[$s]->nodeName);
+
+                                if ($category !== self::PHRASING && $category !== self::FORMATTING) {
+                                    $furthest_block = $this->stack[$s];
+                                }
                             }
 
-                            /* 7.6 Insert last node into node, first removing
-                            it from its previous parent node if any. */
-                            if($last_node->parentNode !== null) {
+                            /* 3. If there is no furthest block, then the UA must
+                            skip the subsequent steps and instead just pop all
+                            the nodes from the bottom of the stack of open
+                            elements, from the current node up to the formatting
+                            element, and remove the formatting element from the
+                            list of active formatting elements. */
+                            if (!isset($furthest_block)) {
+                                for ($n = $length - 1; $n >= $fe_s_pos; $n--) {
+                                    array_pop($this->stack);
+                                }
+
+                                unset($this->a_formatting[$fe_af_pos]);
+                                $this->a_formatting = array_merge($this->a_formatting);
+                                break;
+                            }
+
+                            /* 4. Let the common ancestor be the element
+                            immediately above the formatting element in the stack
+                            of open elements. */
+                            $common_ancestor = $this->stack[$fe_s_pos - 1];
+
+                            /* 5. If the furthest block has a parent node, then
+                            remove the furthest block from its parent node. */
+                            if ($furthest_block->parentNode !== null) {
+                                $furthest_block->parentNode->removeChild($furthest_block);
+                            }
+
+                            /* 6. Let a bookmark note the position of the
+                            formatting element in the list of active formatting
+                            elements relative to the elements on either side
+                            of it in the list. */
+                            $bookmark = $fe_af_pos;
+
+                            /* 7. Let node and last node  be the furthest block.
+                            Follow these steps: */
+                            $node = $furthest_block;
+                            $last_node = $furthest_block;
+
+                            while (true) {
+                                for ($n = array_search($node, $this->stack, true) - 1; $n >= 0; $n--) {
+                                    /* 7.1 Let node be the element immediately
+                                    prior to node in the stack of open elements. */
+                                    $node = $this->stack[$n];
+
+                                    /* 7.2 If node is not in the list of active
+                                    formatting elements, then remove node from
+                                    the stack of open elements and then go back
+                                    to step 1. */
+                                    if (!in_array($node, $this->a_formatting, true)) {
+                                        unset($this->stack[$n]);
+                                        $this->stack = array_merge($this->stack);
+
+                                    } else {
+                                        break;
+                                    }
+                                }
+
+                                /* 7.3 Otherwise, if node is the formatting
+                                element, then go to the next step in the overall
+                                algorithm. */
+                                if ($node === $formatting_element) {
+                                    break;
+
+                                    /* 7.4 Otherwise, if last node is the furthest
+                                    block, then move the aforementioned bookmark to
+                                    be immediately after the node in the list of
+                                    active formatting elements. */
+                                } elseif ($last_node === $furthest_block) {
+                                    $bookmark = array_search($node, $this->a_formatting, true) + 1;
+                                }
+
+                                /* 7.5 If node has any children, perform a
+                                shallow clone of node, replace the entry for
+                                node in the list of active formatting elements
+                                with an entry for the clone, replace the entry
+                                for node in the stack of open elements with an
+                                entry for the clone, and let node be the clone. */
+                                if ($node->hasChildNodes()) {
+                                    $clone = $node->cloneNode();
+                                    $s_pos = array_search($node, $this->stack, true);
+                                    $a_pos = array_search($node, $this->a_formatting, true);
+
+                                    $this->stack[$s_pos] = $clone;
+                                    $this->a_formatting[$a_pos] = $clone;
+                                    $node = $clone;
+                                }
+
+                                /* 7.6 Insert last node into node, first removing
+                                it from its previous parent node if any. */
+                                if ($last_node->parentNode !== null) {
+                                    $last_node->parentNode->removeChild($last_node);
+                                }
+
+                                $node->appendChild($last_node);
+
+                                /* 7.7 Let last node be node. */
+                                $last_node = $node;
+                            }
+
+                            /* 8. Insert whatever last node ended up being in
+                            the previous step into the common ancestor node,
+                            first removing it from its previous parent node if
+                            any. */
+                            if ($last_node->parentNode !== null) {
                                 $last_node->parentNode->removeChild($last_node);
                             }
 
-                            $node->appendChild($last_node);
+                            $common_ancestor->appendChild($last_node);
 
-                            /* 7.7 Let last node be node. */
-                            $last_node = $node;
-                        }
+                            /* 9. Perform a shallow clone of the formatting
+                            element. */
+                            $clone = $formatting_element->cloneNode();
 
-                        /* 8. Insert whatever last node ended up being in
-                        the previous step into the common ancestor node,
-                        first removing it from its previous parent node if
-                        any. */
-                        if($last_node->parentNode !== null) {
-                            $last_node->parentNode->removeChild($last_node);
-                        }
-
-                        $common_ancestor->appendChild($last_node);
-
-                        /* 9. Perform a shallow clone of the formatting
-                        element. */
-                        $clone = $formatting_element->cloneNode();
-
-                        /* 10. Take all of the child nodes of the furthest
-                        block and append them to the clone created in the
-                        last step. */
-                        while($furthest_block->hasChildNodes()) {
-                            $child = $furthest_block->firstChild;
-                            $furthest_block->removeChild($child);
-                            $clone->appendChild($child);
-                        }
-
-                        /* 11. Append that clone to the furthest block. */
-                        $furthest_block->appendChild($clone);
-
-                        /* 12. Remove the formatting element from the list
-                        of active formatting elements, and insert the clone
-                        into the list of active formatting elements at the
-                        position of the aforementioned bookmark. */
-                        $fe_af_pos = array_search($formatting_element, $this->a_formatting, true);
-                        unset($this->a_formatting[$fe_af_pos]);
-                        $this->a_formatting = array_merge($this->a_formatting);
-
-                        $af_part1 = array_slice($this->a_formatting, 0, $bookmark - 1);
-                        $af_part2 = array_slice($this->a_formatting, $bookmark, count($this->a_formatting));
-                        $this->a_formatting = array_merge($af_part1, array($clone), $af_part2);
-
-                        /* 13. Remove the formatting element from the stack
-                        of open elements, and insert the clone into the stack
-                        of open elements immediately after (i.e. in a more
-                        deeply nested position than) the position of the
-                        furthest block in that stack. */
-                        $fe_s_pos = array_search($formatting_element, $this->stack, true);
-                        $fb_s_pos = array_search($furthest_block, $this->stack, true);
-                        unset($this->stack[$fe_s_pos]);
-
-                        $s_part1 = array_slice($this->stack, 0, $fb_s_pos);
-                        $s_part2 = array_slice($this->stack, $fb_s_pos + 1, count($this->stack));
-                        $this->stack = array_merge($s_part1, array($clone), $s_part2);
-
-                        /* 14. Jump back to step 1 in this series of steps. */
-                        unset($formatting_element, $fe_af_pos, $fe_s_pos, $furthest_block);
-                    }
-                break;
-
-                /* An end tag token whose tag name is one of: "button",
-                "marquee", "object" */
-                case 'button': case 'marquee': case 'object':
-                    /* If the stack of open elements has an element in scope whose
-                    tag name matches the tag name of the token, then generate implied
-                    tags. */
-                    if($this->elementInScope($token['name'])) {
-                        $this->generateImpliedEndTags();
-
-                        /* Now, if the current node is not an element with the same
-                        tag name as the token, then this is a parse error. */
-                        // k
-
-                        /* Now, if the stack of open elements has an element in scope
-                        whose tag name matches the tag name of the token, then pop
-                        elements from the stack until that element has been popped from
-                        the stack, and clear the list of active formatting elements up
-                        to the last marker. */
-                        for($n = count($this->stack) - 1; $n >= 0; $n--) {
-                            if($this->stack[$n]->nodeName === $token['name']) {
-                                $n = -1;
+                            /* 10. Take all of the child nodes of the furthest
+                            block and append them to the clone created in the
+                            last step. */
+                            while ($furthest_block->hasChildNodes()) {
+                                $child = $furthest_block->firstChild;
+                                $furthest_block->removeChild($child);
+                                $clone->appendChild($child);
                             }
 
-                            array_pop($this->stack);
+                            /* 11. Append that clone to the furthest block. */
+                            $furthest_block->appendChild($clone);
+
+                            /* 12. Remove the formatting element from the list
+                            of active formatting elements, and insert the clone
+                            into the list of active formatting elements at the
+                            position of the aforementioned bookmark. */
+                            $fe_af_pos = array_search($formatting_element, $this->a_formatting, true);
+                            unset($this->a_formatting[$fe_af_pos]);
+                            $this->a_formatting = array_merge($this->a_formatting);
+
+                            $af_part1 = array_slice($this->a_formatting, 0, $bookmark - 1);
+                            $af_part2 = array_slice($this->a_formatting, $bookmark, count($this->a_formatting));
+                            $this->a_formatting = array_merge($af_part1, array($clone), $af_part2);
+
+                            /* 13. Remove the formatting element from the stack
+                            of open elements, and insert the clone into the stack
+                            of open elements immediately after (i.e. in a more
+                            deeply nested position than) the position of the
+                            furthest block in that stack. */
+                            $fe_s_pos = array_search($formatting_element, $this->stack, true);
+                            $fb_s_pos = array_search($furthest_block, $this->stack, true);
+                            unset($this->stack[$fe_s_pos]);
+
+                            $s_part1 = array_slice($this->stack, 0, $fb_s_pos);
+                            $s_part2 = array_slice($this->stack, $fb_s_pos + 1, count($this->stack));
+                            $this->stack = array_merge($s_part1, array($clone), $s_part2);
+
+                            /* 14. Jump back to step 1 in this series of steps. */
+                            unset($formatting_element, $fe_af_pos, $fe_s_pos, $furthest_block);
                         }
+                        break;
 
-                        $marker = end(array_keys($this->a_formatting, self::MARKER, true));
-
-                        for($n = count($this->a_formatting) - 1; $n > $marker; $n--) {
-                            array_pop($this->a_formatting);
-                        }
-                    }
-                break;
-
-                /* Or an end tag whose tag name is one of: "area", "basefont",
-                "bgsound", "br", "embed", "hr", "iframe", "image", "img",
-                "input", "isindex", "noembed", "noframes", "param", "select",
-                "spacer", "table", "textarea", "wbr" */
-                case 'area': case 'basefont': case 'bgsound': case 'br':
-                case 'embed': case 'hr': case 'iframe': case 'image':
-                case 'img': case 'input': case 'isindex': case 'noembed':
-                case 'noframes': case 'param': case 'select': case 'spacer':
-                case 'table': case 'textarea': case 'wbr':
-                    // Parse error. Ignore the token.
-                break;
-
-                /* An end tag token not covered by the previous entries */
-                default:
-                    for($n = count($this->stack) - 1; $n >= 0; $n--) {
-                        /* Initialise node to be the current node (the bottommost
-                        node of the stack). */
-                        $node = end($this->stack);
-
-                        /* If node has the same tag name as the end tag token,
-                        then: */
-                        if($token['name'] === $node->nodeName) {
-                            /* Generate implied end tags. */
+                    /* An end tag token whose tag name is one of: "button",
+                    "marquee", "object" */
+                    case 'button':
+                    case 'marquee':
+                    case 'object':
+                        /* If the stack of open elements has an element in scope whose
+                        tag name matches the tag name of the token, then generate implied
+                        tags. */
+                        if ($this->elementInScope($token['name'])) {
                             $this->generateImpliedEndTags();
 
-                            /* If the tag name of the end tag token does not
-                            match the tag name of the current node, this is a
-                            parse error. */
+                            /* Now, if the current node is not an element with the same
+                            tag name as the token, then this is a parse error. */
                             // k
 
-                            /* Pop all the nodes from the current node up to
-                            node, including node, then stop this algorithm. */
-                            for($x = count($this->stack) - $n; $x >= $n; $x--) {
+                            /* Now, if the stack of open elements has an element in scope
+                            whose tag name matches the tag name of the token, then pop
+                            elements from the stack until that element has been popped from
+                            the stack, and clear the list of active formatting elements up
+                            to the last marker. */
+                            for ($n = count($this->stack) - 1; $n >= 0; $n--) {
+                                if ($this->stack[$n]->nodeName === $token['name']) {
+                                    $n = -1;
+                                }
+
                                 array_pop($this->stack);
                             }
-                                    
-                        } else {
-                            $category = $this->getElementCategory($node);
 
-                            if($category !== self::SPECIAL && $category !== self::SCOPING) {
-                                /* Otherwise, if node is in neither the formatting
-                                category nor the phrasing category, then this is a
-                                parse error. Stop this algorithm. The end tag token
-                                is ignored. */
-                                return false;
+                            $marker = end(array_keys($this->a_formatting, self::MARKER, true));
+
+                            for ($n = count($this->a_formatting) - 1; $n > $marker; $n--) {
+                                array_pop($this->a_formatting);
                             }
                         }
-                    }
+                        break;
+
+                    /* Or an end tag whose tag name is one of: "area", "basefont",
+                    "bgsound", "br", "embed", "hr", "iframe", "image", "img",
+                    "input", "isindex", "noembed", "noframes", "param", "select",
+                    "spacer", "table", "textarea", "wbr" */
+                    case 'area':
+                    case 'basefont':
+                    case 'bgsound':
+                    case 'br':
+                    case 'embed':
+                    case 'hr':
+                    case 'iframe':
+                    case 'image':
+                    case 'img':
+                    case 'input':
+                    case 'isindex':
+                    case 'noembed':
+                    case 'noframes':
+                    case 'param':
+                    case 'select':
+                    case 'spacer':
+                    case 'table':
+                    case 'textarea':
+                    case 'wbr':
+                        // Parse error. Ignore the token.
+                        break;
+
+                    /* An end tag token not covered by the previous entries */
+                    default:
+                        for ($n = count($this->stack) - 1; $n >= 0; $n--) {
+                            /* Initialise node to be the current node (the bottommost
+                            node of the stack). */
+                            $node = end($this->stack);
+
+                            /* If node has the same tag name as the end tag token,
+                            then: */
+                            if ($token['name'] === $node->nodeName) {
+                                /* Generate implied end tags. */
+                                $this->generateImpliedEndTags();
+
+                                /* If the tag name of the end tag token does not
+                                match the tag name of the current node, this is a
+                                parse error. */
+                                // k
+
+                                /* Pop all the nodes from the current node up to
+                                node, including node, then stop this algorithm. */
+                                for ($x = count($this->stack) - $n; $x >= $n; $x--) {
+                                    array_pop($this->stack);
+                                }
+
+                            } else {
+                                $category = $this->getElementCategory($node);
+
+                                if ($category !== self::SPECIAL && $category !== self::SCOPING) {
+                                    /* Otherwise, if node is in neither the formatting
+                                    category nor the phrasing category, then this is a
+                                    parse error. Stop this algorithm. The end tag token
+                                    is ignored. */
+                                    return false;
+                                }
+                            }
+                        }
+                        break;
+                }
                 break;
-            }
-            break;
         }
     }
 
-    private function inTable($token) {
+    private function inTable($token)
+    {
         $clear = array('html', 'table');
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
         U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
         or U+0020 SPACE */
-        if($token['type'] === HTML5::CHARACTR &&
-        preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) {
+        if ($token['type'] === HTML5::CHARACTR &&
+            preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])
+        ) {
             /* Append the character to the current node. */
             $text = $this->dom->createTextNode($token['data']);
             end($this->stack)->appendChild($text);
 
-        /* A comment token */
-        } elseif($token['type'] === HTML5::COMMENT) {
+            /* A comment token */
+        } elseif ($token['type'] === HTML5::COMMENT) {
             /* Append a Comment node to the current node with the data
             attribute set to the data given in the comment token. */
             $comment = $this->dom->createComment($token['data']);
             end($this->stack)->appendChild($comment);
 
-        /* A start tag whose tag name is "caption" */
-        } elseif($token['type'] === HTML5::STARTTAG &&
-        $token['name'] === 'caption') {
+            /* A start tag whose tag name is "caption" */
+        } elseif ($token['type'] === HTML5::STARTTAG &&
+            $token['name'] === 'caption'
+        ) {
             /* Clear the stack back to a table context. */
             $this->clearStackToTableContext($clear);
 
@@ -2661,9 +3350,10 @@ class HTML5TreeConstructer {
             $this->insertElement($token);
             $this->mode = self::IN_CAPTION;
 
-        /* A start tag whose tag name is "colgroup" */
-        } elseif($token['type'] === HTML5::STARTTAG &&
-        $token['name'] === 'colgroup') {
+            /* A start tag whose tag name is "colgroup" */
+        } elseif ($token['type'] === HTML5::STARTTAG &&
+            $token['name'] === 'colgroup'
+        ) {
             /* Clear the stack back to a table context. */
             $this->clearStackToTableContext($clear);
 
@@ -2672,20 +3362,26 @@ class HTML5TreeConstructer {
             $this->insertElement($token);
             $this->mode = self::IN_CGROUP;
 
-        /* A start tag whose tag name is "col" */
-        } elseif($token['type'] === HTML5::STARTTAG &&
-        $token['name'] === 'col') {
-            $this->inTable(array(
-                'name' => 'colgroup',
-                'type' => HTML5::STARTTAG,
-                'attr' => array()
-            ));
+            /* A start tag whose tag name is "col" */
+        } elseif ($token['type'] === HTML5::STARTTAG &&
+            $token['name'] === 'col'
+        ) {
+            $this->inTable(
+                array(
+                    'name' => 'colgroup',
+                    'type' => HTML5::STARTTAG,
+                    'attr' => array()
+                )
+            );
 
             $this->inColumnGroup($token);
 
-        /* A start tag whose tag name is one of: "tbody", "tfoot", "thead" */
-        } elseif($token['type'] === HTML5::STARTTAG && in_array($token['name'],
-        array('tbody', 'tfoot', 'thead'))) {
+            /* A start tag whose tag name is one of: "tbody", "tfoot", "thead" */
+        } elseif ($token['type'] === HTML5::STARTTAG && in_array(
+                $token['name'],
+                array('tbody', 'tfoot', 'thead')
+            )
+        ) {
             /* Clear the stack back to a table context. */
             $this->clearStackToTableContext($clear);
 
@@ -2694,42 +3390,49 @@ class HTML5TreeConstructer {
             $this->insertElement($token);
             $this->mode = self::IN_TBODY;
 
-        /* A start tag whose tag name is one of: "td", "th", "tr" */
-        } elseif($token['type'] === HTML5::STARTTAG &&
-        in_array($token['name'], array('td', 'th', 'tr'))) {
+            /* A start tag whose tag name is one of: "td", "th", "tr" */
+        } elseif ($token['type'] === HTML5::STARTTAG &&
+            in_array($token['name'], array('td', 'th', 'tr'))
+        ) {
             /* Act as if a start tag token with the tag name "tbody" had been
             seen, then reprocess the current token. */
-            $this->inTable(array(
-                'name' => 'tbody',
-                'type' => HTML5::STARTTAG,
-                'attr' => array()
-            ));
+            $this->inTable(
+                array(
+                    'name' => 'tbody',
+                    'type' => HTML5::STARTTAG,
+                    'attr' => array()
+                )
+            );
 
             return $this->inTableBody($token);
 
-        /* A start tag whose tag name is "table" */
-        } elseif($token['type'] === HTML5::STARTTAG &&
-        $token['name'] === 'table') {
+            /* A start tag whose tag name is "table" */
+        } elseif ($token['type'] === HTML5::STARTTAG &&
+            $token['name'] === 'table'
+        ) {
             /* Parse error. Act as if an end tag token with the tag name "table"
             had been seen, then, if that token wasn't ignored, reprocess the
             current token. */
-            $this->inTable(array(
-                'name' => 'table',
-                'type' => HTML5::ENDTAG
-            ));
+            $this->inTable(
+                array(
+                    'name' => 'table',
+                    'type' => HTML5::ENDTAG
+                )
+            );
 
             return $this->mainPhase($token);
 
-        /* An end tag whose tag name is "table" */
-        } elseif($token['type'] === HTML5::ENDTAG &&
-        $token['name'] === 'table') {
+            /* An end tag whose tag name is "table" */
+        } elseif ($token['type'] === HTML5::ENDTAG &&
+            $token['name'] === 'table'
+        ) {
             /* If the stack of open elements does not have an element in table
             scope with the same tag name as the token, this is a parse error.
             Ignore the token. (innerHTML case) */
-            if(!$this->elementInScope($token['name'], true)) {
+            if (!$this->elementInScope($token['name'], true)) {
                 return false;
 
-            /* Otherwise: */
+                /* Otherwise: */
             } else {
                 /* Generate implied end tags. */
                 $this->generateImpliedEndTags();
@@ -2740,11 +3443,11 @@ class HTML5TreeConstructer {
 
                 /* Pop elements from this stack until a table element has been
                 popped from the stack. */
-                while(true) {
+                while (true) {
                     $current = end($this->stack)->nodeName;
                     array_pop($this->stack);
 
-                    if($current === 'table') {
+                    if ($current === 'table') {
                         break;
                     }
                 }
@@ -2753,14 +3456,28 @@ class HTML5TreeConstructer {
                 $this->resetInsertionMode();
             }
 
-        /* An end tag whose tag name is one of: "body", "caption", "col",
-        "colgroup", "html", "tbody", "td", "tfoot", "th", "thead", "tr" */
-        } elseif($token['type'] === HTML5::ENDTAG && in_array($token['name'],
-        array('body', 'caption', 'col', 'colgroup', 'html', 'tbody', 'td',
-        'tfoot', 'th', 'thead', 'tr'))) {
+            /* An end tag whose tag name is one of: "body", "caption", "col",
+            "colgroup", "html", "tbody", "td", "tfoot", "th", "thead", "tr" */
+        } elseif ($token['type'] === HTML5::ENDTAG && in_array(
+                $token['name'],
+                array(
+                    'body',
+                    'caption',
+                    'col',
+                    'colgroup',
+                    'html',
+                    'tbody',
+                    'td',
+                    'tfoot',
+                    'th',
+                    'thead',
+                    'tr'
+                )
+            )
+        ) {
             // Parse error. Ignore the token.
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Parse error. Process the token as if the insertion mode was "in
             body", with the following exception: */
@@ -2768,8 +3485,11 @@ class HTML5TreeConstructer {
             /* If the current node is a table, tbody, tfoot, thead, or tr
             element, then, whenever a node would be inserted into the current
             node, it must instead be inserted into the foster parent element. */
-            if(in_array(end($this->stack)->nodeName,
-            array('table', 'tbody', 'tfoot', 'thead', 'tr'))) {
+            if (in_array(
+                end($this->stack)->nodeName,
+                array('table', 'tbody', 'tfoot', 'thead', 'tr')
+            )
+            ) {
                 /* The foster parent element is the parent element of the last
                 table element in the stack of open elements, if there is a
                 table element and it has such a parent element. If there is no
@@ -2781,21 +3501,22 @@ class HTML5TreeConstructer {
                 its parent node is not an element, then the foster parent
                 element is the element before the last table element in the
                 stack of open elements. */
-                for($n = count($this->stack) - 1; $n >= 0; $n--) {
-                    if($this->stack[$n]->nodeName === 'table') {
+                for ($n = count($this->stack) - 1; $n >= 0; $n--) {
+                    if ($this->stack[$n]->nodeName === 'table') {
                         $table = $this->stack[$n];
                         break;
                     }
                 }
 
-                if(isset($table) && $table->parentNode !== null) {
+                if (isset($table) && $table->parentNode !== null) {
                     $this->foster_parent = $table->parentNode;
 
-                } elseif(!isset($table)) {
+                } elseif (!isset($table)) {
                     $this->foster_parent = $this->stack[0];
 
-                } elseif(isset($table) && ($table->parentNode === null ||
-                $table->parentNode->nodeType !== XML_ELEMENT_NODE)) {
+                } elseif (isset($table) && ($table->parentNode === null ||
+                        $table->parentNode->nodeType !== XML_ELEMENT_NODE)
+                ) {
                     $this->foster_parent = $this->stack[$n - 1];
                 }
             }
@@ -2804,16 +3525,17 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function inCaption($token) {
+    private function inCaption($token)
+    {
         /* An end tag whose tag name is "caption" */
-        if($token['type'] === HTML5::ENDTAG && $token['name'] === 'caption') {
+        if ($token['type'] === HTML5::ENDTAG && $token['name'] === 'caption') {
             /* If the stack of open elements does not have an element in table
             scope with the same tag name as the token, this is a parse error.
             Ignore the token. (innerHTML case) */
-            if(!$this->elementInScope($token['name'], true)) {
+            if (!$this->elementInScope($token['name'], true)) {
                 // Ignore
 
-            /* Otherwise: */
+                /* Otherwise: */
             } else {
                 /* Generate implied end tags. */
                 $this->generateImpliedEndTags();
@@ -2824,11 +3546,11 @@ class HTML5TreeConstructer {
 
                 /* Pop elements from this stack until a caption element has
                 been popped from the stack. */
-                while(true) {
+                while (true) {
                     $node = end($this->stack)->nodeName;
                     array_pop($this->stack);
 
-                    if($node === 'caption') {
+                    if ($node === 'caption') {
                         break;
                     }
                 }
@@ -2841,99 +3563,131 @@ class HTML5TreeConstructer {
                 $this->mode = self::IN_TABLE;
             }
 
-        /* A start tag whose tag name is one of: "caption", "col", "colgroup",
-        "tbody", "td", "tfoot", "th", "thead", "tr", or an end tag whose tag
-        name is "table" */
-        } elseif(($token['type'] === HTML5::STARTTAG && in_array($token['name'],
-        array('caption', 'col', 'colgroup', 'tbody', 'td', 'tfoot', 'th',
-        'thead', 'tr'))) || ($token['type'] === HTML5::ENDTAG &&
-        $token['name'] === 'table')) {
+            /* A start tag whose tag name is one of: "caption", "col", "colgroup",
+            "tbody", "td", "tfoot", "th", "thead", "tr", or an end tag whose tag
+            name is "table" */
+        } elseif (($token['type'] === HTML5::STARTTAG && in_array(
+                    $token['name'],
+                    array(
+                        'caption',
+                        'col',
+                        'colgroup',
+                        'tbody',
+                        'td',
+                        'tfoot',
+                        'th',
+                        'thead',
+                        'tr'
+                    )
+                )) || ($token['type'] === HTML5::ENDTAG &&
+                $token['name'] === 'table')
+        ) {
             /* Parse error. Act as if an end tag with the tag name "caption"
             had been seen, then, if that token wasn't ignored, reprocess the
             current token. */
-            $this->inCaption(array(
-                'name' => 'caption',
-                'type' => HTML5::ENDTAG
-            ));
+            $this->inCaption(
+                array(
+                    'name' => 'caption',
+                    'type' => HTML5::ENDTAG
+                )
+            );
 
             return $this->inTable($token);
 
-        /* An end tag whose tag name is one of: "body", "col", "colgroup",
-        "html", "tbody", "td", "tfoot", "th", "thead", "tr" */
-        } elseif($token['type'] === HTML5::ENDTAG && in_array($token['name'],
-        array('body', 'col', 'colgroup', 'html', 'tbody', 'tfoot', 'th',
-        'thead', 'tr'))) {
+            /* An end tag whose tag name is one of: "body", "col", "colgroup",
+            "html", "tbody", "td", "tfoot", "th", "thead", "tr" */
+        } elseif ($token['type'] === HTML5::ENDTAG && in_array(
+                $token['name'],
+                array(
+                    'body',
+                    'col',
+                    'colgroup',
+                    'html',
+                    'tbody',
+                    'tfoot',
+                    'th',
+                    'thead',
+                    'tr'
+                )
+            )
+        ) {
             // Parse error. Ignore the token.
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Process the token as if the insertion mode was "in body". */
             $this->inBody($token);
         }
     }
 
-    private function inColumnGroup($token) {
+    private function inColumnGroup($token)
+    {
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
         U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
         or U+0020 SPACE */
-        if($token['type'] === HTML5::CHARACTR &&
-        preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) {
+        if ($token['type'] === HTML5::CHARACTR &&
+            preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])
+        ) {
             /* Append the character to the current node. */
             $text = $this->dom->createTextNode($token['data']);
             end($this->stack)->appendChild($text);
 
-        /* A comment token */
-        } elseif($token['type'] === HTML5::COMMENT) {
+            /* A comment token */
+        } elseif ($token['type'] === HTML5::COMMENT) {
             /* Append a Comment node to the current node with the data
             attribute set to the data given in the comment token. */
             $comment = $this->dom->createComment($token['data']);
             end($this->stack)->appendChild($comment);
 
-        /* A start tag whose tag name is "col" */
-        } elseif($token['type'] === HTML5::STARTTAG && $token['name'] === 'col') {
+            /* A start tag whose tag name is "col" */
+        } elseif ($token['type'] === HTML5::STARTTAG && $token['name'] === 'col') {
             /* Insert a col element for the token. Immediately pop the current
             node off the stack of open elements. */
             $this->insertElement($token);
             array_pop($this->stack);
 
-        /* An end tag whose tag name is "colgroup" */
-        } elseif($token['type'] === HTML5::ENDTAG &&
-        $token['name'] === 'colgroup') {
+            /* An end tag whose tag name is "colgroup" */
+        } elseif ($token['type'] === HTML5::ENDTAG &&
+            $token['name'] === 'colgroup'
+        ) {
             /* If the current node is the root html element, then this is a
             parse error, ignore the token. (innerHTML case) */
-            if(end($this->stack)->nodeName === 'html') {
+            if (end($this->stack)->nodeName === 'html') {
                 // Ignore
 
-            /* Otherwise, pop the current node (which will be a colgroup
-            element) from the stack of open elements. Switch the insertion
-            mode to "in table". */
+                /* Otherwise, pop the current node (which will be a colgroup
+                element) from the stack of open elements. Switch the insertion
+                mode to "in table". */
             } else {
                 array_pop($this->stack);
                 $this->mode = self::IN_TABLE;
             }
 
-        /* An end tag whose tag name is "col" */
-        } elseif($token['type'] === HTML5::ENDTAG && $token['name'] === 'col') {
+            /* An end tag whose tag name is "col" */
+        } elseif ($token['type'] === HTML5::ENDTAG && $token['name'] === 'col') {
             /* Parse error. Ignore the token. */
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Act as if an end tag with the tag name "colgroup" had been seen,
             and then, if that token wasn't ignored, reprocess the current token. */
-            $this->inColumnGroup(array(
-                'name' => 'colgroup',
-                'type' => HTML5::ENDTAG
-            ));
+            $this->inColumnGroup(
+                array(
+                    'name' => 'colgroup',
+                    'type' => HTML5::ENDTAG
+                )
+            );
 
             return $this->inTable($token);
         }
     }
 
-    private function inTableBody($token) {
+    private function inTableBody($token)
+    {
         $clear = array('tbody', 'tfoot', 'thead', 'html');
 
         /* A start tag whose tag name is "tr" */
-        if($token['type'] === HTML5::STARTTAG && $token['name'] === 'tr') {
+        if ($token['type'] === HTML5::STARTTAG && $token['name'] === 'tr') {
             /* Clear the stack back to a table body context. */
             $this->clearStackToTableContext($clear);
 
@@ -2942,29 +3696,33 @@ class HTML5TreeConstructer {
             $this->insertElement($token);
             $this->mode = self::IN_ROW;
 
-        /* A start tag whose tag name is one of: "th", "td" */
-        } elseif($token['type'] === HTML5::STARTTAG &&
-        ($token['name'] === 'th' ||    $token['name'] === 'td')) {
+            /* A start tag whose tag name is one of: "th", "td" */
+        } elseif ($token['type'] === HTML5::STARTTAG &&
+            ($token['name'] === 'th' || $token['name'] === 'td')
+        ) {
             /* Parse error. Act as if a start tag with the tag name "tr" had
             been seen, then reprocess the current token. */
-            $this->inTableBody(array(
-                'name' => 'tr',
-                'type' => HTML5::STARTTAG,
-                'attr' => array()
-            ));
+            $this->inTableBody(
+                array(
+                    'name' => 'tr',
+                    'type' => HTML5::STARTTAG,
+                    'attr' => array()
+                )
+            );
 
             return $this->inRow($token);
 
-        /* An end tag whose tag name is one of: "tbody", "tfoot", "thead" */
-        } elseif($token['type'] === HTML5::ENDTAG &&
-        in_array($token['name'], array('tbody', 'tfoot', 'thead'))) {
+            /* An end tag whose tag name is one of: "tbody", "tfoot", "thead" */
+        } elseif ($token['type'] === HTML5::ENDTAG &&
+            in_array($token['name'], array('tbody', 'tfoot', 'thead'))
+        ) {
             /* If the stack of open elements does not have an element in table
             scope with the same tag name as the token, this is a parse error.
             Ignore the token. */
-            if(!$this->elementInScope($token['name'], true)) {
+            if (!$this->elementInScope($token['name'], true)) {
                 // Ignore
 
-            /* Otherwise: */
+                /* Otherwise: */
             } else {
                 /* Clear the stack back to a table body context. */
                 $this->clearStackToTableContext($clear);
@@ -2975,18 +3733,21 @@ class HTML5TreeConstructer {
                 $this->mode = self::IN_TABLE;
             }
 
-        /* A start tag whose tag name is one of: "caption", "col", "colgroup",
-        "tbody", "tfoot", "thead", or an end tag whose tag name is "table" */
-        } elseif(($token['type'] === HTML5::STARTTAG && in_array($token['name'],
-        array('caption', 'col', 'colgroup', 'tbody', 'tfoor', 'thead'))) ||
-        ($token['type'] === HTML5::STARTTAG && $token['name'] === 'table')) {
+            /* A start tag whose tag name is one of: "caption", "col", "colgroup",
+            "tbody", "tfoot", "thead", or an end tag whose tag name is "table" */
+        } elseif (($token['type'] === HTML5::STARTTAG && in_array(
+                    $token['name'],
+                    array('caption', 'col', 'colgroup', 'tbody', 'tfoor', 'thead')
+                )) ||
+            ($token['type'] === HTML5::STARTTAG && $token['name'] === 'table')
+        ) {
             /* If the stack of open elements does not have a tbody, thead, or
             tfoot element in table scope, this is a parse error. Ignore the
             token. (innerHTML case) */
-            if(!$this->elementInScope(array('tbody', 'thead', 'tfoot'), true)) {
+            if (!$this->elementInScope(array('tbody', 'thead', 'tfoot'), true)) {
                 // Ignore.
 
-            /* Otherwise: */
+                /* Otherwise: */
             } else {
                 /* Clear the stack back to a table body context. */
                 $this->clearStackToTableContext($clear);
@@ -2994,33 +3755,40 @@ class HTML5TreeConstructer {
                 /* Act as if an end tag with the same tag name as the current
                 node ("tbody", "tfoot", or "thead") had been seen, then
                 reprocess the current token. */
-                $this->inTableBody(array(
-                    'name' => end($this->stack)->nodeName,
-                    'type' => HTML5::ENDTAG
-                ));
+                $this->inTableBody(
+                    array(
+                        'name' => end($this->stack)->nodeName,
+                        'type' => HTML5::ENDTAG
+                    )
+                );
 
                 return $this->mainPhase($token);
             }
 
-        /* An end tag whose tag name is one of: "body", "caption", "col",
-        "colgroup", "html", "td", "th", "tr" */
-        } elseif($token['type'] === HTML5::ENDTAG && in_array($token['name'],
-        array('body', 'caption', 'col', 'colgroup', 'html', 'td', 'th', 'tr'))) {
+            /* An end tag whose tag name is one of: "body", "caption", "col",
+            "colgroup", "html", "td", "th", "tr" */
+        } elseif ($token['type'] === HTML5::ENDTAG && in_array(
+                $token['name'],
+                array('body', 'caption', 'col', 'colgroup', 'html', 'td', 'th', 'tr')
+            )
+        ) {
             /* Parse error. Ignore the token. */
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Process the token as if the insertion mode was "in table". */
             $this->inTable($token);
         }
     }
 
-    private function inRow($token) {
+    private function inRow($token)
+    {
         $clear = array('tr', 'html');
 
         /* A start tag whose tag name is one of: "th", "td" */
-        if($token['type'] === HTML5::STARTTAG &&
-        ($token['name'] === 'th' || $token['name'] === 'td')) {
+        if ($token['type'] === HTML5::STARTTAG &&
+            ($token['name'] === 'th' || $token['name'] === 'td')
+        ) {
             /* Clear the stack back to a table row context. */
             $this->clearStackToTableContext($clear);
 
@@ -3033,15 +3801,15 @@ class HTML5TreeConstructer {
             elements. */
             $this->a_formatting[] = self::MARKER;
 
-        /* An end tag whose tag name is "tr" */
-        } elseif($token['type'] === HTML5::ENDTAG && $token['name'] === 'tr') {
+            /* An end tag whose tag name is "tr" */
+        } elseif ($token['type'] === HTML5::ENDTAG && $token['name'] === 'tr') {
             /* If the stack of open elements does not have an element in table
             scope with the same tag name as the token, this is a parse error.
             Ignore the token. (innerHTML case) */
-            if(!$this->elementInScope($token['name'], true)) {
+            if (!$this->elementInScope($token['name'], true)) {
                 // Ignore.
 
-            /* Otherwise: */
+                /* Otherwise: */
             } else {
                 /* Clear the stack back to a table row context. */
                 $this->clearStackToTableContext($clear);
@@ -3053,64 +3821,77 @@ class HTML5TreeConstructer {
                 $this->mode = self::IN_TBODY;
             }
 
-        /* A start tag whose tag name is one of: "caption", "col", "colgroup",
-        "tbody", "tfoot", "thead", "tr" or an end tag whose tag name is "table" */
-        } elseif($token['type'] === HTML5::STARTTAG && in_array($token['name'],
-        array('caption', 'col', 'colgroup', 'tbody', 'tfoot', 'thead', 'tr'))) {
+            /* A start tag whose tag name is one of: "caption", "col", "colgroup",
+            "tbody", "tfoot", "thead", "tr" or an end tag whose tag name is "table" */
+        } elseif ($token['type'] === HTML5::STARTTAG && in_array(
+                $token['name'],
+                array('caption', 'col', 'colgroup', 'tbody', 'tfoot', 'thead', 'tr')
+            )
+        ) {
             /* Act as if an end tag with the tag name "tr" had been seen, then,
             if that token wasn't ignored, reprocess the current token. */
-            $this->inRow(array(
-                'name' => 'tr',
-                'type' => HTML5::ENDTAG
-            ));
+            $this->inRow(
+                array(
+                    'name' => 'tr',
+                    'type' => HTML5::ENDTAG
+                )
+            );
 
             return $this->inCell($token);
 
-        /* An end tag whose tag name is one of: "tbody", "tfoot", "thead" */
-        } elseif($token['type'] === HTML5::ENDTAG &&
-        in_array($token['name'], array('tbody', 'tfoot', 'thead'))) {
+            /* An end tag whose tag name is one of: "tbody", "tfoot", "thead" */
+        } elseif ($token['type'] === HTML5::ENDTAG &&
+            in_array($token['name'], array('tbody', 'tfoot', 'thead'))
+        ) {
             /* If the stack of open elements does not have an element in table
             scope with the same tag name as the token, this is a parse error.
             Ignore the token. */
-            if(!$this->elementInScope($token['name'], true)) {
+            if (!$this->elementInScope($token['name'], true)) {
                 // Ignore.
 
-            /* Otherwise: */
+                /* Otherwise: */
             } else {
                 /* Otherwise, act as if an end tag with the tag name "tr" had
                 been seen, then reprocess the current token. */
-                $this->inRow(array(
-                    'name' => 'tr',
-                    'type' => HTML5::ENDTAG
-                ));
+                $this->inRow(
+                    array(
+                        'name' => 'tr',
+                        'type' => HTML5::ENDTAG
+                    )
+                );
 
                 return $this->inCell($token);
             }
 
-        /* An end tag whose tag name is one of: "body", "caption", "col",
-        "colgroup", "html", "td", "th" */
-        } elseif($token['type'] === HTML5::ENDTAG && in_array($token['name'],
-        array('body', 'caption', 'col', 'colgroup', 'html', 'td', 'th', 'tr'))) {
+            /* An end tag whose tag name is one of: "body", "caption", "col",
+            "colgroup", "html", "td", "th" */
+        } elseif ($token['type'] === HTML5::ENDTAG && in_array(
+                $token['name'],
+                array('body', 'caption', 'col', 'colgroup', 'html', 'td', 'th', 'tr')
+            )
+        ) {
             /* Parse error. Ignore the token. */
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Process the token as if the insertion mode was "in table". */
             $this->inTable($token);
         }
     }
 
-    private function inCell($token) {
+    private function inCell($token)
+    {
         /* An end tag whose tag name is one of: "td", "th" */
-        if($token['type'] === HTML5::ENDTAG &&
-        ($token['name'] === 'td' || $token['name'] === 'th')) {
+        if ($token['type'] === HTML5::ENDTAG &&
+            ($token['name'] === 'td' || $token['name'] === 'th')
+        ) {
             /* If the stack of open elements does not have an element in table
             scope with the same tag name as that of the token, then this is a
             parse error and the token must be ignored. */
-            if(!$this->elementInScope($token['name'], true)) {
+            if (!$this->elementInScope($token['name'], true)) {
                 // Ignore.
 
-            /* Otherwise: */
+                /* Otherwise: */
             } else {
                 /* Generate implied end tags, except for elements with the same
                 tag name as the token. */
@@ -3122,11 +3903,11 @@ class HTML5TreeConstructer {
 
                 /* Pop elements from this stack until an element with the same
                 tag name as the token has been popped from the stack. */
-                while(true) {
+                while (true) {
                     $node = end($this->stack)->nodeName;
                     array_pop($this->stack);
 
-                    if($node === $token['name']) {
+                    if ($node === $token['name']) {
                         break;
                     }
                 }
@@ -3140,178 +3921,223 @@ class HTML5TreeConstructer {
                 $this->mode = self::IN_ROW;
             }
 
-        /* A start tag whose tag name is one of: "caption", "col", "colgroup",
-        "tbody", "td", "tfoot", "th", "thead", "tr" */
-        } elseif($token['type'] === HTML5::STARTTAG && in_array($token['name'],
-        array('caption', 'col', 'colgroup', 'tbody', 'td', 'tfoot', 'th',
-        'thead', 'tr'))) {
+            /* A start tag whose tag name is one of: "caption", "col", "colgroup",
+            "tbody", "td", "tfoot", "th", "thead", "tr" */
+        } elseif ($token['type'] === HTML5::STARTTAG && in_array(
+                $token['name'],
+                array(
+                    'caption',
+                    'col',
+                    'colgroup',
+                    'tbody',
+                    'td',
+                    'tfoot',
+                    'th',
+                    'thead',
+                    'tr'
+                )
+            )
+        ) {
             /* If the stack of open elements does not have a td or th element
             in table scope, then this is a parse error; ignore the token.
             (innerHTML case) */
-            if(!$this->elementInScope(array('td', 'th'), true)) {
+            if (!$this->elementInScope(array('td', 'th'), true)) {
                 // Ignore.
 
-            /* Otherwise, close the cell (see below) and reprocess the current
-            token. */
+                /* Otherwise, close the cell (see below) and reprocess the current
+                token. */
             } else {
                 $this->closeCell();
                 return $this->inRow($token);
             }
 
-        /* A start tag whose tag name is one of: "caption", "col", "colgroup",
-        "tbody", "td", "tfoot", "th", "thead", "tr" */
-        } elseif($token['type'] === HTML5::STARTTAG && in_array($token['name'],
-        array('caption', 'col', 'colgroup', 'tbody', 'td', 'tfoot', 'th',
-        'thead', 'tr'))) {
+            /* A start tag whose tag name is one of: "caption", "col", "colgroup",
+            "tbody", "td", "tfoot", "th", "thead", "tr" */
+        } elseif ($token['type'] === HTML5::STARTTAG && in_array(
+                $token['name'],
+                array(
+                    'caption',
+                    'col',
+                    'colgroup',
+                    'tbody',
+                    'td',
+                    'tfoot',
+                    'th',
+                    'thead',
+                    'tr'
+                )
+            )
+        ) {
             /* If the stack of open elements does not have a td or th element
             in table scope, then this is a parse error; ignore the token.
             (innerHTML case) */
-            if(!$this->elementInScope(array('td', 'th'), true)) {
+            if (!$this->elementInScope(array('td', 'th'), true)) {
                 // Ignore.
 
-            /* Otherwise, close the cell (see below) and reprocess the current
-            token. */
+                /* Otherwise, close the cell (see below) and reprocess the current
+                token. */
             } else {
                 $this->closeCell();
                 return $this->inRow($token);
             }
 
-        /* An end tag whose tag name is one of: "body", "caption", "col",
-        "colgroup", "html" */
-        } elseif($token['type'] === HTML5::ENDTAG && in_array($token['name'],
-        array('body', 'caption', 'col', 'colgroup', 'html'))) {
+            /* An end tag whose tag name is one of: "body", "caption", "col",
+            "colgroup", "html" */
+        } elseif ($token['type'] === HTML5::ENDTAG && in_array(
+                $token['name'],
+                array('body', 'caption', 'col', 'colgroup', 'html')
+            )
+        ) {
             /* Parse error. Ignore the token. */
 
-        /* An end tag whose tag name is one of: "table", "tbody", "tfoot",
-        "thead", "tr" */
-        } elseif($token['type'] === HTML5::ENDTAG && in_array($token['name'],
-        array('table', 'tbody', 'tfoot', 'thead', 'tr'))) {
+            /* An end tag whose tag name is one of: "table", "tbody", "tfoot",
+            "thead", "tr" */
+        } elseif ($token['type'] === HTML5::ENDTAG && in_array(
+                $token['name'],
+                array('table', 'tbody', 'tfoot', 'thead', 'tr')
+            )
+        ) {
             /* If the stack of open elements does not have an element in table
             scope with the same tag name as that of the token (which can only
             happen for "tbody", "tfoot" and "thead", or, in the innerHTML case),
             then this is a parse error and the token must be ignored. */
-            if(!$this->elementInScope($token['name'], true)) {
+            if (!$this->elementInScope($token['name'], true)) {
                 // Ignore.
 
-            /* Otherwise, close the cell (see below) and reprocess the current
-            token. */
+                /* Otherwise, close the cell (see below) and reprocess the current
+                token. */
             } else {
                 $this->closeCell();
                 return $this->inRow($token);
             }
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Process the token as if the insertion mode was "in body". */
             $this->inBody($token);
         }
     }
 
-    private function inSelect($token) {
+    private function inSelect($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token */
-        if($token['type'] === HTML5::CHARACTR) {
+        if ($token['type'] === HTML5::CHARACTR) {
             /* Append the token's character to the current node. */
             $this->insertText($token['data']);
 
-        /* A comment token */
-        } elseif($token['type'] === HTML5::COMMENT) {
+            /* A comment token */
+        } elseif ($token['type'] === HTML5::COMMENT) {
             /* Append a Comment node to the current node with the data
             attribute set to the data given in the comment token. */
             $this->insertComment($token['data']);
 
-        /* A start tag token whose tag name is "option" */
-        } elseif($token['type'] === HTML5::STARTTAG &&
-        $token['name'] === 'option') {
+            /* A start tag token whose tag name is "option" */
+        } elseif ($token['type'] === HTML5::STARTTAG &&
+            $token['name'] === 'option'
+        ) {
             /* If the current node is an option element, act as if an end tag
             with the tag name "option" had been seen. */
-            if(end($this->stack)->nodeName === 'option') {
-                $this->inSelect(array(
-                    'name' => 'option',
-                    'type' => HTML5::ENDTAG
-                ));
+            if (end($this->stack)->nodeName === 'option') {
+                $this->inSelect(
+                    array(
+                        'name' => 'option',
+                        'type' => HTML5::ENDTAG
+                    )
+                );
             }
 
             /* Insert an HTML element for the token. */
             $this->insertElement($token);
 
-        /* A start tag token whose tag name is "optgroup" */
-        } elseif($token['type'] === HTML5::STARTTAG &&
-        $token['name'] === 'optgroup') {
+            /* A start tag token whose tag name is "optgroup" */
+        } elseif ($token['type'] === HTML5::STARTTAG &&
+            $token['name'] === 'optgroup'
+        ) {
             /* If the current node is an option element, act as if an end tag
             with the tag name "option" had been seen. */
-            if(end($this->stack)->nodeName === 'option') {
-                $this->inSelect(array(
-                    'name' => 'option',
-                    'type' => HTML5::ENDTAG
-                ));
+            if (end($this->stack)->nodeName === 'option') {
+                $this->inSelect(
+                    array(
+                        'name' => 'option',
+                        'type' => HTML5::ENDTAG
+                    )
+                );
             }
 
             /* If the current node is an optgroup element, act as if an end tag
             with the tag name "optgroup" had been seen. */
-            if(end($this->stack)->nodeName === 'optgroup') {
-                $this->inSelect(array(
-                    'name' => 'optgroup',
-                    'type' => HTML5::ENDTAG
-                ));
+            if (end($this->stack)->nodeName === 'optgroup') {
+                $this->inSelect(
+                    array(
+                        'name' => 'optgroup',
+                        'type' => HTML5::ENDTAG
+                    )
+                );
             }
 
             /* Insert an HTML element for the token. */
             $this->insertElement($token);
 
-        /* An end tag token whose tag name is "optgroup" */
-        } elseif($token['type'] === HTML5::ENDTAG &&
-        $token['name'] === 'optgroup') {
+            /* An end tag token whose tag name is "optgroup" */
+        } elseif ($token['type'] === HTML5::ENDTAG &&
+            $token['name'] === 'optgroup'
+        ) {
             /* First, if the current node is an option element, and the node
             immediately before it in the stack of open elements is an optgroup
             element, then act as if an end tag with the tag name "option" had
             been seen. */
             $elements_in_stack = count($this->stack);
 
-            if($this->stack[$elements_in_stack - 1]->nodeName === 'option' &&
-            $this->stack[$elements_in_stack - 2]->nodeName === 'optgroup') {
-                $this->inSelect(array(
-                    'name' => 'option',
-                    'type' => HTML5::ENDTAG
-                ));
+            if ($this->stack[$elements_in_stack - 1]->nodeName === 'option' &&
+                $this->stack[$elements_in_stack - 2]->nodeName === 'optgroup'
+            ) {
+                $this->inSelect(
+                    array(
+                        'name' => 'option',
+                        'type' => HTML5::ENDTAG
+                    )
+                );
             }
 
             /* If the current node is an optgroup element, then pop that node
             from the stack of open elements. Otherwise, this is a parse error,
             ignore the token. */
-            if($this->stack[$elements_in_stack - 1] === 'optgroup') {
+            if ($this->stack[$elements_in_stack - 1] === 'optgroup') {
                 array_pop($this->stack);
             }
 
-        /* An end tag token whose tag name is "option" */
-        } elseif($token['type'] === HTML5::ENDTAG &&
-        $token['name'] === 'option') {
+            /* An end tag token whose tag name is "option" */
+        } elseif ($token['type'] === HTML5::ENDTAG &&
+            $token['name'] === 'option'
+        ) {
             /* If the current node is an option element, then pop that node
             from the stack of open elements. Otherwise, this is a parse error,
             ignore the token. */
-            if(end($this->stack)->nodeName === 'option') {
+            if (end($this->stack)->nodeName === 'option') {
                 array_pop($this->stack);
             }
 
-        /* An end tag whose tag name is "select" */
-        } elseif($token['type'] === HTML5::ENDTAG &&
-        $token['name'] === 'select') {
+            /* An end tag whose tag name is "select" */
+        } elseif ($token['type'] === HTML5::ENDTAG &&
+            $token['name'] === 'select'
+        ) {
             /* If the stack of open elements does not have an element in table
             scope with the same tag name as the token, this is a parse error.
             Ignore the token. (innerHTML case) */
-            if(!$this->elementInScope($token['name'], true)) {
+            if (!$this->elementInScope($token['name'], true)) {
                 // w/e
 
-            /* Otherwise: */
+                /* Otherwise: */
             } else {
                 /* Pop elements from the stack of open elements until a select
                 element has been popped from the stack. */
-                while(true) {
+                while (true) {
                     $current = end($this->stack)->nodeName;
                     array_pop($this->stack);
 
-                    if($current === 'select') {
+                    if ($current === 'select') {
                         break;
                     }
                 }
@@ -3320,20 +4146,35 @@ class HTML5TreeConstructer {
                 $this->resetInsertionMode();
             }
 
-        /* A start tag whose tag name is "select" */
-        } elseif($token['name'] === 'select' &&
-        $token['type'] === HTML5::STARTTAG) {
+            /* A start tag whose tag name is "select" */
+        } elseif ($token['name'] === 'select' &&
+            $token['type'] === HTML5::STARTTAG
+        ) {
             /* Parse error. Act as if the token had been an end tag with the
             tag name "select" instead. */
-            $this->inSelect(array(
-                'name' => 'select',
-                'type' => HTML5::ENDTAG
-            ));
+            $this->inSelect(
+                array(
+                    'name' => 'select',
+                    'type' => HTML5::ENDTAG
+                )
+            );
 
-        /* An end tag whose tag name is one of: "caption", "table", "tbody",
-        "tfoot", "thead", "tr", "td", "th" */
-        } elseif(in_array($token['name'], array('caption', 'table', 'tbody',
-        'tfoot', 'thead', 'tr', 'td', 'th')) && $token['type'] === HTML5::ENDTAG) {
+            /* An end tag whose tag name is one of: "caption", "table", "tbody",
+            "tfoot", "thead", "tr", "td", "th" */
+        } elseif (in_array(
+                $token['name'],
+                array(
+                    'caption',
+                    'table',
+                    'tbody',
+                    'tfoot',
+                    'thead',
+                    'tr',
+                    'td',
+                    'th'
+                )
+            ) && $token['type'] === HTML5::ENDTAG
+        ) {
             /* Parse error. */
             // w/e
 
@@ -3341,43 +4182,47 @@ class HTML5TreeConstructer {
             the same tag name as that of the token, then act as if an end tag
             with the tag name "select" had been seen, and reprocess the token.
             Otherwise, ignore the token. */
-            if($this->elementInScope($token['name'], true)) {
-                $this->inSelect(array(
-                    'name' => 'select',
-                    'type' => HTML5::ENDTAG
-                ));
+            if ($this->elementInScope($token['name'], true)) {
+                $this->inSelect(
+                    array(
+                        'name' => 'select',
+                        'type' => HTML5::ENDTAG
+                    )
+                );
 
                 $this->mainPhase($token);
             }
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Parse error. Ignore the token. */
         }
     }
 
-    private function afterBody($token) {
+    private function afterBody($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
         U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
         or U+0020 SPACE */
-        if($token['type'] === HTML5::CHARACTR &&
-        preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) {
+        if ($token['type'] === HTML5::CHARACTR &&
+            preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])
+        ) {
             /* Process the token as it would be processed if the insertion mode
             was "in body". */
             $this->inBody($token);
 
-        /* A comment token */
-        } elseif($token['type'] === HTML5::COMMENT) {
+            /* A comment token */
+        } elseif ($token['type'] === HTML5::COMMENT) {
             /* Append a Comment node to the first element in the stack of open
             elements (the html element), with the data attribute set to the
             data given in the comment token. */
             $comment = $this->dom->createComment($token['data']);
             $this->stack[0]->appendChild($comment);
 
-        /* An end tag with the tag name "html" */
-        } elseif($token['type'] === HTML5::ENDTAG && $token['name'] === 'html') {
+            /* An end tag with the tag name "html" */
+        } elseif ($token['type'] === HTML5::ENDTAG && $token['name'] === 'html') {
             /* If the parser was originally created in order to handle the
             setting of an element's innerHTML attribute, this is a parse error;
             ignore the token. (The element will be an html element in this
@@ -3386,7 +4231,7 @@ class HTML5TreeConstructer {
             /* Otherwise, switch to the trailing end phase. */
             $this->phase = self::END_PHASE;
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Parse error. Set the insertion mode to "in body" and reprocess
             the token. */
@@ -3395,34 +4240,38 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function inFrameset($token) {
+    private function inFrameset($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
         U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
         U+000D CARRIAGE RETURN (CR), or U+0020 SPACE */
-        if($token['type'] === HTML5::CHARACTR &&
-        preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) {
+        if ($token['type'] === HTML5::CHARACTR &&
+            preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])
+        ) {
             /* Append the character to the current node. */
             $this->insertText($token['data']);
 
-        /* A comment token */
-        } elseif($token['type'] === HTML5::COMMENT) {
+            /* A comment token */
+        } elseif ($token['type'] === HTML5::COMMENT) {
             /* Append a Comment node to the current node with the data
             attribute set to the data given in the comment token. */
             $this->insertComment($token['data']);
 
-        /* A start tag with the tag name "frameset" */
-        } elseif($token['name'] === 'frameset' &&
-        $token['type'] === HTML5::STARTTAG) {
+            /* A start tag with the tag name "frameset" */
+        } elseif ($token['name'] === 'frameset' &&
+            $token['type'] === HTML5::STARTTAG
+        ) {
             $this->insertElement($token);
 
-        /* An end tag with the tag name "frameset" */
-        } elseif($token['name'] === 'frameset' &&
-        $token['type'] === HTML5::ENDTAG) {
+            /* An end tag with the tag name "frameset" */
+        } elseif ($token['name'] === 'frameset' &&
+            $token['type'] === HTML5::ENDTAG
+        ) {
             /* If the current node is the root html element, then this is a
             parse error; ignore the token. (innerHTML case) */
-            if(end($this->stack)->nodeName === 'html') {
+            if (end($this->stack)->nodeName === 'html') {
                 // Ignore
 
             } else {
@@ -3437,103 +4286,113 @@ class HTML5TreeConstructer {
                 $this->mode = self::AFTR_FRAME;
             }
 
-        /* A start tag with the tag name "frame" */
-        } elseif($token['name'] === 'frame' &&
-        $token['type'] === HTML5::STARTTAG) {
+            /* A start tag with the tag name "frame" */
+        } elseif ($token['name'] === 'frame' &&
+            $token['type'] === HTML5::STARTTAG
+        ) {
             /* Insert an HTML element for the token. */
             $this->insertElement($token);
 
             /* Immediately pop the current node off the stack of open elements. */
             array_pop($this->stack);
 
-        /* A start tag with the tag name "noframes" */
-        } elseif($token['name'] === 'noframes' &&
-        $token['type'] === HTML5::STARTTAG) {
+            /* A start tag with the tag name "noframes" */
+        } elseif ($token['name'] === 'noframes' &&
+            $token['type'] === HTML5::STARTTAG
+        ) {
             /* Process the token as if the insertion mode had been "in body". */
             $this->inBody($token);
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Parse error. Ignore the token. */
         }
     }
 
-    private function afterFrameset($token) {
+    private function afterFrameset($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
         U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
         U+000D CARRIAGE RETURN (CR), or U+0020 SPACE */
-        if($token['type'] === HTML5::CHARACTR &&
-        preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) {
+        if ($token['type'] === HTML5::CHARACTR &&
+            preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])
+        ) {
             /* Append the character to the current node. */
             $this->insertText($token['data']);
 
-        /* A comment token */
-        } elseif($token['type'] === HTML5::COMMENT) {
+            /* A comment token */
+        } elseif ($token['type'] === HTML5::COMMENT) {
             /* Append a Comment node to the current node with the data
             attribute set to the data given in the comment token. */
             $this->insertComment($token['data']);
 
-        /* An end tag with the tag name "html" */
-        } elseif($token['name'] === 'html' &&
-        $token['type'] === HTML5::ENDTAG) {
+            /* An end tag with the tag name "html" */
+        } elseif ($token['name'] === 'html' &&
+            $token['type'] === HTML5::ENDTAG
+        ) {
             /* Switch to the trailing end phase. */
             $this->phase = self::END_PHASE;
 
-        /* A start tag with the tag name "noframes" */
-        } elseif($token['name'] === 'noframes' &&
-        $token['type'] === HTML5::STARTTAG) {
+            /* A start tag with the tag name "noframes" */
+        } elseif ($token['name'] === 'noframes' &&
+            $token['type'] === HTML5::STARTTAG
+        ) {
             /* Process the token as if the insertion mode had been "in body". */
             $this->inBody($token);
 
-        /* Anything else */
+            /* Anything else */
         } else {
             /* Parse error. Ignore the token. */
         }
     }
 
-    private function trailingEndPhase($token) {
+    private function trailingEndPhase($token)
+    {
         /* After the main phase, as each token is emitted from the tokenisation
         stage, it must be processed as described in this section. */
 
         /* A DOCTYPE token */
-        if($token['type'] === HTML5::DOCTYPE) {
+        if ($token['type'] === HTML5::DOCTYPE) {
             // Parse error. Ignore the token.
 
-        /* A comment token */
-        } elseif($token['type'] === HTML5::COMMENT) {
+            /* A comment token */
+        } elseif ($token['type'] === HTML5::COMMENT) {
             /* Append a Comment node to the Document object with the data
             attribute set to the data given in the comment token. */
             $comment = $this->dom->createComment($token['data']);
             $this->dom->appendChild($comment);
 
-        /* A character token that is one of one of U+0009 CHARACTER TABULATION,
-        U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
-        or U+0020 SPACE */
-        } elseif($token['type'] === HTML5::CHARACTR &&
-        preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) {
+            /* A character token that is one of one of U+0009 CHARACTER TABULATION,
+            U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
+            or U+0020 SPACE */
+        } elseif ($token['type'] === HTML5::CHARACTR &&
+            preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])
+        ) {
             /* Process the token as it would be processed in the main phase. */
             $this->mainPhase($token);
 
-        /* A character token that is not one of U+0009 CHARACTER TABULATION,
-        U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
-        or U+0020 SPACE. Or a start tag token. Or an end tag token. */
-        } elseif(($token['type'] === HTML5::CHARACTR &&
-        preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) ||
-        $token['type'] === HTML5::STARTTAG || $token['type'] === HTML5::ENDTAG) {
+            /* A character token that is not one of U+0009 CHARACTER TABULATION,
+            U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
+            or U+0020 SPACE. Or a start tag token. Or an end tag token. */
+        } elseif (($token['type'] === HTML5::CHARACTR &&
+                preg_match('/^[\t\n\x0b\x0c ]+$/', $token['data'])) ||
+            $token['type'] === HTML5::STARTTAG || $token['type'] === HTML5::ENDTAG
+        ) {
             /* Parse error. Switch back to the main phase and reprocess the
             token. */
             $this->phase = self::MAIN_PHASE;
             return $this->mainPhase($token);
 
-        /* An end-of-file token */
-        } elseif($token['type'] === HTML5::EOF) {
+            /* An end-of-file token */
+        } elseif ($token['type'] === HTML5::EOF) {
             /* OMG DONE!! */
         }
     }
 
-    private function insertElement($token, $append = true, $check = false) {
+    private function insertElement($token, $append = true, $check = false)
+    {
         // Proprietary workaround for libxml2's limitations with tag names
         if ($check) {
             // Slightly modified HTML5 tag-name modification,
@@ -3542,13 +4401,15 @@ class HTML5TreeConstructer {
             // Remove leading hyphens and numbers
             $token['name'] = ltrim($token['name'], '-0..9');
             // In theory, this should ever be needed, but just in case
-            if ($token['name'] === '') $token['name'] = 'span'; // arbitrary generic choice
+            if ($token['name'] === '') {
+                $token['name'] = 'span';
+            } // arbitrary generic choice
         }
-        
+
         $el = $this->dom->createElement($token['name']);
 
-        foreach($token['attr'] as $attr) {
-            if(!$el->hasAttribute($attr['name'])) {
+        foreach ($token['attr'] as $attr) {
+            if (!$el->hasAttribute($attr['name'])) {
                 $el->setAttribute($attr['name'], $attr['value']);
             }
         }
@@ -3559,48 +4420,54 @@ class HTML5TreeConstructer {
         return $el;
     }
 
-    private function insertText($data) {
+    private function insertText($data)
+    {
         $text = $this->dom->createTextNode($data);
         $this->appendToRealParent($text);
     }
 
-    private function insertComment($data) {
+    private function insertComment($data)
+    {
         $comment = $this->dom->createComment($data);
         $this->appendToRealParent($comment);
     }
 
-    private function appendToRealParent($node) {
-        if($this->foster_parent === null) {
+    private function appendToRealParent($node)
+    {
+        if ($this->foster_parent === null) {
             end($this->stack)->appendChild($node);
 
-        } elseif($this->foster_parent !== null) {
+        } elseif ($this->foster_parent !== null) {
             /* If the foster parent element is the parent element of the
             last table element in the stack of open elements, then the new
             node must be inserted immediately before the last table element
             in the stack of open elements in the foster parent element;
             otherwise, the new node must be appended to the foster parent
             element. */
-            for($n = count($this->stack) - 1; $n >= 0; $n--) {
-                if($this->stack[$n]->nodeName === 'table' &&
-                $this->stack[$n]->parentNode !== null) {
+            for ($n = count($this->stack) - 1; $n >= 0; $n--) {
+                if ($this->stack[$n]->nodeName === 'table' &&
+                    $this->stack[$n]->parentNode !== null
+                ) {
                     $table = $this->stack[$n];
                     break;
                 }
             }
 
-            if(isset($table) && $this->foster_parent->isSameNode($table->parentNode))
+            if (isset($table) && $this->foster_parent->isSameNode($table->parentNode)) {
                 $this->foster_parent->insertBefore($node, $table);
-            else
+            } else {
                 $this->foster_parent->appendChild($node);
+            }
 
             $this->foster_parent = null;
         }
     }
 
-    private function elementInScope($el, $table = false) {
-        if(is_array($el)) {
-            foreach($el as $element) {
-                if($this->elementInScope($element, $table)) {
+    private function elementInScope($el, $table = false)
+    {
+        if (is_array($el)) {
+            foreach ($el as $element) {
+                if ($this->elementInScope($element, $table)) {
                     return true;
                 }
             }
@@ -3610,28 +4477,38 @@ class HTML5TreeConstructer {
 
         $leng = count($this->stack);
 
-        for($n = 0; $n < $leng; $n++) {
+        for ($n = 0; $n < $leng; $n++) {
             /* 1. Initialise node to be the current node (the bottommost node of
             the stack). */
             $node = $this->stack[$leng - 1 - $n];
 
-            if($node->tagName === $el) {
+            if ($node->tagName === $el) {
                 /* 2. If node is the target node, terminate in a match state. */
                 return true;
 
-            } elseif($node->tagName === 'table') {
+            } elseif ($node->tagName === 'table') {
                 /* 3. Otherwise, if node is a table element, terminate in a failure
                 state. */
                 return false;
 
-            } elseif($table === true && in_array($node->tagName, array('caption', 'td',
-            'th', 'button', 'marquee', 'object'))) {
+            } elseif ($table === true && in_array(
+                    $node->tagName,
+                    array(
+                        'caption',
+                        'td',
+                        'th',
+                        'button',
+                        'marquee',
+                        'object'
+                    )
+                )
+            ) {
                 /* 4. Otherwise, if the algorithm is the "has an element in scope"
                 variant (rather than the "has an element in table scope" variant),
                 and node is one of the following, terminate in a failure state. */
                 return false;
 
-            } elseif($node === $node->ownerDocument->documentElement) {
+            } elseif ($node === $node->ownerDocument->documentElement) {
                 /* 5. Otherwise, if node is an html element (root element), terminate
                 in a failure state. (This can only happen if the node is the topmost
                 node of the    stack of open elements, and prevents the next step from
@@ -3646,12 +4523,13 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function reconstructActiveFormattingElements() {
+    private function reconstructActiveFormattingElements()
+    {
         /* 1. If there are no entries in the list of active formatting elements,
         then there is nothing to reconstruct; stop this algorithm. */
         $formatting_elements = count($this->a_formatting);
 
-        if($formatting_elements === 0) {
+        if ($formatting_elements === 0) {
             return false;
         }
 
@@ -3663,14 +4541,14 @@ class HTML5TreeConstructer {
         formatting elements is a marker, or if it is an element that is in the
         stack of open elements, then there is nothing to reconstruct; stop this
         algorithm. */
-        if($entry === self::MARKER || in_array($entry, $this->stack, true)) {
+        if ($entry === self::MARKER || in_array($entry, $this->stack, true)) {
             return false;
         }
 
-        for($a = $formatting_elements - 1; $a >= 0; true) {
+        for ($a = $formatting_elements - 1; $a >= 0; true) {
             /* 4. If there are no entries before entry in the list of active
             formatting elements, then jump to step 8. */
-            if($a === 0) {
+            if ($a === 0) {
                 $step_seven = false;
                 break;
             }
@@ -3682,15 +4560,15 @@ class HTML5TreeConstructer {
 
             /* 6. If entry is neither a marker nor an element that is also in
             thetack of open elements, go to step 4. */
-            if($entry === self::MARKER || in_array($entry, $this->stack, true)) {
+            if ($entry === self::MARKER || in_array($entry, $this->stack, true)) {
                 break;
             }
         }
 
-        while(true) {
+        while (true) {
             /* 7. Let entry be the element one later than entry in the list of
             active formatting elements. */
-            if(isset($step_seven) && $step_seven === true) {
+            if (isset($step_seven) && $step_seven === true) {
                 $a++;
                 $entry = $this->a_formatting[$a];
             }
@@ -3709,7 +4587,7 @@ class HTML5TreeConstructer {
 
             /* 11. If the entry for clone in the list of active formatting
             elements is not the last entry in the list, return to step 7. */
-            if(end($this->a_formatting) !== $clone) {
+            if (end($this->a_formatting) !== $clone) {
                 $step_seven = true;
             } else {
                 break;
@@ -3717,12 +4595,13 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function clearTheActiveFormattingElementsUpToTheLastMarker() {
+    private function clearTheActiveFormattingElementsUpToTheLastMarker()
+    {
         /* When the steps below require the UA to clear the list of active
         formatting elements up to the last marker, the UA must perform the
         following steps: */
 
-        while(true) {
+        while (true) {
             /* 1. Let entry be the last (most recently added) entry in the list
             of active formatting elements. */
             $entry = end($this->a_formatting);
@@ -3732,13 +4611,14 @@ class HTML5TreeConstructer {
 
             /* 3. If entry was a marker, then stop the algorithm at this point.
             The list has been cleared up to the last marker. */
-            if($entry === self::MARKER) {
+            if ($entry === self::MARKER) {
                 break;
             }
         }
     }
 
-    private function generateImpliedEndTags($exclude = array()) {
+    private function generateImpliedEndTags($exclude = array())
+    {
         /* When the steps below require the UA to generate implied end tags,
         then, if the current node is a dd element, a dt element, an li element,
         a p element, a td element, a th  element, or a tr element, the UA must
@@ -3747,36 +4627,36 @@ class HTML5TreeConstructer {
         $node = end($this->stack);
         $elements = array_diff(array('dd', 'dt', 'li', 'p', 'td', 'th', 'tr'), $exclude);
 
-        while(in_array(end($this->stack)->nodeName, $elements)) {
+        while (in_array(end($this->stack)->nodeName, $elements)) {
             array_pop($this->stack);
         }
     }
 
-    private function getElementCategory($node) {
+    private function getElementCategory($node)
+    {
         $name = $node->tagName;
-        if(in_array($name, $this->special))
+        if (in_array($name, $this->special)) {
             return self::SPECIAL;
-
-        elseif(in_array($name, $this->scoping))
+        } elseif (in_array($name, $this->scoping)) {
             return self::SCOPING;
-
-        elseif(in_array($name, $this->formatting))
+        } elseif (in_array($name, $this->formatting)) {
             return self::FORMATTING;
-
-        else
+        } else {
             return self::PHRASING;
+        }
     }
 
-    private function clearStackToTableContext($elements) {
+    private function clearStackToTableContext($elements)
+    {
         /* When the steps above require the UA to clear the stack back to a
         table context, it means that the UA must, while the current node is not
         a table element or an html element, pop elements from the stack of open
         elements. If this causes any elements to be popped from the stack, then
         this is a parse error. */
-        while(true) {
+        while (true) {
             $node = end($this->stack)->nodeName;
 
-            if(in_array($node, $elements)) {
+            if (in_array($node, $elements)) {
                 break;
             } else {
                 array_pop($this->stack);
@@ -3784,12 +4664,13 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function resetInsertionMode() {
+    private function resetInsertionMode()
+    {
         /* 1. Let last be false. */
         $last = false;
         $leng = count($this->stack);
 
-        for($n = $leng - 1; $n >= 0; $n--) {
+        for ($n = $leng - 1; $n >= 0; $n--) {
             /* 2. Let node be the last node in the stack of open elements. */
             $node = $this->stack[$n];
 
@@ -3797,108 +4678,111 @@ class HTML5TreeConstructer {
             set last to true. If the element whose innerHTML  attribute is being
             set is neither a td  element nor a th element, then set node to the
             element whose innerHTML  attribute is being set. (innerHTML  case) */
-            if($this->stack[0]->isSameNode($node)) {
+            if ($this->stack[0]->isSameNode($node)) {
                 $last = true;
             }
 
             /* 4. If node is a select element, then switch the insertion mode to
             "in select" and abort these steps. (innerHTML case) */
-            if($node->nodeName === 'select') {
+            if ($node->nodeName === 'select') {
                 $this->mode = self::IN_SELECT;
                 break;
 
-            /* 5. If node is a td or th element, then switch the insertion mode
-            to "in cell" and abort these steps. */
-            } elseif($node->nodeName === 'td' || $node->nodeName === 'th') {
+                /* 5. If node is a td or th element, then switch the insertion mode
+                to "in cell" and abort these steps. */
+            } elseif ($node->nodeName === 'td' || $node->nodeName === 'th') {
                 $this->mode = self::IN_CELL;
                 break;
 
-            /* 6. If node is a tr element, then switch the insertion mode to
-            "in    row" and abort these steps. */
-            } elseif($node->nodeName === 'tr') {
+                /* 6. If node is a tr element, then switch the insertion mode to
+                "in    row" and abort these steps. */
+            } elseif ($node->nodeName === 'tr') {
                 $this->mode = self::IN_ROW;
                 break;
 
-            /* 7. If node is a tbody, thead, or tfoot element, then switch the
-            insertion mode to "in table body" and abort these steps. */
-            } elseif(in_array($node->nodeName, array('tbody', 'thead', 'tfoot'))) {
+                /* 7. If node is a tbody, thead, or tfoot element, then switch the
+                insertion mode to "in table body" and abort these steps. */
+            } elseif (in_array($node->nodeName, array('tbody', 'thead', 'tfoot'))) {
                 $this->mode = self::IN_TBODY;
                 break;
 
-            /* 8. If node is a caption element, then switch the insertion mode
-            to "in caption" and abort these steps. */
-            } elseif($node->nodeName === 'caption') {
+                /* 8. If node is a caption element, then switch the insertion mode
+                to "in caption" and abort these steps. */
+            } elseif ($node->nodeName === 'caption') {
                 $this->mode = self::IN_CAPTION;
                 break;
 
-            /* 9. If node is a colgroup element, then switch the insertion mode
-            to "in column group" and abort these steps. (innerHTML case) */
-            } elseif($node->nodeName === 'colgroup') {
+                /* 9. If node is a colgroup element, then switch the insertion mode
+                to "in column group" and abort these steps. (innerHTML case) */
+            } elseif ($node->nodeName === 'colgroup') {
                 $this->mode = self::IN_CGROUP;
                 break;
 
-            /* 10. If node is a table element, then switch the insertion mode
-            to "in table" and abort these steps. */
-            } elseif($node->nodeName === 'table') {
+                /* 10. If node is a table element, then switch the insertion mode
+                to "in table" and abort these steps. */
+            } elseif ($node->nodeName === 'table') {
                 $this->mode = self::IN_TABLE;
                 break;
 
-            /* 11. If node is a head element, then switch the insertion mode
-            to "in body" ("in body"! not "in head"!) and abort these steps.
-            (innerHTML case) */
-            } elseif($node->nodeName === 'head') {
+                /* 11. If node is a head element, then switch the insertion mode
+                to "in body" ("in body"! not "in head"!) and abort these steps.
+                (innerHTML case) */
+            } elseif ($node->nodeName === 'head') {
                 $this->mode = self::IN_BODY;
                 break;
 
-            /* 12. If node is a body element, then switch the insertion mode to
-            "in body" and abort these steps. */
-            } elseif($node->nodeName === 'body') {
+                /* 12. If node is a body element, then switch the insertion mode to
+                "in body" and abort these steps. */
+            } elseif ($node->nodeName === 'body') {
                 $this->mode = self::IN_BODY;
                 break;
 
-            /* 13. If node is a frameset element, then switch the insertion
-            mode to "in frameset" and abort these steps. (innerHTML case) */
-            } elseif($node->nodeName === 'frameset') {
+                /* 13. If node is a frameset element, then switch the insertion
+                mode to "in frameset" and abort these steps. (innerHTML case) */
+            } elseif ($node->nodeName === 'frameset') {
                 $this->mode = self::IN_FRAME;
                 break;
 
-            /* 14. If node is an html element, then: if the head element
-            pointer is null, switch the insertion mode to "before head",
-            otherwise, switch the insertion mode to "after head". In either
-            case, abort these steps. (innerHTML case) */
-            } elseif($node->nodeName === 'html') {
+                /* 14. If node is an html element, then: if the head element
+                pointer is null, switch the insertion mode to "before head",
+                otherwise, switch the insertion mode to "after head". In either
+                case, abort these steps. (innerHTML case) */
+            } elseif ($node->nodeName === 'html') {
                 $this->mode = ($this->head_pointer === null)
                     ? self::BEFOR_HEAD
                     : self::AFTER_HEAD;
 
                 break;
 
-            /* 15. If last is true, then set the insertion mode to "in body"
-            and    abort these steps. (innerHTML case) */
-            } elseif($last) {
+                /* 15. If last is true, then set the insertion mode to "in body"
+                and    abort these steps. (innerHTML case) */
+            } elseif ($last) {
                 $this->mode = self::IN_BODY;
                 break;
             }
         }
     }
 
-    private function closeCell() {
+    private function closeCell()
+    {
         /* If the stack of open elements has a td or th element in table scope,
         then act as if an end tag token with that tag name had been seen. */
-        foreach(array('td', 'th') as $cell) {
-            if($this->elementInScope($cell, true)) {
-                $this->inCell(array(
-                    'name' => $cell,
-                    'type' => HTML5::ENDTAG
-                ));
+        foreach (array('td', 'th') as $cell) {
+            if ($this->elementInScope($cell, true)) {
+                $this->inCell(
+                    array(
+                        'name' => $cell,
+                        'type' => HTML5::ENDTAG
+                    )
+                );
 
                 break;
             }
         }
     }
 
-    public function save() {
+    public function save()
+    {
         return $this->dom;
     }
 }
-?>

--- a/library/HTMLPurifier/PercentEncoder.php
+++ b/library/HTMLPurifier/PercentEncoder.php
@@ -13,17 +13,26 @@ class HTMLPurifier_PercentEncoder
 
     /**
      * Reserved characters to preserve when using encode().
+     * @type array
      */
     protected $preserve = array();
 
     /**
      * String of characters that should be preserved while using encode().
+     * @param bool $preserve
      */
-    public function __construct($preserve = false) {
+    public function __construct($preserve = false)
+    {
         // unreserved letters, ought to const-ify
-        for ($i = 48; $i <= 57;  $i++) $this->preserve[$i] = true; // digits
-        for ($i = 65; $i <= 90;  $i++) $this->preserve[$i] = true; // upper-case
-        for ($i = 97; $i <= 122; $i++) $this->preserve[$i] = true; // lower-case
+        for ($i = 48; $i <= 57; $i++) { // digits
+            $this->preserve[$i] = true;
+        }
+        for ($i = 65; $i <= 90; $i++) { // upper-case
+            $this->preserve[$i] = true;
+        }
+        for ($i = 97; $i <= 122; $i++) { // lower-case
+            $this->preserve[$i] = true;
+        }
         $this->preserve[45] = true; // Dash         -
         $this->preserve[46] = true; // Period       .
         $this->preserve[95] = true; // Underscore   _
@@ -44,13 +53,14 @@ class HTMLPurifier_PercentEncoder
      *      Assumes that the string has already been normalized, making any
      *      and all percent escape sequences valid. Percents will not be
      *      re-escaped, regardless of their status in $preserve
-     * @param $string String to be encoded
-     * @return Encoded string.
+     * @param string $string String to be encoded
+     * @return string Encoded string.
      */
-    public function encode($string) {
+    public function encode($string)
+    {
         $ret = '';
         for ($i = 0, $c = strlen($string); $i < $c; $i++) {
-            if ($string[$i] !== '%' && !isset($this->preserve[$int = ord($string[$i])]) ) {
+            if ($string[$i] !== '%' && !isset($this->preserve[$int = ord($string[$i])])) {
                 $ret .= '%' . sprintf('%02X', $int);
             } else {
                 $ret .= $string[$i];
@@ -64,10 +74,14 @@ class HTMLPurifier_PercentEncoder
      * @warning This function is affected by $preserve, even though the
      *          usual desired behavior is for this not to preserve those
      *          characters. Be careful when reusing instances of PercentEncoder!
-     * @param $string String to normalize
+     * @param string $string String to normalize
+     * @return string
      */
-    public function normalize($string) {
-        if ($string == '') return '';
+    public function normalize($string)
+    {
+        if ($string == '') {
+            return '';
+        }
         $parts = explode('%', $string);
         $ret = array_shift($parts);
         foreach ($parts as $part) {
@@ -92,7 +106,6 @@ class HTMLPurifier_PercentEncoder
         }
         return $ret;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Printer.php
+++ b/library/HTMLPurifier/Printer.php
@@ -7,25 +7,30 @@ class HTMLPurifier_Printer
 {
 
     /**
-     * Instance of HTMLPurifier_Generator for HTML generation convenience funcs
+     * For HTML generation convenience funcs.
+     * @type HTMLPurifier_Generator
      */
     protected $generator;
 
     /**
-     * Instance of HTMLPurifier_Config, for easy access
+     * For easy access.
+     * @type HTMLPurifier_Config
      */
     protected $config;
 
     /**
      * Initialize $generator.
      */
-    public function __construct() {
+    public function __construct()
+    {
     }
 
     /**
      * Give generator necessary configuration if possible
+     * @param HTMLPurifier_Config $config
      */
-    public function prepareGenerator($config) {
+    public function prepareGenerator($config)
+    {
         $all = $config->getAll();
         $context = new HTMLPurifier_Context();
         $this->generator = new HTMLPurifier_Generator($config, $context);
@@ -39,45 +44,62 @@ class HTMLPurifier_Printer
 
     /**
      * Returns a start tag
-     * @param $tag Tag name
-     * @param $attr Attribute array
+     * @param string $tag Tag name
+     * @param array $attr Attribute array
+     * @return string
      */
-    protected function start($tag, $attr = array()) {
+    protected function start($tag, $attr = array())
+    {
         return $this->generator->generateFromToken(
-                    new HTMLPurifier_Token_Start($tag, $attr ? $attr : array())
-               );
+            new HTMLPurifier_Token_Start($tag, $attr ? $attr : array())
+        );
     }
 
     /**
-     * Returns an end teg
-     * @param $tag Tag name
+     * Returns an end tag
+     * @param string $tag Tag name
+     * @return string
      */
-    protected function end($tag) {
+    protected function end($tag)
+    {
         return $this->generator->generateFromToken(
-                    new HTMLPurifier_Token_End($tag)
-               );
+            new HTMLPurifier_Token_End($tag)
+        );
     }
 
     /**
      * Prints a complete element with content inside
-     * @param $tag Tag name
-     * @param $contents Element contents
-     * @param $attr Tag attributes
-     * @param $escape Bool whether or not to escape contents
+     * @param string $tag Tag name
+     * @param string $contents Element contents
+     * @param array $attr Tag attributes
+     * @param bool $escape whether or not to escape contents
+     * @return string
      */
-    protected function element($tag, $contents, $attr = array(), $escape = true) {
+    protected function element($tag, $contents, $attr = array(), $escape = true)
+    {
         return $this->start($tag, $attr) .
-               ($escape ? $this->escape($contents) : $contents) .
-               $this->end($tag);
+            ($escape ? $this->escape($contents) : $contents) .
+            $this->end($tag);
     }
 
-    protected function elementEmpty($tag, $attr = array()) {
+    /**
+     * @param string $tag
+     * @param array $attr
+     * @return string
+     */
+    protected function elementEmpty($tag, $attr = array())
+    {
         return $this->generator->generateFromToken(
             new HTMLPurifier_Token_Empty($tag, $attr)
         );
     }
 
-    protected function text($text) {
+    /**
+     * @param string $text
+     * @return string
+     */
+    protected function text($text)
+    {
         return $this->generator->generateFromToken(
             new HTMLPurifier_Token_Text($text)
         );
@@ -85,24 +107,29 @@ class HTMLPurifier_Printer
 
     /**
      * Prints a simple key/value row in a table.
-     * @param $name Key
-     * @param $value Value
+     * @param string $name Key
+     * @param mixed $value Value
+     * @return string
      */
-    protected function row($name, $value) {
-        if (is_bool($value)) $value = $value ? 'On' : 'Off';
+    protected function row($name, $value)
+    {
+        if (is_bool($value)) {
+            $value = $value ? 'On' : 'Off';
+        }
         return
             $this->start('tr') . "\n" .
-                $this->element('th', $name) . "\n" .
-                $this->element('td', $value) . "\n" .
-            $this->end('tr')
-        ;
+            $this->element('th', $name) . "\n" .
+            $this->element('td', $value) . "\n" .
+            $this->end('tr');
     }
 
     /**
      * Escapes a string for HTML output.
-     * @param $string String to escape
+     * @param string $string String to escape
+     * @return string
      */
-    protected function escape($string) {
+    protected function escape($string)
+    {
         $string = HTMLPurifier_Encoder::cleanUTF8($string);
         $string = htmlspecialchars($string, ENT_COMPAT, 'UTF-8');
         return $string;
@@ -110,32 +137,46 @@ class HTMLPurifier_Printer
 
     /**
      * Takes a list of strings and turns them into a single list
-     * @param $array List of strings
-     * @param $polite Bool whether or not to add an end before the last
+     * @param string[] $array List of strings
+     * @param bool $polite Bool whether or not to add an end before the last
+     * @return string
      */
-    protected function listify($array, $polite = false) {
-        if (empty($array)) return 'None';
+    protected function listify($array, $polite = false)
+    {
+        if (empty($array)) {
+            return 'None';
+        }
         $ret = '';
         $i = count($array);
         foreach ($array as $value) {
             $i--;
             $ret .= $value;
-            if ($i > 0 && !($polite && $i == 1)) $ret .= ', ';
-            if ($polite && $i == 1) $ret .= 'and ';
+            if ($i > 0 && !($polite && $i == 1)) {
+                $ret .= ', ';
+            }
+            if ($polite && $i == 1) {
+                $ret .= 'and ';
+            }
         }
         return $ret;
     }
 
     /**
      * Retrieves the class of an object without prefixes, as well as metadata
-     * @param $obj Object to determine class of
-     * @param $prefix Further prefix to remove
+     * @param object $obj Object to determine class of
+     * @param string $sec_prefix Further prefix to remove
+     * @return string
      */
-    protected function getClass($obj, $sec_prefix = '') {
+    protected function getClass($obj, $sec_prefix = '')
+    {
         static $five = null;
-        if ($five === null) $five = version_compare(PHP_VERSION, '5', '>=');
+        if ($five === null) {
+            $five = version_compare(PHP_VERSION, '5', '>=');
+        }
         $prefix = 'HTMLPurifier_' . $sec_prefix;
-        if (!$five) $prefix = strtolower($prefix);
+        if (!$five) {
+            $prefix = strtolower($prefix);
+        }
         $class = str_replace($prefix, '', get_class($obj));
         $lclass = strtolower($class);
         $class .= '(';
@@ -164,13 +205,14 @@ class HTMLPurifier_Printer
                 break;
             case 'css_importantdecorator':
                 $class .= $this->getClass($obj->def, $sec_prefix);
-                if ($obj->allow) $class .= ', !important';
+                if ($obj->allow) {
+                    $class .= ', !important';
+                }
                 break;
         }
         $class .= ')';
         return $class;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Printer/CSSDefinition.php
+++ b/library/HTMLPurifier/Printer/CSSDefinition.php
@@ -2,10 +2,17 @@
 
 class HTMLPurifier_Printer_CSSDefinition extends HTMLPurifier_Printer
 {
-
+    /**
+     * @type HTMLPurifier_CSSDefinition
+     */
     protected $def;
 
-    public function render($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return string
+     */
+    public function render($config)
+    {
         $this->def = $config->getCSSDefinition();
         $ret = '';
 
@@ -32,7 +39,6 @@ class HTMLPurifier_Printer_CSSDefinition extends HTMLPurifier_Printer
 
         return $ret;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Printer/ConfigForm.php
+++ b/library/HTMLPurifier/Printer/ConfigForm.php
@@ -7,17 +7,20 @@ class HTMLPurifier_Printer_ConfigForm extends HTMLPurifier_Printer
 {
 
     /**
-     * Printers for specific fields
+     * Printers for specific fields.
+     * @type HTMLPurifier_Printer[]
      */
     protected $fields = array();
 
     /**
-     * Documentation URL, can have fragment tagged on end
+     * Documentation URL, can have fragment tagged on end.
+     * @type string
      */
     protected $docURL;
 
     /**
-     * Name of form element to stuff config in
+     * Name of form element to stuff config in.
+     * @type string
      */
     protected $name;
 
@@ -25,24 +28,27 @@ class HTMLPurifier_Printer_ConfigForm extends HTMLPurifier_Printer
      * Whether or not to compress directive names, clipping them off
      * after a certain amount of letters. False to disable or integer letters
      * before clipping.
+     * @type bool
      */
     protected $compress = false;
 
     /**
-     * @param $name Form element name for directives to be stuffed into
-     * @param $doc_url String documentation URL, will have fragment tagged on
-     * @param $compress Integer max length before compressing a directive name, set to false to turn off
+     * @param string $name Form element name for directives to be stuffed into
+     * @param string $doc_url String documentation URL, will have fragment tagged on
+     * @param bool $compress Integer max length before compressing a directive name, set to false to turn off
      */
     public function __construct(
-        $name, $doc_url = null, $compress = false
+        $name,
+        $doc_url = null,
+        $compress = false
     ) {
         parent::__construct();
         $this->docURL = $doc_url;
-        $this->name   = $name;
+        $this->name = $name;
         $this->compress = $compress;
         // initialize sub-printers
-        $this->fields[0]    = new HTMLPurifier_Printer_ConfigForm_default();
-        $this->fields[HTMLPurifier_VarParser::BOOL]       = new HTMLPurifier_Printer_ConfigForm_bool();
+        $this->fields[0] = new HTMLPurifier_Printer_ConfigForm_default();
+        $this->fields[HTMLPurifier_VarParser::BOOL] = new HTMLPurifier_Printer_ConfigForm_bool();
     }
 
     /**
@@ -50,32 +56,42 @@ class HTMLPurifier_Printer_ConfigForm extends HTMLPurifier_Printer
      * @param $cols Integer columns of textarea, null to use default
      * @param $rows Integer rows of textarea, null to use default
      */
-    public function setTextareaDimensions($cols = null, $rows = null) {
-        if ($cols) $this->fields['default']->cols = $cols;
-        if ($rows) $this->fields['default']->rows = $rows;
+    public function setTextareaDimensions($cols = null, $rows = null)
+    {
+        if ($cols) {
+            $this->fields['default']->cols = $cols;
+        }
+        if ($rows) {
+            $this->fields['default']->rows = $rows;
+        }
     }
 
     /**
      * Retrieves styling, in case it is not accessible by webserver
      */
-    public static function getCSS() {
+    public static function getCSS()
+    {
         return file_get_contents(HTMLPURIFIER_PREFIX . '/HTMLPurifier/Printer/ConfigForm.css');
     }
 
     /**
      * Retrieves JavaScript, in case it is not accessible by webserver
      */
-    public static function getJavaScript() {
+    public static function getJavaScript()
+    {
         return file_get_contents(HTMLPURIFIER_PREFIX . '/HTMLPurifier/Printer/ConfigForm.js');
     }
 
     /**
      * Returns HTML output for a configuration form
-     * @param $config Configuration object of current form state, or an array
+     * @param HTMLPurifier_Config|array $config Configuration object of current form state, or an array
      *        where [0] has an HTML namespace and [1] is being rendered.
-     * @param $allowed Optional namespace(s) and directives to restrict form to.
+     * @param array|bool $allowed Optional namespace(s) and directives to restrict form to.
+     * @param bool $render_controls
+     * @return string
      */
-    public function render($config, $allowed = true, $render_controls = true) {
+    public function render($config, $allowed = true, $render_controls = true)
+    {
         if (is_array($config) && isset($config[0])) {
             $gen_config = $config[0];
             $config = $config[1];
@@ -91,29 +107,29 @@ class HTMLPurifier_Printer_ConfigForm extends HTMLPurifier_Printer
         $all = array();
         foreach ($allowed as $key) {
             list($ns, $directive) = $key;
-            $all[$ns][$directive] = $config->get($ns .'.'. $directive);
+            $all[$ns][$directive] = $config->get($ns . '.' . $directive);
         }
 
         $ret = '';
         $ret .= $this->start('table', array('class' => 'hp-config'));
         $ret .= $this->start('thead');
         $ret .= $this->start('tr');
-            $ret .= $this->element('th', 'Directive', array('class' => 'hp-directive'));
-            $ret .= $this->element('th', 'Value', array('class' => 'hp-value'));
+        $ret .= $this->element('th', 'Directive', array('class' => 'hp-directive'));
+        $ret .= $this->element('th', 'Value', array('class' => 'hp-value'));
         $ret .= $this->end('tr');
         $ret .= $this->end('thead');
         foreach ($all as $ns => $directives) {
             $ret .= $this->renderNamespace($ns, $directives);
         }
         if ($render_controls) {
-             $ret .= $this->start('tbody');
-             $ret .= $this->start('tr');
-                 $ret .= $this->start('td', array('colspan' => 2, 'class' => 'controls'));
-                     $ret .= $this->elementEmpty('input', array('type' => 'submit', 'value' => 'Submit'));
-                     $ret .= '[<a href="?">Reset</a>]';
-                 $ret .= $this->end('td');
-             $ret .= $this->end('tr');
-             $ret .= $this->end('tbody');
+            $ret .= $this->start('tbody');
+            $ret .= $this->start('tr');
+            $ret .= $this->start('td', array('colspan' => 2, 'class' => 'controls'));
+            $ret .= $this->elementEmpty('input', array('type' => 'submit', 'value' => 'Submit'));
+            $ret .= '[<a href="?">Reset</a>]';
+            $ret .= $this->end('td');
+            $ret .= $this->end('tr');
+            $ret .= $this->end('tbody');
         }
         $ret .= $this->end('table');
         return $ret;
@@ -122,13 +138,15 @@ class HTMLPurifier_Printer_ConfigForm extends HTMLPurifier_Printer
     /**
      * Renders a single namespace
      * @param $ns String namespace name
-     * @param $directive Associative array of directives to values
+     * @param array $directives array of directives to values
+     * @return string
      */
-    protected function renderNamespace($ns, $directives) {
+    protected function renderNamespace($ns, $directives)
+    {
         $ret = '';
         $ret .= $this->start('tbody', array('class' => 'namespace'));
         $ret .= $this->start('tr');
-            $ret .= $this->element('th', $ns, array('colspan' => 2));
+        $ret .= $this->element('th', $ns, array('colspan' => 2));
         $ret .= $this->end('tr');
         $ret .= $this->end('tbody');
         $ret .= $this->start('tbody');
@@ -139,40 +157,44 @@ class HTMLPurifier_Printer_ConfigForm extends HTMLPurifier_Printer
                 $url = str_replace('%s', urlencode("$ns.$directive"), $this->docURL);
                 $ret .= $this->start('a', array('href' => $url));
             }
-                $attr = array('for' => "{$this->name}:$ns.$directive");
+            $attr = array('for' => "{$this->name}:$ns.$directive");
 
-                // crop directive name if it's too long
-                if (!$this->compress || (strlen($directive) < $this->compress)) {
-                    $directive_disp = $directive;
-                } else {
-                    $directive_disp = substr($directive, 0, $this->compress - 2) . '...';
-                    $attr['title'] = $directive;
-                }
+            // crop directive name if it's too long
+            if (!$this->compress || (strlen($directive) < $this->compress)) {
+                $directive_disp = $directive;
+            } else {
+                $directive_disp = substr($directive, 0, $this->compress - 2) . '...';
+                $attr['title'] = $directive;
+            }
 
-                $ret .= $this->element(
-                    'label',
-                    $directive_disp,
-                    // component printers must create an element with this id
-                    $attr
-                );
-            if ($this->docURL) $ret .= $this->end('a');
+            $ret .= $this->element(
+                'label',
+                $directive_disp,
+                // component printers must create an element with this id
+                $attr
+            );
+            if ($this->docURL) {
+                $ret .= $this->end('a');
+            }
             $ret .= $this->end('th');
 
             $ret .= $this->start('td');
-                $def = $this->config->def->info["$ns.$directive"];
-                if (is_int($def)) {
-                    $allow_null = $def < 0;
-                    $type = abs($def);
-                } else {
-                    $type = $def->type;
-                    $allow_null = isset($def->allow_null);
-                }
-                if (!isset($this->fields[$type])) $type = 0; // default
-                $type_obj = $this->fields[$type];
-                if ($allow_null) {
-                    $type_obj = new HTMLPurifier_Printer_ConfigForm_NullDecorator($type_obj);
-                }
-                $ret .= $type_obj->render($ns, $directive, $value, $this->name, array($this->genConfig, $this->config));
+            $def = $this->config->def->info["$ns.$directive"];
+            if (is_int($def)) {
+                $allow_null = $def < 0;
+                $type = abs($def);
+            } else {
+                $type = $def->type;
+                $allow_null = isset($def->allow_null);
+            }
+            if (!isset($this->fields[$type])) {
+                $type = 0;
+            } // default
+            $type_obj = $this->fields[$type];
+            if ($allow_null) {
+                $type_obj = new HTMLPurifier_Printer_ConfigForm_NullDecorator($type_obj);
+            }
+            $ret .= $type_obj->render($ns, $directive, $value, $this->name, array($this->genConfig, $this->config));
             $ret .= $this->end('td');
             $ret .= $this->end('tr');
         }
@@ -185,19 +207,33 @@ class HTMLPurifier_Printer_ConfigForm extends HTMLPurifier_Printer
 /**
  * Printer decorator for directives that accept null
  */
-class HTMLPurifier_Printer_ConfigForm_NullDecorator extends HTMLPurifier_Printer {
+class HTMLPurifier_Printer_ConfigForm_NullDecorator extends HTMLPurifier_Printer
+{
     /**
      * Printer being decorated
+     * @type HTMLPurifier_Printer
      */
     protected $obj;
+
     /**
-     * @param $obj Printer to decorate
+     * @param HTMLPurifier_Printer $obj Printer to decorate
      */
-    public function __construct($obj) {
+    public function __construct($obj)
+    {
         parent::__construct();
         $this->obj = $obj;
     }
-    public function render($ns, $directive, $value, $name, $config) {
+
+    /**
+     * @param string $ns
+     * @param string $directive
+     * @param string $value
+     * @param string $name
+     * @param HTMLPurifier_Config|array $config
+     * @return string
+     */
+    public function render($ns, $directive, $value, $name, $config)
+    {
         if (is_array($config) && isset($config[0])) {
             $gen_config = $config[0];
             $config = $config[1];
@@ -215,15 +251,19 @@ class HTMLPurifier_Printer_ConfigForm_NullDecorator extends HTMLPurifier_Printer
             'type' => 'checkbox',
             'value' => '1',
             'class' => 'null-toggle',
-            'name' => "$name"."[Null_$ns.$directive]",
+            'name' => "$name" . "[Null_$ns.$directive]",
             'id' => "$name:Null_$ns.$directive",
             'onclick' => "toggleWriteability('$name:$ns.$directive',checked)" // INLINE JAVASCRIPT!!!!
         );
         if ($this->obj instanceof HTMLPurifier_Printer_ConfigForm_bool) {
             // modify inline javascript slightly
-            $attr['onclick'] = "toggleWriteability('$name:Yes_$ns.$directive',checked);toggleWriteability('$name:No_$ns.$directive',checked)";
+            $attr['onclick'] =
+                "toggleWriteability('$name:Yes_$ns.$directive',checked);" .
+                "toggleWriteability('$name:No_$ns.$directive',checked)";
         }
-        if ($value === null) $attr['checked'] = 'checked';
+        if ($value === null) {
+            $attr['checked'] = 'checked';
+        }
         $ret .= $this->elementEmpty('input', $attr);
         $ret .= $this->text(' or ');
         $ret .= $this->elementEmpty('br');
@@ -235,10 +275,28 @@ class HTMLPurifier_Printer_ConfigForm_NullDecorator extends HTMLPurifier_Printer
 /**
  * Swiss-army knife configuration form field printer
  */
-class HTMLPurifier_Printer_ConfigForm_default extends HTMLPurifier_Printer {
+class HTMLPurifier_Printer_ConfigForm_default extends HTMLPurifier_Printer
+{
+    /**
+     * @type int
+     */
     public $cols = 18;
+
+    /**
+     * @type int
+     */
     public $rows = 5;
-    public function render($ns, $directive, $value, $name, $config) {
+
+    /**
+     * @param string $ns
+     * @param string $directive
+     * @param string $value
+     * @param string $name
+     * @param HTMLPurifier_Config|array $config
+     * @return string
+     */
+    public function render($ns, $directive, $value, $name, $config)
+    {
         if (is_array($config) && isset($config[0])) {
             $gen_config = $config[0];
             $config = $config[1];
@@ -262,6 +320,7 @@ class HTMLPurifier_Printer_ConfigForm_default extends HTMLPurifier_Printer {
                     foreach ($array as $val => $b) {
                         $value[] = $val;
                     }
+                    //TODO does this need a break?
                 case HTMLPurifier_VarParser::ALIST:
                     $value = implode(PHP_EOL, $value);
                     break;
@@ -281,25 +340,27 @@ class HTMLPurifier_Printer_ConfigForm_default extends HTMLPurifier_Printer {
             $value = serialize($value);
         }
         $attr = array(
-            'name' => "$name"."[$ns.$directive]",
+            'name' => "$name" . "[$ns.$directive]",
             'id' => "$name:$ns.$directive"
         );
-        if ($value === null) $attr['disabled'] = 'disabled';
+        if ($value === null) {
+            $attr['disabled'] = 'disabled';
+        }
         if (isset($def->allowed)) {
             $ret .= $this->start('select', $attr);
             foreach ($def->allowed as $val => $b) {
                 $attr = array();
-                if ($value == $val) $attr['selected'] = 'selected';
+                if ($value == $val) {
+                    $attr['selected'] = 'selected';
+                }
                 $ret .= $this->element('option', $val, $attr);
             }
             $ret .= $this->end('select');
-        } elseif (
-            $type === HTMLPurifier_VarParser::TEXT ||
-            $type === HTMLPurifier_VarParser::ITEXT ||
-            $type === HTMLPurifier_VarParser::ALIST ||
-            $type === HTMLPurifier_VarParser::HASH ||
-            $type === HTMLPurifier_VarParser::LOOKUP
-        ) {
+        } elseif ($type === HTMLPurifier_VarParser::TEXT ||
+                $type === HTMLPurifier_VarParser::ITEXT ||
+                $type === HTMLPurifier_VarParser::ALIST ||
+                $type === HTMLPurifier_VarParser::HASH ||
+                $type === HTMLPurifier_VarParser::LOOKUP) {
             $attr['cols'] = $this->cols;
             $attr['rows'] = $this->rows;
             $ret .= $this->start('textarea', $attr);
@@ -317,8 +378,18 @@ class HTMLPurifier_Printer_ConfigForm_default extends HTMLPurifier_Printer {
 /**
  * Bool form field printer
  */
-class HTMLPurifier_Printer_ConfigForm_bool extends HTMLPurifier_Printer {
-    public function render($ns, $directive, $value, $name, $config) {
+class HTMLPurifier_Printer_ConfigForm_bool extends HTMLPurifier_Printer
+{
+    /**
+     * @param string $ns
+     * @param string $directive
+     * @param string $value
+     * @param string $name
+     * @param HTMLPurifier_Config|array $config
+     * @return string
+     */
+    public function render($ns, $directive, $value, $name, $config)
+    {
         if (is_array($config) && isset($config[0])) {
             $gen_config = $config[0];
             $config = $config[1];
@@ -336,12 +407,16 @@ class HTMLPurifier_Printer_ConfigForm_bool extends HTMLPurifier_Printer {
 
         $attr = array(
             'type' => 'radio',
-            'name' => "$name"."[$ns.$directive]",
+            'name' => "$name" . "[$ns.$directive]",
             'id' => "$name:Yes_$ns.$directive",
             'value' => '1'
         );
-        if ($value === true) $attr['checked'] = 'checked';
-        if ($value === null) $attr['disabled'] = 'disabled';
+        if ($value === true) {
+            $attr['checked'] = 'checked';
+        }
+        if ($value === null) {
+            $attr['disabled'] = 'disabled';
+        }
         $ret .= $this->elementEmpty('input', $attr);
 
         $ret .= $this->start('label', array('for' => "$name:No_$ns.$directive"));
@@ -351,12 +426,16 @@ class HTMLPurifier_Printer_ConfigForm_bool extends HTMLPurifier_Printer {
 
         $attr = array(
             'type' => 'radio',
-            'name' => "$name"."[$ns.$directive]",
+            'name' => "$name" . "[$ns.$directive]",
             'id' => "$name:No_$ns.$directive",
             'value' => '0'
         );
-        if ($value === false) $attr['checked'] = 'checked';
-        if ($value === null) $attr['disabled'] = 'disabled';
+        if ($value === false) {
+            $attr['checked'] = 'checked';
+        }
+        if ($value === null) {
+            $attr['disabled'] = 'disabled';
+        }
         $ret .= $this->elementEmpty('input', $attr);
 
         $ret .= $this->end('div');

--- a/library/HTMLPurifier/Printer/HTMLDefinition.php
+++ b/library/HTMLPurifier/Printer/HTMLDefinition.php
@@ -4,11 +4,16 @@ class HTMLPurifier_Printer_HTMLDefinition extends HTMLPurifier_Printer
 {
 
     /**
-     * Instance of HTMLPurifier_HTMLDefinition, for easy access
+     * @type HTMLPurifier_HTMLDefinition, for easy access
      */
     protected $def;
 
-    public function render($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return string
+     */
+    public function render($config)
+    {
         $ret = '';
         $this->config =& $config;
 
@@ -28,8 +33,10 @@ class HTMLPurifier_Printer_HTMLDefinition extends HTMLPurifier_Printer
 
     /**
      * Renders the Doctype table
+     * @return string
      */
-    protected function renderDoctype() {
+    protected function renderDoctype()
+    {
         $doctype = $this->def->doctype;
         $ret = '';
         $ret .= $this->start('table');
@@ -45,8 +52,10 @@ class HTMLPurifier_Printer_HTMLDefinition extends HTMLPurifier_Printer
 
     /**
      * Renders environment table, which is miscellaneous info
+     * @return string
      */
-    protected function renderEnvironment() {
+    protected function renderEnvironment()
+    {
         $def = $this->def;
 
         $ret = '';
@@ -59,28 +68,28 @@ class HTMLPurifier_Printer_HTMLDefinition extends HTMLPurifier_Printer
         $ret .= $this->row('Block wrap name', $def->info_block_wrapper);
 
         $ret .= $this->start('tr');
-            $ret .= $this->element('th', 'Global attributes');
-            $ret .= $this->element('td', $this->listifyAttr($def->info_global_attr),0,0);
+        $ret .= $this->element('th', 'Global attributes');
+        $ret .= $this->element('td', $this->listifyAttr($def->info_global_attr), null, 0);
         $ret .= $this->end('tr');
 
         $ret .= $this->start('tr');
-            $ret .= $this->element('th', 'Tag transforms');
-            $list = array();
-            foreach ($def->info_tag_transform as $old => $new) {
-                $new = $this->getClass($new, 'TagTransform_');
-                $list[] = "<$old> with $new";
-            }
-            $ret .= $this->element('td', $this->listify($list));
+        $ret .= $this->element('th', 'Tag transforms');
+        $list = array();
+        foreach ($def->info_tag_transform as $old => $new) {
+            $new = $this->getClass($new, 'TagTransform_');
+            $list[] = "<$old> with $new";
+        }
+        $ret .= $this->element('td', $this->listify($list));
         $ret .= $this->end('tr');
 
         $ret .= $this->start('tr');
-            $ret .= $this->element('th', 'Pre-AttrTransform');
-            $ret .= $this->element('td', $this->listifyObjectList($def->info_attr_transform_pre));
+        $ret .= $this->element('th', 'Pre-AttrTransform');
+        $ret .= $this->element('td', $this->listifyObjectList($def->info_attr_transform_pre));
         $ret .= $this->end('tr');
 
         $ret .= $this->start('tr');
-            $ret .= $this->element('th', 'Post-AttrTransform');
-            $ret .= $this->element('td', $this->listifyObjectList($def->info_attr_transform_post));
+        $ret .= $this->element('th', 'Post-AttrTransform');
+        $ret .= $this->element('td', $this->listifyObjectList($def->info_attr_transform_post));
         $ret .= $this->end('tr');
 
         $ret .= $this->end('table');
@@ -89,8 +98,10 @@ class HTMLPurifier_Printer_HTMLDefinition extends HTMLPurifier_Printer
 
     /**
      * Renders the Content Sets table
+     * @return string
      */
-    protected function renderContentSets() {
+    protected function renderContentSets()
+    {
         $ret = '';
         $ret .= $this->start('table');
         $ret .= $this->element('caption', 'Content Sets');
@@ -106,8 +117,10 @@ class HTMLPurifier_Printer_HTMLDefinition extends HTMLPurifier_Printer
 
     /**
      * Renders the Elements ($info) table
+     * @return string
      */
-    protected function renderInfo() {
+    protected function renderInfo()
+    {
         $ret = '';
         $ret .= $this->start('table');
         $ret .= $this->element('caption', 'Elements ($info)');
@@ -118,39 +131,39 @@ class HTMLPurifier_Printer_HTMLDefinition extends HTMLPurifier_Printer
         $ret .= $this->end('tr');
         foreach ($this->def->info as $name => $def) {
             $ret .= $this->start('tr');
-                $ret .= $this->element('th', "<$name>", array('class'=>'heavy', 'colspan' => 2));
+            $ret .= $this->element('th', "<$name>", array('class' => 'heavy', 'colspan' => 2));
             $ret .= $this->end('tr');
             $ret .= $this->start('tr');
-                $ret .= $this->element('th', 'Inline content');
-                $ret .= $this->element('td', $def->descendants_are_inline ? 'Yes' : 'No');
+            $ret .= $this->element('th', 'Inline content');
+            $ret .= $this->element('td', $def->descendants_are_inline ? 'Yes' : 'No');
             $ret .= $this->end('tr');
             if (!empty($def->excludes)) {
                 $ret .= $this->start('tr');
-                    $ret .= $this->element('th', 'Excludes');
-                    $ret .= $this->element('td', $this->listifyTagLookup($def->excludes));
+                $ret .= $this->element('th', 'Excludes');
+                $ret .= $this->element('td', $this->listifyTagLookup($def->excludes));
                 $ret .= $this->end('tr');
             }
             if (!empty($def->attr_transform_pre)) {
                 $ret .= $this->start('tr');
-                    $ret .= $this->element('th', 'Pre-AttrTransform');
-                    $ret .= $this->element('td', $this->listifyObjectList($def->attr_transform_pre));
+                $ret .= $this->element('th', 'Pre-AttrTransform');
+                $ret .= $this->element('td', $this->listifyObjectList($def->attr_transform_pre));
                 $ret .= $this->end('tr');
             }
             if (!empty($def->attr_transform_post)) {
                 $ret .= $this->start('tr');
-                    $ret .= $this->element('th', 'Post-AttrTransform');
-                    $ret .= $this->element('td', $this->listifyObjectList($def->attr_transform_post));
+                $ret .= $this->element('th', 'Post-AttrTransform');
+                $ret .= $this->element('td', $this->listifyObjectList($def->attr_transform_post));
                 $ret .= $this->end('tr');
             }
             if (!empty($def->auto_close)) {
                 $ret .= $this->start('tr');
-                    $ret .= $this->element('th', 'Auto closed by');
-                    $ret .= $this->element('td', $this->listifyTagLookup($def->auto_close));
+                $ret .= $this->element('th', 'Auto closed by');
+                $ret .= $this->element('td', $this->listifyTagLookup($def->auto_close));
                 $ret .= $this->end('tr');
             }
             $ret .= $this->start('tr');
-                $ret .= $this->element('th', 'Allowed attributes');
-                $ret .= $this->element('td',$this->listifyAttr($def->attr), array(), 0);
+            $ret .= $this->element('th', 'Allowed attributes');
+            $ret .= $this->element('td', $this->listifyAttr($def->attr), array(), 0);
             $ret .= $this->end('tr');
 
             if (!empty($def->required_attr)) {
@@ -165,64 +178,94 @@ class HTMLPurifier_Printer_HTMLDefinition extends HTMLPurifier_Printer
 
     /**
      * Renders a row describing the allowed children of an element
-     * @param $def HTMLPurifier_ChildDef of pertinent element
+     * @param HTMLPurifier_ChildDef $def HTMLPurifier_ChildDef of pertinent element
+     * @return string
      */
-    protected function renderChildren($def) {
+    protected function renderChildren($def)
+    {
         $context = new HTMLPurifier_Context();
         $ret = '';
         $ret .= $this->start('tr');
+        $elements = array();
+        $attr = array();
+        if (isset($def->elements)) {
+            if ($def->type == 'strictblockquote') {
+                $def->validateChildren(array(), $this->config, $context);
+            }
+            $elements = $def->elements;
+        }
+        if ($def->type == 'chameleon') {
+            $attr['rowspan'] = 2;
+        } elseif ($def->type == 'empty') {
             $elements = array();
-            $attr = array();
-            if (isset($def->elements)) {
-                if ($def->type == 'strictblockquote') {
-                    $def->validateChildren(array(), $this->config, $context);
-                }
-                $elements = $def->elements;
-            }
-            if ($def->type == 'chameleon') {
-                $attr['rowspan'] = 2;
-            } elseif ($def->type == 'empty') {
-                $elements = array();
-            } elseif ($def->type == 'table') {
-                $elements = array_flip(array('col', 'caption', 'colgroup', 'thead',
-                    'tfoot', 'tbody', 'tr'));
-            }
-            $ret .= $this->element('th', 'Allowed children', $attr);
+        } elseif ($def->type == 'table') {
+            $elements = array_flip(
+                array(
+                    'col',
+                    'caption',
+                    'colgroup',
+                    'thead',
+                    'tfoot',
+                    'tbody',
+                    'tr'
+                )
+            );
+        }
+        $ret .= $this->element('th', 'Allowed children', $attr);
 
-            if ($def->type == 'chameleon') {
+        if ($def->type == 'chameleon') {
 
-                $ret .= $this->element('td',
-                    '<em>Block</em>: ' .
-                    $this->escape($this->listifyTagLookup($def->block->elements)),0,0);
-                $ret .= $this->end('tr');
-                $ret .= $this->start('tr');
-                $ret .= $this->element('td',
-                    '<em>Inline</em>: ' .
-                    $this->escape($this->listifyTagLookup($def->inline->elements)),0,0);
+            $ret .= $this->element(
+                'td',
+                '<em>Block</em>: ' .
+                $this->escape($this->listifyTagLookup($def->block->elements)),
+                null,
+                0
+            );
+            $ret .= $this->end('tr');
+            $ret .= $this->start('tr');
+            $ret .= $this->element(
+                'td',
+                '<em>Inline</em>: ' .
+                $this->escape($this->listifyTagLookup($def->inline->elements)),
+                null,
+                0
+            );
 
-            } elseif ($def->type == 'custom') {
+        } elseif ($def->type == 'custom') {
 
-                $ret .= $this->element('td', '<em>'.ucfirst($def->type).'</em>: ' .
-                    $def->dtd_regex);
+            $ret .= $this->element(
+                'td',
+                '<em>' . ucfirst($def->type) . '</em>: ' .
+                $def->dtd_regex
+            );
 
-            } else {
-                $ret .= $this->element('td',
-                    '<em>'.ucfirst($def->type).'</em>: ' .
-                    $this->escape($this->listifyTagLookup($elements)),0,0);
-            }
+        } else {
+            $ret .= $this->element(
+                'td',
+                '<em>' . ucfirst($def->type) . '</em>: ' .
+                $this->escape($this->listifyTagLookup($elements)),
+                null,
+                0
+            );
+        }
         $ret .= $this->end('tr');
         return $ret;
     }
 
     /**
      * Listifies a tag lookup table.
-     * @param $array Tag lookup array in form of array('tagname' => true)
+     * @param array $array Tag lookup array in form of array('tagname' => true)
+     * @return string
      */
-    protected function listifyTagLookup($array) {
+    protected function listifyTagLookup($array)
+    {
         ksort($array);
         $list = array();
         foreach ($array as $name => $discard) {
-            if ($name !== '#PCDATA' && !isset($this->def->info[$name])) continue;
+            if ($name !== '#PCDATA' && !isset($this->def->info[$name])) {
+                continue;
+            }
             $list[] = $name;
         }
         return $this->listify($list);
@@ -230,13 +273,15 @@ class HTMLPurifier_Printer_HTMLDefinition extends HTMLPurifier_Printer
 
     /**
      * Listifies a list of objects by retrieving class names and internal state
-     * @param $array List of objects
+     * @param array $array List of objects
+     * @return string
      * @todo Also add information about internal state
      */
-    protected function listifyObjectList($array) {
+    protected function listifyObjectList($array)
+    {
         ksort($array);
         $list = array();
-        foreach ($array as $discard => $obj) {
+        foreach ($array as $obj) {
             $list[] = $this->getClass($obj, 'AttrTransform_');
         }
         return $this->listify($list);
@@ -244,13 +289,17 @@ class HTMLPurifier_Printer_HTMLDefinition extends HTMLPurifier_Printer
 
     /**
      * Listifies a hash of attributes to AttrDef classes
-     * @param $array Array hash in form of array('attrname' => HTMLPurifier_AttrDef)
+     * @param array $array Array hash in form of array('attrname' => HTMLPurifier_AttrDef)
+     * @return string
      */
-    protected function listifyAttr($array) {
+    protected function listifyAttr($array)
+    {
         ksort($array);
         $list = array();
         foreach ($array as $name => $obj) {
-            if ($obj === false) continue;
+            if ($obj === false) {
+                continue;
+            }
             $list[] = "$name&nbsp;=&nbsp;<i>" . $this->getClass($obj, 'AttrDef_') . '</i>';
         }
         return $this->listify($list);
@@ -258,15 +307,18 @@ class HTMLPurifier_Printer_HTMLDefinition extends HTMLPurifier_Printer
 
     /**
      * Creates a heavy header row
+     * @param string $text
+     * @param int $num
+     * @return string
      */
-    protected function heavyHeader($text, $num = 1) {
+    protected function heavyHeader($text, $num = 1)
+    {
         $ret = '';
         $ret .= $this->start('tr');
         $ret .= $this->element('th', $text, array('colspan' => $num, 'class' => 'heavy'));
         $ret .= $this->end('tr');
         return $ret;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/PropertyList.php
+++ b/library/HTMLPurifier/PropertyList.php
@@ -6,61 +6,93 @@
 class HTMLPurifier_PropertyList
 {
     /**
-     * Internal data-structure for properties
+     * Internal data-structure for properties.
+     * @type array
      */
     protected $data = array();
 
     /**
-     * Parent plist
+     * Parent plist.
+     * @type HTMLPurifier_PropertyList
      */
     protected $parent;
 
+    /**
+     * Cache.
+     * @type array
+     */
     protected $cache;
 
-    public function __construct($parent = null) {
+    /**
+     * @param HTMLPurifier_PropertyList $parent Parent plist
+     */
+    public function __construct($parent = null)
+    {
         $this->parent = $parent;
     }
 
     /**
      * Recursively retrieves the value for a key
+     * @param string $name
+     * @throws HTMLPurifier_Exception
      */
-    public function get($name) {
-        if ($this->has($name)) return $this->data[$name];
+    public function get($name)
+    {
+        if ($this->has($name)) {
+            return $this->data[$name];
+        }
         // possible performance bottleneck, convert to iterative if necessary
-        if ($this->parent) return $this->parent->get($name);
+        if ($this->parent) {
+            return $this->parent->get($name);
+        }
         throw new HTMLPurifier_Exception("Key '$name' not found");
     }
 
     /**
      * Sets the value of a key, for this plist
+     * @param string $name
+     * @param mixed $value
      */
-    public function set($name, $value) {
+    public function set($name, $value)
+    {
         $this->data[$name] = $value;
     }
 
     /**
      * Returns true if a given key exists
+     * @param string $name
+     * @return bool
      */
-    public function has($name) {
+    public function has($name)
+    {
         return array_key_exists($name, $this->data);
     }
 
     /**
      * Resets a value to the value of it's parent, usually the default. If
      * no value is specified, the entire plist is reset.
+     * @param string $name
      */
-    public function reset($name = null) {
-        if ($name == null) $this->data = array();
-        else unset($this->data[$name]);
+    public function reset($name = null)
+    {
+        if ($name == null) {
+            $this->data = array();
+        } else {
+            unset($this->data[$name]);
+        }
     }
 
     /**
      * Squashes this property list and all of its property lists into a single
      * array, and returns the array. This value is cached by default.
-     * @param $force If true, ignores the cache and regenerates the array.
+     * @param bool $force If true, ignores the cache and regenerates the array.
+     * @return array
      */
-    public function squash($force = false) {
-        if ($this->cache !== null && !$force) return $this->cache;
+    public function squash($force = false)
+    {
+        if ($this->cache !== null && !$force) {
+            return $this->cache;
+        }
         if ($this->parent) {
             return $this->cache = array_merge($this->parent->squash($force), $this->data);
         } else {
@@ -70,15 +102,19 @@ class HTMLPurifier_PropertyList
 
     /**
      * Returns the parent plist.
+     * @return HTMLPurifier_PropertyList
      */
-    public function getParent() {
+    public function getParent()
+    {
         return $this->parent;
     }
 
     /**
      * Sets the parent plist.
+     * @param HTMLPurifier_PropertyList $plist Parent plist
      */
-    public function setParent($plist) {
+    public function setParent($plist)
+    {
         $this->parent = $plist;
     }
 }

--- a/library/HTMLPurifier/PropertyListIterator.php
+++ b/library/HTMLPurifier/PropertyListIterator.php
@@ -6,27 +6,37 @@
 class HTMLPurifier_PropertyListIterator extends FilterIterator
 {
 
+    /**
+     * @type int
+     */
     protected $l;
+    /**
+     * @type string
+     */
     protected $filter;
 
     /**
-     * @param $data Array of data to iterate over
-     * @param $filter Optional prefix to only allow values of
+     * @param Iterator $iterator Array of data to iterate over
+     * @param string $filter Optional prefix to only allow values of
      */
-    public function __construct(Iterator $iterator, $filter = null) {
+    public function __construct(Iterator $iterator, $filter = null)
+    {
         parent::__construct($iterator);
         $this->l = strlen($filter);
         $this->filter = $filter;
     }
 
-    public function accept() {
+    /**
+     * @return bool
+     */
+    public function accept()
+    {
         $key = $this->getInnerIterator()->key();
-        if( strncmp($key, $this->filter, $this->l) !== 0 ) {
+        if (strncmp($key, $this->filter, $this->l) !== 0) {
             return false;
         }
         return true;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Strategy.php
+++ b/library/HTMLPurifier/Strategy.php
@@ -15,12 +15,12 @@ abstract class HTMLPurifier_Strategy
     /**
      * Executes the strategy on the tokens.
      *
-     * @param $tokens Array of HTMLPurifier_Token objects to be operated on.
-     * @param $config Configuration options
-     * @returns Processed array of token objects.
+     * @param HTMLPurifier_Token[] $tokens Array of HTMLPurifier_Token objects to be operated on.
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return HTMLPurifier_Token[] Processed array of token objects.
      */
     abstract public function execute($tokens, $config, $context);
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Strategy/Composite.php
+++ b/library/HTMLPurifier/Strategy/Composite.php
@@ -8,16 +8,23 @@ abstract class HTMLPurifier_Strategy_Composite extends HTMLPurifier_Strategy
 
     /**
      * List of strategies to run tokens through.
+     * @type HTMLPurifier_Strategy[]
      */
     protected $strategies = array();
 
-    public function execute($tokens, $config, $context) {
+    /**
+     * @param HTMLPurifier_Token[] $tokens
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return HTMLPurifier_Token[]
+     */
+    public function execute($tokens, $config, $context)
+    {
         foreach ($this->strategies as $strategy) {
             $tokens = $strategy->execute($tokens, $config, $context);
         }
         return $tokens;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Strategy/Core.php
+++ b/library/HTMLPurifier/Strategy/Core.php
@@ -5,14 +5,13 @@
  */
 class HTMLPurifier_Strategy_Core extends HTMLPurifier_Strategy_Composite
 {
-
-    public function __construct() {
+    public function __construct()
+    {
         $this->strategies[] = new HTMLPurifier_Strategy_RemoveForeignElements();
         $this->strategies[] = new HTMLPurifier_Strategy_MakeWellFormed();
         $this->strategies[] = new HTMLPurifier_Strategy_FixNesting();
         $this->strategies[] = new HTMLPurifier_Strategy_ValidateAttributes();
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Strategy/FixNesting.php
+++ b/library/HTMLPurifier/Strategy/FixNesting.php
@@ -47,7 +47,14 @@
 class HTMLPurifier_Strategy_FixNesting extends HTMLPurifier_Strategy
 {
 
-    public function execute($tokens, $config, $context) {
+    /**
+     * @param HTMLPurifier_Token[] $tokens
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array|HTMLPurifier_Token[]
+     */
+    public function execute($tokens, $config, $context)
+    {
         //####################################################################//
         // Pre-processing
 
@@ -95,7 +102,7 @@ class HTMLPurifier_Strategy_FixNesting extends HTMLPurifier_Strategy
 
         // iterate through all start nodes. Determining the start node
         // is complicated so it has been omitted from the loop construct
-        for ($i = 0, $size = count($tokens) ; $i < $size; ) {
+        for ($i = 0, $size = count($tokens); $i < $size;) {
 
             //################################################################//
             // Gather information on children
@@ -110,12 +117,16 @@ class HTMLPurifier_Strategy_FixNesting extends HTMLPurifier_Strategy
                     $depth++;
                     // skip token assignment on first iteration, this is the
                     // token we currently are on
-                    if ($depth == 1) continue;
+                    if ($depth == 1) {
+                        continue;
+                    }
                 } elseif ($tokens[$j] instanceof HTMLPurifier_Token_End) {
                     $depth--;
                     // skip token assignment on last iteration, this is the
                     // end token of the token we're currently on
-                    if ($depth == 0) break;
+                    if ($depth == 0) {
+                        break;
+                    }
                 }
                 $child_tokens[] = $tokens[$j];
             }
@@ -130,12 +141,12 @@ class HTMLPurifier_Strategy_FixNesting extends HTMLPurifier_Strategy
 
             // calculate parent information
             if ($count = count($stack)) {
-                $parent_index = $stack[$count-1];
-                $parent_name  = $tokens[$parent_index]->name;
+                $parent_index = $stack[$count - 1];
+                $parent_name = $tokens[$parent_index]->name;
                 if ($parent_index == 0) {
-                    $parent_def   = $definition->info_parent_def;
+                    $parent_def = $definition->info_parent_def;
                 } else {
-                    $parent_def   = $definition->info[$parent_name];
+                    $parent_def = $definition->info[$parent_name];
                 }
             } else {
                 // processing as if the parent were the "root" node
@@ -195,7 +206,10 @@ class HTMLPurifier_Strategy_FixNesting extends HTMLPurifier_Strategy
                 if (!empty($def->child)) {
                     // have DTD child def validate children
                     $result = $def->child->validateChildren(
-                        $child_tokens, $config, $context);
+                        $child_tokens,
+                        $config,
+                        $context
+                    );
                 } else {
                     // weird, no child definition, get rid of everything
                     $result = false;
@@ -217,12 +231,14 @@ class HTMLPurifier_Strategy_FixNesting extends HTMLPurifier_Strategy
                 $stack[] = $i;
 
                 // register exclusions if there are any
-                if (!empty($excludes)) $exclude_stack[] = $excludes;
+                if (!empty($excludes)) {
+                    $exclude_stack[] = $excludes;
+                }
 
                 // move cursor to next possible start node
                 $i++;
 
-            } elseif($result === false) {
+            } elseif ($result === false) {
                 // remove entire node
 
                 if ($e) {
@@ -286,11 +302,12 @@ class HTMLPurifier_Strategy_FixNesting extends HTMLPurifier_Strategy
                 $stack[] = $i;
 
                 // register exclusions if there are any
-                if (!empty($excludes)) $exclude_stack[] = $excludes;
+                if (!empty($excludes)) {
+                    $exclude_stack[] = $excludes;
+                }
 
                 // move cursor to next possible start node
                 $i++;
-
             }
 
             //################################################################//
@@ -336,11 +353,8 @@ class HTMLPurifier_Strategy_FixNesting extends HTMLPurifier_Strategy
 
         //####################################################################//
         // Return
-
         return $tokens;
-
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Strategy/RemoveForeignElements.php
+++ b/library/HTMLPurifier/Strategy/RemoveForeignElements.php
@@ -11,13 +11,20 @@
 class HTMLPurifier_Strategy_RemoveForeignElements extends HTMLPurifier_Strategy
 {
 
-    public function execute($tokens, $config, $context) {
+    /**
+     * @param HTMLPurifier_Token[] $tokens
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return array|HTMLPurifier_Token[]
+     */
+    public function execute($tokens, $config, $context)
+    {
         $definition = $config->getHTMLDefinition();
         $generator = new HTMLPurifier_Generator($config, $context);
         $result = array();
 
         $escape_invalid_tags = $config->get('Core.EscapeInvalidTags');
-        $remove_invalid_img  = $config->get('Core.RemoveInvalidImg');
+        $remove_invalid_img = $config->get('Core.RemoveInvalidImg');
 
         // currently only used to determine if comments should be kept
         $trusted = $config->get('HTML.Trusted');
@@ -26,7 +33,7 @@ class HTMLPurifier_Strategy_RemoveForeignElements extends HTMLPurifier_Strategy
         $check_comments = $comment_lookup !== array() || $comment_regexp !== null;
 
         $remove_script_contents = $config->get('Core.RemoveScriptContents');
-        $hidden_elements     = $config->get('Core.HiddenElements');
+        $hidden_elements = $config->get('Core.HiddenElements');
 
         // remove script contents compatibility
         if ($remove_script_contents === true) {
@@ -51,34 +58,31 @@ class HTMLPurifier_Strategy_RemoveForeignElements extends HTMLPurifier_Strategy
             $e =& $context->get('ErrorCollector');
         }
 
-        foreach($tokens as $token) {
+        foreach ($tokens as $token) {
             if ($remove_until) {
                 if (empty($token->is_tag) || $token->name !== $remove_until) {
                     continue;
                 }
             }
-            if (!empty( $token->is_tag )) {
+            if (!empty($token->is_tag)) {
                 // DEFINITION CALL
 
                 // before any processing, try to transform the element
-                if (
-                    isset($definition->info_tag_transform[$token->name])
-                ) {
+                if (isset($definition->info_tag_transform[$token->name])) {
                     $original_name = $token->name;
                     // there is a transformation for this tag
                     // DEFINITION CALL
                     $token = $definition->
-                                info_tag_transform[$token->name]->
-                                    transform($token, $config, $context);
-                    if ($e) $e->send(E_NOTICE, 'Strategy_RemoveForeignElements: Tag transform', $original_name);
+                        info_tag_transform[$token->name]->transform($token, $config, $context);
+                    if ($e) {
+                        $e->send(E_NOTICE, 'Strategy_RemoveForeignElements: Tag transform', $original_name);
+                    }
                 }
 
                 if (isset($definition->info[$token->name])) {
-
                     // mostly everything's good, but
                     // we need to make sure required attributes are in order
-                    if (
-                        ($token instanceof HTMLPurifier_Token_Start || $token instanceof HTMLPurifier_Token_Empty) &&
+                    if (($token instanceof HTMLPurifier_Token_Start || $token instanceof HTMLPurifier_Token_Empty) &&
                         $definition->info[$token->name]->required_attr &&
                         ($token->name != 'img' || $remove_invalid_img) // ensure config option still works
                     ) {
@@ -91,7 +95,13 @@ class HTMLPurifier_Strategy_RemoveForeignElements extends HTMLPurifier_Strategy
                             }
                         }
                         if (!$ok) {
-                            if ($e) $e->send(E_ERROR, 'Strategy_RemoveForeignElements: Missing required attribute', $name);
+                            if ($e) {
+                                $e->send(
+                                    E_ERROR,
+                                    'Strategy_RemoveForeignElements: Missing required attribute',
+                                    $name
+                                );
+                            }
                             continue;
                         }
                         $token->armor['ValidateAttributes'] = true;
@@ -105,7 +115,9 @@ class HTMLPurifier_Strategy_RemoveForeignElements extends HTMLPurifier_Strategy
 
                 } elseif ($escape_invalid_tags) {
                     // invalid tag, generate HTML representation and insert in
-                    if ($e) $e->send(E_WARNING, 'Strategy_RemoveForeignElements: Foreign element to text');
+                    if ($e) {
+                        $e->send(E_WARNING, 'Strategy_RemoveForeignElements: Foreign element to text');
+                    }
                     $token = new HTMLPurifier_Token_Text(
                         $generator->generateFromToken($token)
                     );
@@ -120,9 +132,13 @@ class HTMLPurifier_Strategy_RemoveForeignElements extends HTMLPurifier_Strategy
                         } else {
                             $remove_until = false;
                         }
-                        if ($e) $e->send(E_ERROR, 'Strategy_RemoveForeignElements: Foreign meta element removed');
+                        if ($e) {
+                            $e->send(E_ERROR, 'Strategy_RemoveForeignElements: Foreign meta element removed');
+                        }
                     } else {
-                        if ($e) $e->send(E_ERROR, 'Strategy_RemoveForeignElements: Foreign element removed');
+                        if ($e) {
+                            $e->send(E_ERROR, 'Strategy_RemoveForeignElements: Foreign element removed');
+                        }
                     }
                     continue;
                 }
@@ -146,11 +162,15 @@ class HTMLPurifier_Strategy_RemoveForeignElements extends HTMLPurifier_Strategy
                         $found_double_hyphen = true;
                         $token->data = str_replace('--', '-', $token->data);
                     }
-                    if ($trusted || !empty($comment_lookup[trim($token->data)]) || ($comment_regexp !== NULL && preg_match($comment_regexp, trim($token->data)))) {
+                    if ($trusted || !empty($comment_lookup[trim($token->data)]) ||
+                        ($comment_regexp !== null && preg_match($comment_regexp, trim($token->data)))) {
                         // OK good
                         if ($e) {
                             if ($trailing_hyphen) {
-                                $e->send(E_NOTICE, 'Strategy_RemoveForeignElements: Trailing hyphen in comment removed');
+                                $e->send(
+                                    E_NOTICE,
+                                    'Strategy_RemoveForeignElements: Trailing hyphen in comment removed'
+                                );
                             }
                             if ($found_double_hyphen) {
                                 $e->send(E_NOTICE, 'Strategy_RemoveForeignElements: Hyphens in comment collapsed');
@@ -164,7 +184,9 @@ class HTMLPurifier_Strategy_RemoveForeignElements extends HTMLPurifier_Strategy
                     }
                 } else {
                     // strip comments
-                    if ($e) $e->send(E_NOTICE, 'Strategy_RemoveForeignElements: Comment removed');
+                    if ($e) {
+                        $e->send(E_NOTICE, 'Strategy_RemoveForeignElements: Comment removed');
+                    }
                     continue;
                 }
             } elseif ($token instanceof HTMLPurifier_Token_Text) {
@@ -177,12 +199,9 @@ class HTMLPurifier_Strategy_RemoveForeignElements extends HTMLPurifier_Strategy
             // we removed tokens until the end, throw error
             $e->send(E_ERROR, 'Strategy_RemoveForeignElements: Token removed to end', $remove_until);
         }
-
         $context->destroy('CurrentToken');
-
         return $result;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Strategy/ValidateAttributes.php
+++ b/library/HTMLPurifier/Strategy/ValidateAttributes.php
@@ -7,8 +7,14 @@
 class HTMLPurifier_Strategy_ValidateAttributes extends HTMLPurifier_Strategy
 {
 
-    public function execute($tokens, $config, $context) {
-
+    /**
+     * @param HTMLPurifier_Token[] $tokens
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return HTMLPurifier_Token[]
+     */
+    public function execute($tokens, $config, $context)
+    {
         // setup validator
         $validator = new HTMLPurifier_AttrValidator();
 
@@ -19,10 +25,14 @@ class HTMLPurifier_Strategy_ValidateAttributes extends HTMLPurifier_Strategy
 
             // only process tokens that have attributes,
             //   namely start and empty tags
-            if (!$token instanceof HTMLPurifier_Token_Start && !$token instanceof HTMLPurifier_Token_Empty) continue;
+            if (!$token instanceof HTMLPurifier_Token_Start && !$token instanceof HTMLPurifier_Token_Empty) {
+                continue;
+            }
 
             // skip tokens that are armored
-            if (!empty($token->armor['ValidateAttributes'])) continue;
+            if (!empty($token->armor['ValidateAttributes'])) {
+                continue;
+            }
 
             // note that we have no facilities here for removing tokens
             $validator->validateToken($token, $config, $context);
@@ -30,10 +40,8 @@ class HTMLPurifier_Strategy_ValidateAttributes extends HTMLPurifier_Strategy
             $tokens[$key] = $token; // for PHP 4
         }
         $context->destroy('CurrentToken');
-
         return $tokens;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/StringHash.php
+++ b/library/HTMLPurifier/StringHash.php
@@ -10,28 +10,36 @@
  */
 class HTMLPurifier_StringHash extends ArrayObject
 {
+    /**
+     * @type array
+     */
     protected $accessed = array();
 
     /**
      * Retrieves a value, and logs the access.
+     * @param mixed $index
+     * @return mixed
      */
-    public function offsetGet($index) {
+    public function offsetGet($index)
+    {
         $this->accessed[$index] = true;
         return parent::offsetGet($index);
     }
 
     /**
      * Returns a lookup array of all array indexes that have been accessed.
-     * @return Array in form array($index => true).
+     * @return array in form array($index => true).
      */
-    public function getAccessed() {
+    public function getAccessed()
+    {
         return $this->accessed;
     }
 
     /**
      * Resets the access array.
      */
-    public function resetAccessed() {
+    public function resetAccessed()
+    {
         $this->accessed = array();
     }
 }

--- a/library/HTMLPurifier/StringHashParser.php
+++ b/library/HTMLPurifier/StringHashParser.php
@@ -28,15 +28,25 @@
 class HTMLPurifier_StringHashParser
 {
 
+    /**
+     * @type string
+     */
     public $default = 'ID';
 
     /**
      * Parses a file that contains a single string-hash.
+     * @param string $file
+     * @return array
      */
-    public function parseFile($file) {
-        if (!file_exists($file)) return false;
+    public function parseFile($file)
+    {
+        if (!file_exists($file)) {
+            return false;
+        }
         $fh = fopen($file, 'r');
-        if (!$fh) return false;
+        if (!$fh) {
+            return false;
+        }
         $ret = $this->parseHandle($fh);
         fclose($fh);
         return $ret;
@@ -44,12 +54,19 @@ class HTMLPurifier_StringHashParser
 
     /**
      * Parses a file that contains multiple string-hashes delimited by '----'
+     * @param string $file
+     * @return array
      */
-    public function parseMultiFile($file) {
-        if (!file_exists($file)) return false;
+    public function parseMultiFile($file)
+    {
+        if (!file_exists($file)) {
+            return false;
+        }
         $ret = array();
         $fh = fopen($file, 'r');
-        if (!$fh) return false;
+        if (!$fh) {
+            return false;
+        }
         while (!feof($fh)) {
             $ret[] = $this->parseHandle($fh);
         }
@@ -62,26 +79,36 @@ class HTMLPurifier_StringHashParser
      * @note While it's possible to simulate in-memory parsing by using
      *       custom stream wrappers, if such a use-case arises we should
      *       factor out the file handle into its own class.
-     * @param $fh File handle with pointer at start of valid string-hash
+     * @param resource $fh File handle with pointer at start of valid string-hash
      *            block.
+     * @return array
      */
-    protected function parseHandle($fh) {
+    protected function parseHandle($fh)
+    {
         $state   = false;
         $single  = false;
         $ret     = array();
         do {
             $line = fgets($fh);
-            if ($line === false) break;
+            if ($line === false) {
+                break;
+            }
             $line = rtrim($line, "\n\r");
-            if (!$state && $line === '') continue;
-            if ($line === '----') break;
+            if (!$state && $line === '') {
+                continue;
+            }
+            if ($line === '----') {
+                break;
+            }
             if (strncmp('--#', $line, 3) === 0) {
                 // Comment
                 continue;
             } elseif (strncmp('--', $line, 2) === 0) {
                 // Multiline declaration
                 $state = trim($line, '- ');
-                if (!isset($ret[$state])) $ret[$state] = '';
+                if (!isset($ret[$state])) {
+                    $ret[$state] = '';
+                }
                 continue;
             } elseif (!$state) {
                 $single = true;
@@ -104,7 +131,6 @@ class HTMLPurifier_StringHashParser
         } while (!feof($fh));
         return $ret;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/TagTransform.php
+++ b/library/HTMLPurifier/TagTransform.php
@@ -8,14 +8,15 @@ abstract class HTMLPurifier_TagTransform
 
     /**
      * Tag name to transform the tag to.
+     * @type string
      */
     public $transform_to;
 
     /**
      * Transforms the obsolete tag into the valid tag.
-     * @param $tag Tag to be transformed.
-     * @param $config Mandatory HTMLPurifier_Config object
-     * @param $context Mandatory HTMLPurifier_Context object
+     * @param HTMLPurifier_Token_Tag $tag Tag to be transformed.
+     * @param HTMLPurifier_Config $config Mandatory HTMLPurifier_Config object
+     * @param HTMLPurifier_Context $context Mandatory HTMLPurifier_Context object
      */
     abstract public function transform($tag, $config, $context);
 
@@ -23,14 +24,14 @@ abstract class HTMLPurifier_TagTransform
      * Prepends CSS properties to the style attribute, creating the
      * attribute if it doesn't exist.
      * @warning Copied over from AttrTransform, be sure to keep in sync
-     * @param $attr Attribute array to process (passed by reference)
-     * @param $css CSS to prepend
+     * @param array $attr Attribute array to process (passed by reference)
+     * @param string $css CSS to prepend
      */
-    protected function prependCSS(&$attr, $css) {
+    protected function prependCSS(&$attr, $css)
+    {
         $attr['style'] = isset($attr['style']) ? $attr['style'] : '';
         $attr['style'] = $css . $attr['style'];
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/TagTransform/Font.php
+++ b/library/HTMLPurifier/TagTransform/Font.php
@@ -17,9 +17,14 @@
  */
 class HTMLPurifier_TagTransform_Font extends HTMLPurifier_TagTransform
 {
-
+    /**
+     * @type string
+     */
     public $transform_to = 'span';
 
+    /**
+     * @type array
+     */
     protected $_size_lookup = array(
         '0' => 'xx-small',
         '1' => 'xx-small',
@@ -37,8 +42,14 @@ class HTMLPurifier_TagTransform_Font extends HTMLPurifier_TagTransform
         '+4' => '300%'
     );
 
-    public function transform($tag, $config, $context) {
-
+    /**
+     * @param HTMLPurifier_Token_Tag $tag
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return HTMLPurifier_Token_End|string
+     */
+    public function transform($tag, $config, $context)
+    {
         if ($tag instanceof HTMLPurifier_Token_End) {
             $new_tag = clone $tag;
             $new_tag->name = $this->transform_to;
@@ -65,17 +76,23 @@ class HTMLPurifier_TagTransform_Font extends HTMLPurifier_TagTransform
             // normalize large numbers
             if ($attr['size'] !== '') {
                 if ($attr['size']{0} == '+' || $attr['size']{0} == '-') {
-                    $size = (int) $attr['size'];
-                    if ($size < -2) $attr['size'] = '-2';
-                    if ($size > 4)  $attr['size'] = '+4';
+                    $size = (int)$attr['size'];
+                    if ($size < -2) {
+                        $attr['size'] = '-2';
+                    }
+                    if ($size > 4) {
+                        $attr['size'] = '+4';
+                    }
                 } else {
-                    $size = (int) $attr['size'];
-                    if ($size > 7) $attr['size'] = '7';
+                    $size = (int)$attr['size'];
+                    if ($size > 7) {
+                        $attr['size'] = '7';
+                    }
                 }
             }
             if (isset($this->_size_lookup[$attr['size']])) {
                 $prepend_style .= 'font-size:' .
-                  $this->_size_lookup[$attr['size']] . ';';
+                    $this->_size_lookup[$attr['size']] . ';';
             }
             unset($attr['size']);
         }
@@ -91,7 +108,6 @@ class HTMLPurifier_TagTransform_Font extends HTMLPurifier_TagTransform
         $new_tag->attr = $attr;
 
         return $new_tag;
-
     }
 }
 

--- a/library/HTMLPurifier/TagTransform/Simple.php
+++ b/library/HTMLPurifier/TagTransform/Simple.php
@@ -7,19 +7,29 @@
  */
 class HTMLPurifier_TagTransform_Simple extends HTMLPurifier_TagTransform
 {
-
+    /**
+     * @type string
+     */
     protected $style;
 
     /**
-     * @param $transform_to Tag name to transform to.
-     * @param $style CSS style to add to the tag
+     * @param string $transform_to Tag name to transform to.
+     * @param string $style CSS style to add to the tag
      */
-    public function __construct($transform_to, $style = null) {
+    public function __construct($transform_to, $style = null)
+    {
         $this->transform_to = $transform_to;
         $this->style = $style;
     }
 
-    public function transform($tag, $config, $context) {
+    /**
+     * @param HTMLPurifier_Token_Tag $tag
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return string
+     */
+    public function transform($tag, $config, $context)
+    {
         $new_tag = clone $tag;
         $new_tag->name = $this->transform_to;
         if (!is_null($this->style) &&
@@ -29,7 +39,6 @@ class HTMLPurifier_TagTransform_Simple extends HTMLPurifier_TagTransform
         }
         return $new_tag;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Token.php
+++ b/library/HTMLPurifier/Token.php
@@ -3,55 +3,93 @@
 /**
  * Abstract base token class that all others inherit from.
  */
-class HTMLPurifier_Token {
-    public $line; /**< Line number node was on in source document. Null if unknown. */
-    public $col;  /**< Column of line node was on in source document. Null if unknown. */
+class HTMLPurifier_Token
+{
+    /**
+     * Line number node was on in source document. Null if unknown.
+     * @type int
+     */
+    public $line;
+
+    /**
+     * Column of line node was on in source document. Null if unknown.
+     * @type int
+     */
+    public $col;
 
     /**
      * Lookup array of processing that this token is exempt from.
      * Currently, valid values are "ValidateAttributes" and
      * "MakeWellFormed_TagClosedError"
+     * @type array
      */
     public $armor = array();
 
     /**
      * Used during MakeWellFormed.
+     * @type
      */
     public $skip;
+
+    /**
+     * @type
+     */
     public $rewind;
+
+    /**
+     * @type
+     */
     public $carryover;
 
-    public function __get($n) {
-      if ($n === 'type') {
-        trigger_error('Deprecated type property called; use instanceof', E_USER_NOTICE);
-        switch (get_class($this)) {
-          case 'HTMLPurifier_Token_Start':      return 'start';
-          case 'HTMLPurifier_Token_Empty':      return 'empty';
-          case 'HTMLPurifier_Token_End':        return 'end';
-          case 'HTMLPurifier_Token_Text':       return 'text';
-          case 'HTMLPurifier_Token_Comment':    return 'comment';
-          default: return null;
+    /**
+     * @param string $n
+     * @return null|string
+     */
+    public function __get($n)
+    {
+        if ($n === 'type') {
+            trigger_error('Deprecated type property called; use instanceof', E_USER_NOTICE);
+            switch (get_class($this)) {
+                case 'HTMLPurifier_Token_Start':
+                    return 'start';
+                case 'HTMLPurifier_Token_Empty':
+                    return 'empty';
+                case 'HTMLPurifier_Token_End':
+                    return 'end';
+                case 'HTMLPurifier_Token_Text':
+                    return 'text';
+                case 'HTMLPurifier_Token_Comment':
+                    return 'comment';
+                default:
+                    return null;
+            }
         }
-      }
     }
 
     /**
      * Sets the position of the token in the source document.
+     * @param int $l
+     * @param int $c
      */
-    public function position($l = null, $c = null) {
+    public function position($l = null, $c = null)
+    {
         $this->line = $l;
-        $this->col  = $c;
+        $this->col = $c;
     }
 
     /**
      * Convenience function for DirectLex settings line/col position.
+     * @param int $l
+     * @param int $c
      */
-    public function rawPosition($l, $c) {
-        if ($c === -1) $l++;
+    public function rawPosition($l, $c)
+    {
+        if ($c === -1) {
+            $l++;
+        }
         $this->line = $l;
-        $this->col  = $c;
+        $this->col = $c;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Token/Comment.php
+++ b/library/HTMLPurifier/Token/Comment.php
@@ -5,17 +5,29 @@
  */
 class HTMLPurifier_Token_Comment extends HTMLPurifier_Token
 {
-    public $data; /**< Character data within comment. */
+    /**
+     * Character data within comment.
+     * @type string
+     */
+    public $data;
+
+    /**
+     * @type bool
+     */
     public $is_whitespace = true;
+
     /**
      * Transparent constructor.
      *
-     * @param $data String comment data.
+     * @param string $data String comment data.
+     * @param int $line
+     * @param int $col
      */
-    public function __construct($data, $line = null, $col = null) {
+    public function __construct($data, $line = null, $col = null)
+    {
         $this->data = $data;
         $this->line = $line;
-        $this->col  = $col;
+        $this->col = $col;
     }
 }
 

--- a/library/HTMLPurifier/Token/Empty.php
+++ b/library/HTMLPurifier/Token/Empty.php
@@ -5,7 +5,6 @@
  */
 class HTMLPurifier_Token_Empty extends HTMLPurifier_Token_Tag
 {
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Token/End.php
+++ b/library/HTMLPurifier/Token/End.php
@@ -10,8 +10,9 @@
 class HTMLPurifier_Token_End extends HTMLPurifier_Token_Tag
 {
     /**
-     * Token that started this node. Added by MakeWellFormed. Please
-     * do not edit this!
+     * Token that started this node.
+     * Added by MakeWellFormed. Please do not edit this!
+     * @type HTMLPurifier_Token
      */
     public $start;
 }

--- a/library/HTMLPurifier/Token/Start.php
+++ b/library/HTMLPurifier/Token/Start.php
@@ -5,7 +5,6 @@
  */
 class HTMLPurifier_Token_Start extends HTMLPurifier_Token_Tag
 {
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/Token/Tag.php
+++ b/library/HTMLPurifier/Token/Tag.php
@@ -10,6 +10,7 @@ class HTMLPurifier_Token_Tag extends HTMLPurifier_Token
      *
      * This allows us to check objects with <tt>!empty($obj->is_tag)</tt>
      * without having to use a function call <tt>is_a()</tt>.
+     * @type bool
      */
     public $is_tag = true;
 
@@ -19,21 +20,27 @@ class HTMLPurifier_Token_Tag extends HTMLPurifier_Token
      * @note Strictly speaking, XML tags are case sensitive, so we shouldn't
      * be lower-casing them, but these tokens cater to HTML tags, which are
      * insensitive.
+     * @type string
      */
     public $name;
 
     /**
      * Associative array of the tag's attributes.
+     * @type array
      */
     public $attr = array();
 
     /**
      * Non-overloaded constructor, which lower-cases passed tag name.
      *
-     * @param $name String name.
-     * @param $attr Associative array of attributes.
+     * @param string $name String name.
+     * @param array $attr Associative array of attributes.
+     * @param int $line
+     * @param int $col
+     * @param array $armor
      */
-    public function __construct($name, $attr = array(), $line = null, $col = null, $armor = array()) {
+    public function __construct($name, $attr = array(), $line = null, $col = null, $armor = array())
+    {
         $this->name = ctype_lower($name) ? $name : strtolower($name);
         foreach ($attr as $key => $value) {
             // normalization only necessary when key is not lowercase
@@ -49,7 +56,7 @@ class HTMLPurifier_Token_Tag extends HTMLPurifier_Token
         }
         $this->attr = $attr;
         $this->line = $line;
-        $this->col  = $col;
+        $this->col = $col;
         $this->armor = $armor;
     }
 }

--- a/library/HTMLPurifier/Token/Text.php
+++ b/library/HTMLPurifier/Token/Text.php
@@ -12,22 +12,38 @@
 class HTMLPurifier_Token_Text extends HTMLPurifier_Token
 {
 
-    public $name = '#PCDATA'; /**< PCDATA tag name compatible with DTD. */
-    public $data; /**< Parsed character data of text. */
-    public $is_whitespace; /**< Bool indicating if node is whitespace. */
+    /**
+     * @type string
+     */
+    public $name = '#PCDATA';
+    /**< PCDATA tag name compatible with DTD. */
+
+    /**
+     * @type string
+     */
+    public $data;
+    /**< Parsed character data of text. */
+
+    /**
+     * @type bool
+     */
+    public $is_whitespace;
+
+    /**< Bool indicating if node is whitespace. */
 
     /**
      * Constructor, accepts data and determines if it is whitespace.
-     *
-     * @param $data String parsed character data.
+     * @param string $data String parsed character data.
+     * @param int $line
+     * @param int $col
      */
-    public function __construct($data, $line = null, $col = null) {
+    public function __construct($data, $line = null, $col = null)
+    {
         $this->data = $data;
         $this->is_whitespace = ctype_space($data);
         $this->line = $line;
-        $this->col  = $col;
+        $this->col = $col;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/TokenFactory.php
+++ b/library/HTMLPurifier/TokenFactory.php
@@ -13,32 +13,53 @@
  */
 class HTMLPurifier_TokenFactory
 {
+    // p stands for prototype
 
     /**
-     * Prototypes that will be cloned.
-     * @private
+     * @type HTMLPurifier_Token_Start
      */
-    // p stands for prototype
-    private $p_start, $p_end, $p_empty, $p_text, $p_comment;
+    private $p_start;
+
+    /**
+     * @type HTMLPurifier_Token_End
+     */
+    private $p_end;
+
+    /**
+     * @type HTMLPurifier_Token_Empty
+     */
+    private $p_empty;
+
+    /**
+     * @type HTMLPurifier_Token_Text
+     */
+    private $p_text;
+
+    /**
+     * @type HTMLPurifier_Token_Comment
+     */
+    private $p_comment;
 
     /**
      * Generates blank prototypes for cloning.
      */
-    public function __construct() {
-        $this->p_start  = new HTMLPurifier_Token_Start('', array());
-        $this->p_end    = new HTMLPurifier_Token_End('');
-        $this->p_empty  = new HTMLPurifier_Token_Empty('', array());
-        $this->p_text   = new HTMLPurifier_Token_Text('');
-        $this->p_comment= new HTMLPurifier_Token_Comment('');
+    public function __construct()
+    {
+        $this->p_start = new HTMLPurifier_Token_Start('', array());
+        $this->p_end = new HTMLPurifier_Token_End('');
+        $this->p_empty = new HTMLPurifier_Token_Empty('', array());
+        $this->p_text = new HTMLPurifier_Token_Text('');
+        $this->p_comment = new HTMLPurifier_Token_Comment('');
     }
 
     /**
      * Creates a HTMLPurifier_Token_Start.
-     * @param $name Tag name
-     * @param $attr Associative array of attributes
-     * @return Generated HTMLPurifier_Token_Start
+     * @param string $name Tag name
+     * @param array $attr Associative array of attributes
+     * @return HTMLPurifier_Token_Start Generated HTMLPurifier_Token_Start
      */
-    public function createStart($name, $attr = array()) {
+    public function createStart($name, $attr = array())
+    {
         $p = clone $this->p_start;
         $p->__construct($name, $attr);
         return $p;
@@ -46,10 +67,11 @@ class HTMLPurifier_TokenFactory
 
     /**
      * Creates a HTMLPurifier_Token_End.
-     * @param $name Tag name
-     * @return Generated HTMLPurifier_Token_End
+     * @param string $name Tag name
+     * @return HTMLPurifier_Token_End Generated HTMLPurifier_Token_End
      */
-    public function createEnd($name) {
+    public function createEnd($name)
+    {
         $p = clone $this->p_end;
         $p->__construct($name);
         return $p;
@@ -57,11 +79,12 @@ class HTMLPurifier_TokenFactory
 
     /**
      * Creates a HTMLPurifier_Token_Empty.
-     * @param $name Tag name
-     * @param $attr Associative array of attributes
-     * @return Generated HTMLPurifier_Token_Empty
+     * @param string $name Tag name
+     * @param array $attr Associative array of attributes
+     * @return HTMLPurifier_Token_Empty Generated HTMLPurifier_Token_Empty
      */
-    public function createEmpty($name, $attr = array()) {
+    public function createEmpty($name, $attr = array())
+    {
         $p = clone $this->p_empty;
         $p->__construct($name, $attr);
         return $p;
@@ -69,10 +92,11 @@ class HTMLPurifier_TokenFactory
 
     /**
      * Creates a HTMLPurifier_Token_Text.
-     * @param $data Data of text token
-     * @return Generated HTMLPurifier_Token_Text
+     * @param string $data Data of text token
+     * @return HTMLPurifier_Token_Text Generated HTMLPurifier_Token_Text
      */
-    public function createText($data) {
+    public function createText($data)
+    {
         $p = clone $this->p_text;
         $p->__construct($data);
         return $p;
@@ -80,15 +104,15 @@ class HTMLPurifier_TokenFactory
 
     /**
      * Creates a HTMLPurifier_Token_Comment.
-     * @param $data Data of comment token
-     * @return Generated HTMLPurifier_Token_Comment
+     * @param string $data Data of comment token
+     * @return HTMLPurifier_Token_Comment Generated HTMLPurifier_Token_Comment
      */
-    public function createComment($data) {
+    public function createComment($data)
+    {
         $p = clone $this->p_comment;
         $p->__construct($data);
         return $p;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/URI.php
+++ b/library/HTMLPurifier/URI.php
@@ -10,17 +10,57 @@
  */
 class HTMLPurifier_URI
 {
-
-    public $scheme, $userinfo, $host, $port, $path, $query, $fragment;
+    /**
+     * @type string
+     */
+    public $scheme;
 
     /**
+     * @type string
+     */
+    public $userinfo;
+
+    /**
+     * @type string
+     */
+    public $host;
+
+    /**
+     * @type int
+     */
+    public $port;
+
+    /**
+     * @type string
+     */
+    public $path;
+
+    /**
+     * @type string
+     */
+    public $query;
+
+    /**
+     * @type string
+     */
+    public $fragment;
+
+    /**
+     * @param string $scheme
+     * @param string $userinfo
+     * @param string $host
+     * @param int $port
+     * @param string $path
+     * @param string $query
+     * @param string $fragment
      * @note Automatically normalizes scheme and port
      */
-    public function __construct($scheme, $userinfo, $host, $port, $path, $query, $fragment) {
+    public function __construct($scheme, $userinfo, $host, $port, $path, $query, $fragment)
+    {
         $this->scheme = is_null($scheme) || ctype_lower($scheme) ? $scheme : strtolower($scheme);
         $this->userinfo = $userinfo;
         $this->host = $host;
-        $this->port = is_null($port) ? $port : (int) $port;
+        $this->port = is_null($port) ? $port : (int)$port;
         $this->path = $path;
         $this->query = $query;
         $this->fragment = $fragment;
@@ -28,15 +68,18 @@ class HTMLPurifier_URI
 
     /**
      * Retrieves a scheme object corresponding to the URI's scheme/default
-     * @param $config Instance of HTMLPurifier_Config
-     * @param $context Instance of HTMLPurifier_Context
-     * @return Scheme object appropriate for validating this URI
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return HTMLPurifier_URIScheme Scheme object appropriate for validating this URI
      */
-    public function getSchemeObj($config, $context) {
+    public function getSchemeObj($config, $context)
+    {
         $registry = HTMLPurifier_URISchemeRegistry::instance();
         if ($this->scheme !== null) {
             $scheme_obj = $registry->getScheme($this->scheme, $config, $context);
-            if (!$scheme_obj) return false; // invalid scheme, clean it out
+            if (!$scheme_obj) {
+                return false;
+            } // invalid scheme, clean it out
         } else {
             // no scheme: retrieve the default one
             $def = $config->getDefinition('URI');
@@ -56,12 +99,12 @@ class HTMLPurifier_URI
     /**
      * Generic validation method applicable for all schemes. May modify
      * this URI in order to get it into a compliant form.
-     * @param $config Instance of HTMLPurifier_Config
-     * @param $context Instance of HTMLPurifier_Context
-     * @return True if validation/filtering succeeds, false if failure
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool True if validation/filtering succeeds, false if failure
      */
-    public function validate($config, $context) {
-
+    public function validate($config, $context)
+    {
         // ABNF definitions from RFC 3986
         $chars_sub_delims = '!$&\'()*+,;=';
         $chars_gen_delims = ':/?#[]@';
@@ -71,7 +114,9 @@ class HTMLPurifier_URI
         if (!is_null($this->host)) {
             $host_def = new HTMLPurifier_AttrDef_URI_Host();
             $this->host = $host_def->validate($this->host, $config, $context);
-            if ($this->host === false) $this->host = null;
+            if ($this->host === false) {
+                $this->host = null;
+            }
         }
 
         // validate scheme
@@ -97,11 +142,12 @@ class HTMLPurifier_URI
 
         // validate port
         if (!is_null($this->port)) {
-            if ($this->port < 1 || $this->port > 65535) $this->port = null;
+            if ($this->port < 1 || $this->port > 65535) {
+                $this->port = null;
+            }
         }
 
         // validate path
-        $path_parts = array();
         $segments_encoder = new HTMLPurifier_PercentEncoder($chars_pchar . '/');
         if (!is_null($this->host)) { // this catches $this->host === ''
             // path-abempty (hier and relative)
@@ -161,16 +207,15 @@ class HTMLPurifier_URI
         if (!is_null($this->fragment)) {
             $this->fragment = $qf_encoder->encode($this->fragment);
         }
-
         return true;
-
     }
 
     /**
      * Convert URI back to string
-     * @return String URI appropriate for output
+     * @return string URI appropriate for output
      */
-    public function toString() {
+    public function toString()
+    {
         // reconstruct authority
         $authority = null;
         // there is a rendering difference between a null authority
@@ -178,9 +223,13 @@ class HTMLPurifier_URI
         // (http:///foo-bar).
         if (!is_null($this->host)) {
             $authority = '';
-            if(!is_null($this->userinfo)) $authority .= $this->userinfo . '@';
+            if (!is_null($this->userinfo)) {
+                $authority .= $this->userinfo . '@';
+            }
             $authority .= $this->host;
-            if(!is_null($this->port))     $authority .= ':' . $this->port;
+            if (!is_null($this->port)) {
+                $authority .= ':' . $this->port;
+            }
         }
 
         // Reconstruct the result
@@ -190,11 +239,19 @@ class HTMLPurifier_URI
         // differently than http:///foo), so unfortunately we have to
         // defer to the schemes to do the right thing.
         $result = '';
-        if (!is_null($this->scheme))    $result .= $this->scheme . ':';
-        if (!is_null($authority))       $result .=  '//' . $authority;
+        if (!is_null($this->scheme)) {
+            $result .= $this->scheme . ':';
+        }
+        if (!is_null($authority)) {
+            $result .= '//' . $authority;
+        }
         $result .= $this->path;
-        if (!is_null($this->query))     $result .= '?' . $this->query;
-        if (!is_null($this->fragment))  $result .= '#' . $this->fragment;
+        if (!is_null($this->query)) {
+            $result .= '?' . $this->query;
+        }
+        if (!is_null($this->fragment)) {
+            $result .= '#' . $this->fragment;
+        }
 
         return $result;
     }
@@ -207,11 +264,19 @@ class HTMLPurifier_URI
      * Note that this does not do any scheme checking, so it is mostly
      * only appropriate for metadata that doesn't care about protocol
      * security.  isBenign is probably what you actually want.
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
      */
-    public function isLocal($config, $context) {
-        if ($this->host === null) return true;
+    public function isLocal($config, $context)
+    {
+        if ($this->host === null) {
+            return true;
+        }
         $uri_def = $config->getDefinition('URI');
-        if ($uri_def->host === $this->host) return true;
+        if ($uri_def->host === $this->host) {
+            return true;
+        }
         return false;
     }
 
@@ -221,12 +286,20 @@ class HTMLPurifier_URI
      *
      *      - It is a local URL (isLocal), and
      *      - It has a equal or better level of security
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
      */
-    public function isBenign($config, $context) {
-        if (!$this->isLocal($config, $context)) return false;
+    public function isBenign($config, $context)
+    {
+        if (!$this->isLocal($config, $context)) {
+            return false;
+        }
 
         $scheme_obj = $this->getSchemeObj($config, $context);
-        if (!$scheme_obj) return false; // conservative approach
+        if (!$scheme_obj) {
+            return false;
+        } // conservative approach
 
         $current_scheme_obj = $config->getDefinition('URI')->getDefaultScheme($config, $context);
         if ($current_scheme_obj->secure) {
@@ -236,7 +309,6 @@ class HTMLPurifier_URI
         }
         return true;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/URIDefinition.php
+++ b/library/HTMLPurifier/URIDefinition.php
@@ -23,7 +23,8 @@ class HTMLPurifier_URIDefinition extends HTMLPurifier_Definition
      */
     public $defaultScheme;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->registerFilter(new HTMLPurifier_URIFilter_DisableExternal());
         $this->registerFilter(new HTMLPurifier_URIFilter_DisableExternalResources());
         $this->registerFilter(new HTMLPurifier_URIFilter_DisableResources());
@@ -33,11 +34,13 @@ class HTMLPurifier_URIDefinition extends HTMLPurifier_Definition
         $this->registerFilter(new HTMLPurifier_URIFilter_Munge());
     }
 
-    public function registerFilter($filter) {
+    public function registerFilter($filter)
+    {
         $this->registeredFilters[$filter->name] = $filter;
     }
 
-    public function addFilter($filter, $config) {
+    public function addFilter($filter, $config)
+    {
         $r = $filter->prepare($config);
         if ($r === false) return; // null is ok, for backwards compat
         if ($filter->post) {
@@ -47,12 +50,14 @@ class HTMLPurifier_URIDefinition extends HTMLPurifier_Definition
         }
     }
 
-    protected function doSetup($config) {
+    protected function doSetup($config)
+    {
         $this->setupMemberVariables($config);
         $this->setupFilters($config);
     }
 
-    protected function setupFilters($config) {
+    protected function setupFilters($config)
+    {
         foreach ($this->registeredFilters as $name => $filter) {
             if ($filter->always_load) {
                 $this->addFilter($filter, $config);
@@ -66,7 +71,8 @@ class HTMLPurifier_URIDefinition extends HTMLPurifier_Definition
         unset($this->registeredFilters);
     }
 
-    protected function setupMemberVariables($config) {
+    protected function setupMemberVariables($config)
+    {
         $this->host = $config->get('URI.Host');
         $base_uri = $config->get('URI.Base');
         if (!is_null($base_uri)) {
@@ -78,11 +84,13 @@ class HTMLPurifier_URIDefinition extends HTMLPurifier_Definition
         if (is_null($this->defaultScheme)) $this->defaultScheme = $config->get('URI.DefaultScheme');
     }
 
-    public function getDefaultScheme($config, $context) {
+    public function getDefaultScheme($config, $context)
+    {
         return HTMLPurifier_URISchemeRegistry::instance()->getScheme($this->defaultScheme, $config, $context);
     }
 
-    public function filter(&$uri, $config, $context) {
+    public function filter(&$uri, $config, $context)
+    {
         foreach ($this->filters as $name => $f) {
             $result = $f->filter($uri, $config, $context);
             if (!$result) return false;
@@ -90,7 +98,8 @@ class HTMLPurifier_URIDefinition extends HTMLPurifier_Definition
         return true;
     }
 
-    public function postFilter(&$uri, $config, $context) {
+    public function postFilter(&$uri, $config, $context)
+    {
         foreach ($this->postFilters as $name => $f) {
             $result = $f->filter($uri, $config, $context);
             if (!$result) return false;

--- a/library/HTMLPurifier/URIFilter.php
+++ b/library/HTMLPurifier/URIFilter.php
@@ -29,39 +29,46 @@ abstract class HTMLPurifier_URIFilter
 {
 
     /**
-     * Unique identifier of filter
+     * Unique identifier of filter.
+     * @type string
      */
     public $name;
 
     /**
      * True if this filter should be run after scheme validation.
+     * @type bool
      */
     public $post = false;
 
     /**
-     * True if this filter should always be loaded (this permits
-     * a filter to be named Foo without the corresponding %URI.Foo
-     * directive existing.)
+     * True if this filter should always be loaded.
+     * This permits a filter to be named Foo without the corresponding
+     * %URI.Foo directive existing.
+     * @type bool
      */
     public $always_load = false;
 
     /**
      * Performs initialization for the filter.  If the filter returns
      * false, this means that it shouldn't be considered active.
+     * @param HTMLPurifier_Config $config
+     * @return bool
      */
-    public function prepare($config) {return true;}
+    public function prepare($config)
+    {
+        return true;
+    }
 
     /**
      * Filter a URI object
-     * @param $uri Reference to URI object variable
-     * @param $config Instance of HTMLPurifier_Config
-     * @param $context Instance of HTMLPurifier_Context
+     * @param HTMLPurifier_URI $uri Reference to URI object variable
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
      * @return bool Whether or not to continue processing: false indicates
      *         URL is no good, true indicates continue processing. Note that
      *         all changes are committed directly on the URI object
      */
     abstract public function filter(&$uri, $config, $context);
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/URIFilter/DisableExternal.php
+++ b/library/HTMLPurifier/URIFilter/DisableExternal.php
@@ -2,19 +2,50 @@
 
 class HTMLPurifier_URIFilter_DisableExternal extends HTMLPurifier_URIFilter
 {
+    /**
+     * @type string
+     */
     public $name = 'DisableExternal';
+
+    /**
+     * @type array
+     */
     protected $ourHostParts = false;
-    public function prepare($config) {
+
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return void
+     */
+    public function prepare($config)
+    {
         $our_host = $config->getDefinition('URI')->host;
-        if ($our_host !== null) $this->ourHostParts = array_reverse(explode('.', $our_host));
+        if ($our_host !== null) {
+            $this->ourHostParts = array_reverse(explode('.', $our_host));
+        }
     }
-    public function filter(&$uri, $config, $context) {
-        if (is_null($uri->host)) return true;
-        if ($this->ourHostParts === false) return false;
+
+    /**
+     * @param HTMLPurifier_URI $uri Reference
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function filter(&$uri, $config, $context)
+    {
+        if (is_null($uri->host)) {
+            return true;
+        }
+        if ($this->ourHostParts === false) {
+            return false;
+        }
         $host_parts = array_reverse(explode('.', $uri->host));
         foreach ($this->ourHostParts as $i => $x) {
-            if (!isset($host_parts[$i])) return false;
-            if ($host_parts[$i] != $this->ourHostParts[$i]) return false;
+            if (!isset($host_parts[$i])) {
+                return false;
+            }
+            if ($host_parts[$i] != $this->ourHostParts[$i]) {
+                return false;
+            }
         }
         return true;
     }

--- a/library/HTMLPurifier/URIFilter/DisableExternalResources.php
+++ b/library/HTMLPurifier/URIFilter/DisableExternalResources.php
@@ -2,9 +2,22 @@
 
 class HTMLPurifier_URIFilter_DisableExternalResources extends HTMLPurifier_URIFilter_DisableExternal
 {
+    /**
+     * @type string
+     */
     public $name = 'DisableExternalResources';
-    public function filter(&$uri, $config, $context) {
-        if (!$context->get('EmbeddedURI', true)) return true;
+
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function filter(&$uri, $config, $context)
+    {
+        if (!$context->get('EmbeddedURI', true)) {
+            return true;
+        }
         return parent::filter($uri, $config, $context);
     }
 }

--- a/library/HTMLPurifier/URIFilter/DisableResources.php
+++ b/library/HTMLPurifier/URIFilter/DisableResources.php
@@ -2,8 +2,19 @@
 
 class HTMLPurifier_URIFilter_DisableResources extends HTMLPurifier_URIFilter
 {
+    /**
+     * @type string
+     */
     public $name = 'DisableResources';
-    public function filter(&$uri, $config, $context) {
+
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function filter(&$uri, $config, $context)
+    {
         return !$context->get('EmbeddedURI', true);
     }
 }

--- a/library/HTMLPurifier/URIFilter/HostBlacklist.php
+++ b/library/HTMLPurifier/URIFilter/HostBlacklist.php
@@ -6,14 +6,35 @@
 // points are involved), but I'm not 100% sure
 class HTMLPurifier_URIFilter_HostBlacklist extends HTMLPurifier_URIFilter
 {
+    /**
+     * @type string
+     */
     public $name = 'HostBlacklist';
+
+    /**
+     * @type array
+     */
     protected $blacklist = array();
-    public function prepare($config) {
+
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function prepare($config)
+    {
         $this->blacklist = $config->get('URI.HostBlacklist');
         return true;
     }
-    public function filter(&$uri, $config, $context) {
-        foreach($this->blacklist as $blacklisted_host_fragment) {
+
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function filter(&$uri, $config, $context)
+    {
+        foreach ($this->blacklist as $blacklisted_host_fragment) {
             if (strpos($uri->host, $blacklisted_host_fragment) !== false) {
                 return false;
             }

--- a/library/HTMLPurifier/URIFilter/MakeAbsolute.php
+++ b/library/HTMLPurifier/URIFilter/MakeAbsolute.php
@@ -4,14 +4,35 @@
 
 class HTMLPurifier_URIFilter_MakeAbsolute extends HTMLPurifier_URIFilter
 {
+    /**
+     * @type string
+     */
     public $name = 'MakeAbsolute';
+
+    /**
+     * @type
+     */
     protected $base;
+
+    /**
+     * @type array
+     */
     protected $basePathStack = array();
-    public function prepare($config) {
+
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function prepare($config)
+    {
         $def = $config->getDefinition('URI');
         $this->base = $def->base;
         if (is_null($this->base)) {
-            trigger_error('URI.MakeAbsolute is being ignored due to lack of value for URI.Base configuration', E_USER_WARNING);
+            trigger_error(
+                'URI.MakeAbsolute is being ignored due to lack of ' .
+                'value for URI.Base configuration',
+                E_USER_WARNING
+            );
             return false;
         }
         $this->base->fragment = null; // fragment is invalid for base URI
@@ -21,19 +42,29 @@ class HTMLPurifier_URIFilter_MakeAbsolute extends HTMLPurifier_URIFilter
         $this->basePathStack = $stack;
         return true;
     }
-    public function filter(&$uri, $config, $context) {
-        if (is_null($this->base)) return true; // abort early
-        if (
-            $uri->path === '' && is_null($uri->scheme) &&
-            is_null($uri->host) && is_null($uri->query) && is_null($uri->fragment)
-        ) {
+
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function filter(&$uri, $config, $context)
+    {
+        if (is_null($this->base)) {
+            return true;
+        } // abort early
+        if ($uri->path === '' && is_null($uri->scheme) &&
+            is_null($uri->host) && is_null($uri->query) && is_null($uri->fragment)) {
             // reference to current document
             $uri = clone $this->base;
             return true;
         }
         if (!is_null($uri->scheme)) {
             // absolute URI already: don't change
-            if (!is_null($uri->host)) return true;
+            if (!is_null($uri->host)) {
+                return true;
+            }
             $scheme_obj = $uri->getSchemeObj($config, $context);
             if (!$scheme_obj) {
                 // scheme not recognized
@@ -66,22 +97,33 @@ class HTMLPurifier_URIFilter_MakeAbsolute extends HTMLPurifier_URIFilter
         }
         // re-combine
         $uri->scheme = $this->base->scheme;
-        if (is_null($uri->userinfo)) $uri->userinfo = $this->base->userinfo;
-        if (is_null($uri->host))     $uri->host     = $this->base->host;
-        if (is_null($uri->port))     $uri->port     = $this->base->port;
+        if (is_null($uri->userinfo)) {
+            $uri->userinfo = $this->base->userinfo;
+        }
+        if (is_null($uri->host)) {
+            $uri->host = $this->base->host;
+        }
+        if (is_null($uri->port)) {
+            $uri->port = $this->base->port;
+        }
         return true;
     }
 
     /**
      * Resolve dots and double-dots in a path stack
+     * @param array $stack
+     * @return array
      */
-    private function _collapseStack($stack) {
+    private function _collapseStack($stack)
+    {
         $result = array();
         $is_folder = false;
         for ($i = 0; isset($stack[$i]); $i++) {
             $is_folder = false;
             // absorb an internally duplicated slash
-            if ($stack[$i] == '' && $i && isset($stack[$i+1])) continue;
+            if ($stack[$i] == '' && $i && isset($stack[$i + 1])) {
+                continue;
+            }
             if ($stack[$i] == '..') {
                 if (!empty($result)) {
                     $segment = array_pop($result);
@@ -106,7 +148,9 @@ class HTMLPurifier_URIFilter_MakeAbsolute extends HTMLPurifier_URIFilter
             }
             $result[] = $stack[$i];
         }
-        if ($is_folder) $result[] = '';
+        if ($is_folder) {
+            $result[] = '';
+        }
         return $result;
     }
 }

--- a/library/HTMLPurifier/URIFilter/Munge.php
+++ b/library/HTMLPurifier/URIFilter/Munge.php
@@ -2,26 +2,76 @@
 
 class HTMLPurifier_URIFilter_Munge extends HTMLPurifier_URIFilter
 {
+    /**
+     * @type string
+     */
     public $name = 'Munge';
-    public $post = true;
-    private $target, $parser, $doEmbed, $secretKey;
 
+    /**
+     * @type bool
+     */
+    public $post = true;
+
+    /**
+     * @type string
+     */
+    private $target;
+
+    /**
+     * @type HTMLPurifier_URIParser
+     */
+    private $parser;
+
+    /**
+     * @type bool
+     */
+    private $doEmbed;
+
+    /**
+     * @type string
+     */
+    private $secretKey;
+
+    /**
+     * @type array
+     */
     protected $replace = array();
 
-    public function prepare($config) {
-        $this->target    = $config->get('URI.' . $this->name);
-        $this->parser    = new HTMLPurifier_URIParser();
-        $this->doEmbed   = $config->get('URI.MungeResources');
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function prepare($config)
+    {
+        $this->target = $config->get('URI.' . $this->name);
+        $this->parser = new HTMLPurifier_URIParser();
+        $this->doEmbed = $config->get('URI.MungeResources');
         $this->secretKey = $config->get('URI.MungeSecretKey');
         return true;
     }
-    public function filter(&$uri, $config, $context) {
-        if ($context->get('EmbeddedURI', true) && !$this->doEmbed) return true;
+
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function filter(&$uri, $config, $context)
+    {
+        if ($context->get('EmbeddedURI', true) && !$this->doEmbed) {
+            return true;
+        }
 
         $scheme_obj = $uri->getSchemeObj($config, $context);
-        if (!$scheme_obj) return true; // ignore unknown schemes, maybe another postfilter did it
-        if (!$scheme_obj->browsable) return true; // ignore non-browseable schemes, since we can't munge those in a reasonable way
-        if ($uri->isBenign($config, $context)) return true; // don't redirect if a benign URL
+        if (!$scheme_obj) {
+            return true;
+        } // ignore unknown schemes, maybe another postfilter did it
+        if (!$scheme_obj->browsable) {
+            return true;
+        } // ignore non-browseable schemes, since we can't munge those in a reasonable way
+        if ($uri->isBenign($config, $context)) {
+            return true;
+        } // don't redirect if a benign URL
 
         $this->makeReplace($uri, $config, $context);
         $this->replace = array_map('rawurlencode', $this->replace);
@@ -30,12 +80,20 @@ class HTMLPurifier_URIFilter_Munge extends HTMLPurifier_URIFilter
         $new_uri = $this->parser->parse($new_uri);
         // don't redirect if the target host is the same as the
         // starting host
-        if ($uri->host === $new_uri->host) return true;
+        if ($uri->host === $new_uri->host) {
+            return true;
+        }
         $uri = $new_uri; // overwrite
         return true;
     }
 
-    protected function makeReplace($uri, $config, $context) {
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     */
+    protected function makeReplace($uri, $config, $context)
+    {
         $string = $uri->toString();
         // always available
         $this->replace['%s'] = $string;
@@ -45,9 +103,10 @@ class HTMLPurifier_URIFilter_Munge extends HTMLPurifier_URIFilter
         $this->replace['%m'] = $context->get('CurrentAttr', true);
         $this->replace['%p'] = $context->get('CurrentCSSProperty', true);
         // not always available
-        if ($this->secretKey) $this->replace['%t'] = sha1($this->secretKey . ':' . $string);
+        if ($this->secretKey) {
+            $this->replace['%t'] = sha1($this->secretKey . ':' . $string);
+        }
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/URIFilter/SafeIframe.php
+++ b/library/HTMLPurifier/URIFilter/SafeIframe.php
@@ -8,25 +8,58 @@
  */
 class HTMLPurifier_URIFilter_SafeIframe extends HTMLPurifier_URIFilter
 {
+    /**
+     * @type string
+     */
     public $name = 'SafeIframe';
+
+    /**
+     * @type bool
+     */
     public $always_load = true;
-    protected $regexp = NULL;
-    // XXX: The not so good bit about how this is all setup now is we
+
+    /**
+     * @type string
+     */
+    protected $regexp = null;
+
+    // XXX: The not so good bit about how this is all set up now is we
     // can't check HTML.SafeIframe in the 'prepare' step: we have to
     // defer till the actual filtering.
-    public function prepare($config) {
+    /**
+     * @param HTMLPurifier_Config $config
+     * @return bool
+     */
+    public function prepare($config)
+    {
         $this->regexp = $config->get('URI.SafeIframeRegexp');
         return true;
     }
-    public function filter(&$uri, $config, $context) {
+
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function filter(&$uri, $config, $context)
+    {
         // check if filter not applicable
-        if (!$config->get('HTML.SafeIframe')) return true;
+        if (!$config->get('HTML.SafeIframe')) {
+            return true;
+        }
         // check if the filter should actually trigger
-        if (!$context->get('EmbeddedURI', true)) return true;
+        if (!$context->get('EmbeddedURI', true)) {
+            return true;
+        }
         $token = $context->get('CurrentToken', true);
-        if (!($token && $token->name == 'iframe')) return true;
+        if (!($token && $token->name == 'iframe')) {
+            return true;
+        }
         // check if we actually have some whitelists enabled
-        if ($this->regexp === null) return false;
+        if ($this->regexp === null) {
+            return false;
+        }
         // actually check the whitelists
         return preg_match($this->regexp, $uri->toString());
     }

--- a/library/HTMLPurifier/URIParser.php
+++ b/library/HTMLPurifier/URIParser.php
@@ -12,7 +12,8 @@ class HTMLPurifier_URIParser
      */
     protected $percentEncoder;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->percentEncoder = new HTMLPurifier_PercentEncoder();
     }
 
@@ -22,8 +23,8 @@ class HTMLPurifier_URIParser
      * @return HTMLPurifier_URI representation of URI. This representation has
      *         not been validated yet and may not conform to RFC.
      */
-    public function parse($uri) {
-
+    public function parse($uri)
+    {
         $uri = $this->percentEncoder->normalize($uri);
 
         // Regexp is as per Appendix B.

--- a/library/HTMLPurifier/URIScheme.php
+++ b/library/HTMLPurifier/URIScheme.php
@@ -7,27 +7,31 @@ abstract class HTMLPurifier_URIScheme
 {
 
     /**
-     * Scheme's default port (integer).  If an explicit port number is
+     * Scheme's default port (integer). If an explicit port number is
      * specified that coincides with the default port, it will be
      * elided.
+     * @type int
      */
     public $default_port = null;
 
     /**
-     * Whether or not URIs of this schem are locatable by a browser
+     * Whether or not URIs of this scheme are locatable by a browser
      * http and ftp are accessible, while mailto and news are not.
+     * @type bool
      */
     public $browsable = false;
 
     /**
      * Whether or not data transmitted over this scheme is encrypted.
      * https is secure, http is not.
+     * @type bool
      */
     public $secure = false;
 
     /**
      * Whether or not the URI always uses <hier_part>, resolves edge cases
      * with making relative URIs absolute
+     * @type bool
      */
     public $hierarchical = false;
 
@@ -35,28 +39,32 @@ abstract class HTMLPurifier_URIScheme
      * Whether or not the URI may omit a hostname when the scheme is
      * explicitly specified, ala file:///path/to/file. As of writing,
      * 'file' is the only scheme that browsers support his properly.
+     * @type bool
      */
     public $may_omit_host = false;
 
     /**
      * Validates the components of a URI for a specific scheme.
-     * @param $uri Reference to a HTMLPurifier_URI object
-     * @param $config HTMLPurifier_Config object
-     * @param $context HTMLPurifier_Context object
-     * @return Bool success or failure
+     * @param HTMLPurifier_URI $uri Reference to a HTMLPurifier_URI object
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool success or failure
      */
-    public abstract function doValidate(&$uri, $config, $context);
+    abstract public function doValidate(&$uri, $config, $context);
 
     /**
      * Public interface for validating components of a URI.  Performs a
      * bunch of default actions. Don't overload this method.
-     * @param $uri Reference to a HTMLPurifier_URI object
-     * @param $config HTMLPurifier_Config object
-     * @param $context HTMLPurifier_Context object
-     * @return Bool success or failure
+     * @param HTMLPurifier_URI $uri Reference to a HTMLPurifier_URI object
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool success or failure
      */
-    public function validate(&$uri, $config, $context) {
-        if ($this->default_port == $uri->port) $uri->port = null;
+    public function validate(&$uri, $config, $context)
+    {
+        if ($this->default_port == $uri->port) {
+            $uri->port = null;
+        }
         // kludge: browsers do funny things when the scheme but not the
         // authority is set
         if (!$this->may_omit_host &&
@@ -65,7 +73,7 @@ abstract class HTMLPurifier_URIScheme
             // if the scheme is not present, a *blank* host is in error,
             // since this translates into '///path' which most browsers
             // interpret as being 'http://path'.
-             (is_null($uri->scheme) && $uri->host === '')
+            (is_null($uri->scheme) && $uri->host === '')
         ) {
             do {
                 if (is_null($uri->scheme)) {
@@ -89,7 +97,6 @@ abstract class HTMLPurifier_URIScheme
         }
         return $this->doValidate($uri, $config, $context);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/URIScheme/data.php
+++ b/library/HTMLPurifier/URIScheme/data.php
@@ -3,21 +3,38 @@
 /**
  * Implements data: URI for base64 encoded images supported by GD.
  */
-class HTMLPurifier_URIScheme_data extends HTMLPurifier_URIScheme {
-
+class HTMLPurifier_URIScheme_data extends HTMLPurifier_URIScheme
+{
+    /**
+     * @type bool
+     */
     public $browsable = true;
+
+    /**
+     * @type array
+     */
     public $allowed_types = array(
         // you better write validation code for other types if you
         // decide to allow them
         'image/jpeg' => true,
         'image/gif' => true,
         'image/png' => true,
-        );
+    );
     // this is actually irrelevant since we only write out the path
     // component
+    /**
+     * @type bool
+     */
     public $may_omit_host = true;
 
-    public function doValidate(&$uri, $config, $context) {
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function doValidate(&$uri, $config, $context)
+    {
         $result = explode(',', $uri->path, 2);
         $is_base64 = false;
         $charset = null;
@@ -26,7 +43,7 @@ class HTMLPurifier_URIScheme_data extends HTMLPurifier_URIScheme {
             list($metadata, $data) = $result;
             // do some legwork on the metadata
             $metas = explode(';', $metadata);
-            while(!empty($metas)) {
+            while (!empty($metas)) {
                 $cur = array_shift($metas);
                 if ($cur == 'base64') {
                     $is_base64 = true;
@@ -35,10 +52,14 @@ class HTMLPurifier_URIScheme_data extends HTMLPurifier_URIScheme {
                 if (substr($cur, 0, 8) == 'charset=') {
                     // doesn't match if there are arbitrary spaces, but
                     // whatever dude
-                    if ($charset !== null) continue; // garbage
+                    if ($charset !== null) {
+                        continue;
+                    } // garbage
                     $charset = substr($cur, 8); // not used
                 } else {
-                    if ($content_type !== null) continue; // garbage
+                    if ($content_type !== null) {
+                        continue;
+                    } // garbage
                     $content_type = $cur;
                 }
             }
@@ -70,7 +91,9 @@ class HTMLPurifier_URIScheme_data extends HTMLPurifier_URIScheme {
             $info = getimagesize($file);
             restore_error_handler();
             unlink($file);
-            if ($info == false) return false;
+            if ($info == false) {
+                return false;
+            }
             $image_code = $info[2];
         } else {
             trigger_error("could not find exif_imagetype or getimagesize functions", E_USER_ERROR);
@@ -79,7 +102,9 @@ class HTMLPurifier_URIScheme_data extends HTMLPurifier_URIScheme {
         if ($real_content_type != $content_type) {
             // we're nice guys; if the content type is something else we
             // support, change it over
-            if (empty($this->allowed_types[$real_content_type])) return false;
+            if (empty($this->allowed_types[$real_content_type])) {
+                return false;
+            }
             $content_type = $real_content_type;
         }
         // ok, it's kosher, rewrite what we need
@@ -92,7 +117,11 @@ class HTMLPurifier_URIScheme_data extends HTMLPurifier_URIScheme {
         return true;
     }
 
-    public function muteErrorHandler($errno, $errstr) {}
-
+    /**
+     * @param int $errno
+     * @param string $errstr
+     */
+    public function muteErrorHandler($errno, $errstr)
+    {
+    }
 }
-

--- a/library/HTMLPurifier/URIScheme/file.php
+++ b/library/HTMLPurifier/URIScheme/file.php
@@ -3,30 +3,42 @@
 /**
  * Validates file as defined by RFC 1630 and RFC 1738.
  */
-class HTMLPurifier_URIScheme_file extends HTMLPurifier_URIScheme {
-
-    // Generally file:// URLs are not accessible from most
-    // machines, so placing them as an img src is incorrect.
+class HTMLPurifier_URIScheme_file extends HTMLPurifier_URIScheme
+{
+    /**
+     * Generally file:// URLs are not accessible from most
+     * machines, so placing them as an img src is incorrect.
+     * @type bool
+     */
     public $browsable = false;
 
-    // Basically the *only* URI scheme for which this is true, since
-    // accessing files on the local machine is very common.  In fact,
-    // browsers on some operating systems don't understand the
-    // authority, though I hear it is used on Windows to refer to
-    // network shares.
+    /**
+     * Basically the *only* URI scheme for which this is true, since
+     * accessing files on the local machine is very common.  In fact,
+     * browsers on some operating systems don't understand the
+     * authority, though I hear it is used on Windows to refer to
+     * network shares.
+     * @type bool
+     */
     public $may_omit_host = true;
 
-    public function doValidate(&$uri, $config, $context) {
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function doValidate(&$uri, $config, $context)
+    {
         // Authentication method is not supported
         $uri->userinfo = null;
         // file:// makes no provisions for accessing the resource
-        $uri->port     = null;
+        $uri->port = null;
         // While it seems to work on Firefox, the querystring has
         // no possible effect and is thus stripped.
-        $uri->query    = null;
+        $uri->query = null;
         return true;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/URIScheme/ftp.php
+++ b/library/HTMLPurifier/URIScheme/ftp.php
@@ -3,14 +3,32 @@
 /**
  * Validates ftp (File Transfer Protocol) URIs as defined by generic RFC 1738.
  */
-class HTMLPurifier_URIScheme_ftp extends HTMLPurifier_URIScheme {
-
+class HTMLPurifier_URIScheme_ftp extends HTMLPurifier_URIScheme
+{
+    /**
+     * @type int
+     */
     public $default_port = 21;
+
+    /**
+     * @type bool
+     */
     public $browsable = true; // usually
+
+    /**
+     * @type bool
+     */
     public $hierarchical = true;
 
-    public function doValidate(&$uri, $config, $context) {
-        $uri->query    = null;
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function doValidate(&$uri, $config, $context)
+    {
+        $uri->query = null;
 
         // typecode check
         $semicolon_pos = strrpos($uri->path, ';'); // reverse
@@ -33,10 +51,8 @@ class HTMLPurifier_URIScheme_ftp extends HTMLPurifier_URIScheme {
             $uri->path = str_replace(';', '%3B', $uri->path);
             $uri->path .= $type_ret;
         }
-
         return true;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/URIScheme/http.php
+++ b/library/HTMLPurifier/URIScheme/http.php
@@ -3,17 +3,34 @@
 /**
  * Validates http (HyperText Transfer Protocol) as defined by RFC 2616
  */
-class HTMLPurifier_URIScheme_http extends HTMLPurifier_URIScheme {
-
+class HTMLPurifier_URIScheme_http extends HTMLPurifier_URIScheme
+{
+    /**
+     * @type int
+     */
     public $default_port = 80;
+
+    /**
+     * @type bool
+     */
     public $browsable = true;
+
+    /**
+     * @type bool
+     */
     public $hierarchical = true;
 
-    public function doValidate(&$uri, $config, $context) {
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function doValidate(&$uri, $config, $context)
+    {
         $uri->userinfo = null;
         return true;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/URIScheme/https.php
+++ b/library/HTMLPurifier/URIScheme/https.php
@@ -3,11 +3,16 @@
 /**
  * Validates https (Secure HTTP) according to http scheme.
  */
-class HTMLPurifier_URIScheme_https extends HTMLPurifier_URIScheme_http {
-
+class HTMLPurifier_URIScheme_https extends HTMLPurifier_URIScheme_http
+{
+    /**
+     * @type int
+     */
     public $default_port = 443;
+    /**
+     * @type bool
+     */
     public $secure = true;
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/URIScheme/mailto.php
+++ b/library/HTMLPurifier/URIScheme/mailto.php
@@ -9,19 +9,32 @@
  * @todo Filter allowed query parameters
  */
 
-class HTMLPurifier_URIScheme_mailto extends HTMLPurifier_URIScheme {
-
+class HTMLPurifier_URIScheme_mailto extends HTMLPurifier_URIScheme
+{
+    /**
+     * @type bool
+     */
     public $browsable = false;
+
+    /**
+     * @type bool
+     */
     public $may_omit_host = true;
 
-    public function doValidate(&$uri, $config, $context) {
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function doValidate(&$uri, $config, $context)
+    {
         $uri->userinfo = null;
         $uri->host     = null;
         $uri->port     = null;
         // we need to validate path against RFC 2368's addr-spec
         return true;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/URIScheme/news.php
+++ b/library/HTMLPurifier/URIScheme/news.php
@@ -3,20 +3,33 @@
 /**
  * Validates news (Usenet) as defined by generic RFC 1738
  */
-class HTMLPurifier_URIScheme_news extends HTMLPurifier_URIScheme {
-
+class HTMLPurifier_URIScheme_news extends HTMLPurifier_URIScheme
+{
+    /**
+     * @type bool
+     */
     public $browsable = false;
+
+    /**
+     * @type bool
+     */
     public $may_omit_host = true;
 
-    public function doValidate(&$uri, $config, $context) {
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function doValidate(&$uri, $config, $context)
+    {
         $uri->userinfo = null;
-        $uri->host     = null;
-        $uri->port     = null;
-        $uri->query    = null;
+        $uri->host = null;
+        $uri->port = null;
+        $uri->query = null;
         // typecode check needed on path
         return true;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/URIScheme/nntp.php
+++ b/library/HTMLPurifier/URIScheme/nntp.php
@@ -3,17 +3,30 @@
 /**
  * Validates nntp (Network News Transfer Protocol) as defined by generic RFC 1738
  */
-class HTMLPurifier_URIScheme_nntp extends HTMLPurifier_URIScheme {
-
+class HTMLPurifier_URIScheme_nntp extends HTMLPurifier_URIScheme
+{
+    /**
+     * @type int
+     */
     public $default_port = 119;
+
+    /**
+     * @type bool
+     */
     public $browsable = false;
 
-    public function doValidate(&$uri, $config, $context) {
+    /**
+     * @param HTMLPurifier_URI $uri
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return bool
+     */
+    public function doValidate(&$uri, $config, $context)
+    {
         $uri->userinfo = null;
-        $uri->query    = null;
+        $uri->query = null;
         return true;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/URISchemeRegistry.php
+++ b/library/HTMLPurifier/URISchemeRegistry.php
@@ -8,12 +8,14 @@ class HTMLPurifier_URISchemeRegistry
 
     /**
      * Retrieve sole instance of the registry.
-     * @param $prototype Optional prototype to overload sole instance with,
+     * @param HTMLPurifier_URISchemeRegistry $prototype Optional prototype to overload sole instance with,
      *                   or bool true to reset to default registry.
+     * @return HTMLPurifier_URISchemeRegistry
      * @note Pass a registry object $prototype with a compatible interface and
      *       the function will copy it and return it all further times.
      */
-    public static function instance($prototype = null) {
+    public static function instance($prototype = null)
+    {
         static $instance = null;
         if ($prototype !== null) {
             $instance = $prototype;
@@ -25,17 +27,22 @@ class HTMLPurifier_URISchemeRegistry
 
     /**
      * Cache of retrieved schemes.
+     * @type HTMLPurifier_URIScheme[]
      */
     protected $schemes = array();
 
     /**
      * Retrieves a scheme validator object
-     * @param $scheme String scheme name like http or mailto
-     * @param $config HTMLPurifier_Config object
-     * @param $config HTMLPurifier_Context object
+     * @param string $scheme String scheme name like http or mailto
+     * @param HTMLPurifier_Config $config
+     * @param HTMLPurifier_Context $context
+     * @return HTMLPurifier_URIScheme
      */
-    public function getScheme($scheme, $config, $context) {
-        if (!$config) $config = HTMLPurifier_Config::createDefault();
+    public function getScheme($scheme, $config, $context)
+    {
+        if (!$config) {
+            $config = HTMLPurifier_Config::createDefault();
+        }
 
         // important, otherwise attacker could include arbitrary file
         $allowed_schemes = $config->get('URI.AllowedSchemes');
@@ -45,24 +52,30 @@ class HTMLPurifier_URISchemeRegistry
             return;
         }
 
-        if (isset($this->schemes[$scheme])) return $this->schemes[$scheme];
-        if (!isset($allowed_schemes[$scheme])) return;
+        if (isset($this->schemes[$scheme])) {
+            return $this->schemes[$scheme];
+        }
+        if (!isset($allowed_schemes[$scheme])) {
+            return;
+        }
 
         $class = 'HTMLPurifier_URIScheme_' . $scheme;
-        if (!class_exists($class)) return;
+        if (!class_exists($class)) {
+            return;
+        }
         $this->schemes[$scheme] = new $class();
         return $this->schemes[$scheme];
     }
 
     /**
      * Registers a custom scheme to the cache, bypassing reflection.
-     * @param $scheme Scheme name
-     * @param $scheme_obj HTMLPurifier_URIScheme object
+     * @param string $scheme Scheme name
+     * @param HTMLPurifier_URIScheme $scheme_obj
      */
-    public function register($scheme, $scheme_obj) {
+    public function register($scheme, $scheme_obj)
+    {
         $this->schemes[$scheme] = $scheme_obj;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/VarParser.php
+++ b/library/HTMLPurifier/VarParser.php
@@ -7,58 +7,59 @@
 class HTMLPurifier_VarParser
 {
 
-    const STRING    = 1;
-    const ISTRING   = 2;
-    const TEXT      = 3;
-    const ITEXT     = 4;
-    const INT       = 5;
-    const FLOAT     = 6;
-    const BOOL      = 7;
-    const LOOKUP    = 8;
-    const ALIST     = 9;
-    const HASH      = 10;
-    const MIXED     = 11;
+    const STRING = 1;
+    const ISTRING = 2;
+    const TEXT = 3;
+    const ITEXT = 4;
+    const INT = 5;
+    const FLOAT = 6;
+    const BOOL = 7;
+    const LOOKUP = 8;
+    const ALIST = 9;
+    const HASH = 10;
+    const MIXED = 11;
 
     /**
      * Lookup table of allowed types. Mainly for backwards compatibility, but
      * also convenient for transforming string type names to the integer constants.
      */
-    static public $types = array(
-        'string'    => self::STRING,
-        'istring'   => self::ISTRING,
-        'text'      => self::TEXT,
-        'itext'     => self::ITEXT,
-        'int'       => self::INT,
-        'float'     => self::FLOAT,
-        'bool'      => self::BOOL,
-        'lookup'    => self::LOOKUP,
-        'list'      => self::ALIST,
-        'hash'      => self::HASH,
-        'mixed'     => self::MIXED
+    public static $types = array(
+        'string' => self::STRING,
+        'istring' => self::ISTRING,
+        'text' => self::TEXT,
+        'itext' => self::ITEXT,
+        'int' => self::INT,
+        'float' => self::FLOAT,
+        'bool' => self::BOOL,
+        'lookup' => self::LOOKUP,
+        'list' => self::ALIST,
+        'hash' => self::HASH,
+        'mixed' => self::MIXED
     );
 
     /**
      * Lookup table of types that are string, and can have aliases or
      * allowed value lists.
      */
-    static public $stringTypes = array(
-        self::STRING    => true,
-        self::ISTRING   => true,
-        self::TEXT      => true,
-        self::ITEXT     => true,
+    public static $stringTypes = array(
+        self::STRING => true,
+        self::ISTRING => true,
+        self::TEXT => true,
+        self::ITEXT => true,
     );
 
     /**
-     * Validate a variable according to type. Throws
-     * HTMLPurifier_VarParserException if invalid.
+     * Validate a variable according to type.
      * It may return NULL as a valid type if $allow_null is true.
      *
-     * @param $var Variable to validate
-     * @param $type Type of variable, see HTMLPurifier_VarParser->types
-     * @param $allow_null Whether or not to permit null as a value
-     * @return Validated and type-coerced variable
+     * @param mixed $var Variable to validate
+     * @param int $type Type of variable, see HTMLPurifier_VarParser->types
+     * @param bool $allow_null Whether or not to permit null as a value
+     * @return string Validated and type-coerced variable
+     * @throws HTMLPurifier_VarParserException
      */
-    final public function parse($var, $type, $allow_null = false) {
+    final public function parse($var, $type, $allow_null = false)
+    {
         if (is_string($type)) {
             if (!isset(HTMLPurifier_VarParser::$types[$type])) {
                 throw new HTMLPurifier_VarParserException("Invalid type '$type'");
@@ -67,7 +68,9 @@ class HTMLPurifier_VarParser
             }
         }
         $var = $this->parseImplementation($var, $type, $allow_null);
-        if ($allow_null && $var === null) return null;
+        if ($allow_null && $var === null) {
+            return null;
+        }
         // These are basic checks, to make sure nothing horribly wrong
         // happened in our implementations.
         switch ($type) {
@@ -75,27 +78,45 @@ class HTMLPurifier_VarParser
             case (self::ISTRING):
             case (self::TEXT):
             case (self::ITEXT):
-                if (!is_string($var)) break;
-                if ($type == self::ISTRING || $type == self::ITEXT) $var = strtolower($var);
+                if (!is_string($var)) {
+                    break;
+                }
+                if ($type == self::ISTRING || $type == self::ITEXT) {
+                    $var = strtolower($var);
+                }
                 return $var;
             case (self::INT):
-                if (!is_int($var)) break;
+                if (!is_int($var)) {
+                    break;
+                }
                 return $var;
             case (self::FLOAT):
-                if (!is_float($var)) break;
+                if (!is_float($var)) {
+                    break;
+                }
                 return $var;
             case (self::BOOL):
-                if (!is_bool($var)) break;
+                if (!is_bool($var)) {
+                    break;
+                }
                 return $var;
             case (self::LOOKUP):
             case (self::ALIST):
             case (self::HASH):
-                if (!is_array($var)) break;
+                if (!is_array($var)) {
+                    break;
+                }
                 if ($type === self::LOOKUP) {
-                    foreach ($var as $k) if ($k !== true) $this->error('Lookup table contains value other than true');
+                    foreach ($var as $k) {
+                        if ($k !== true) {
+                            $this->error('Lookup table contains value other than true');
+                        }
+                    }
                 } elseif ($type === self::ALIST) {
                     $keys = array_keys($var);
-                    if (array_keys($keys) !== $keys) $this->error('Indices for list are not uniform');
+                    if (array_keys($keys) !== $keys) {
+                        $this->error('Indices for list are not uniform');
+                    }
                 }
                 return $var;
             case (self::MIXED):
@@ -107,17 +128,24 @@ class HTMLPurifier_VarParser
     }
 
     /**
-     * Actually implements the parsing. Base implementation is to not
+     * Actually implements the parsing. Base implementation does not
      * do anything to $var. Subclasses should overload this!
+     * @param mixed $var
+     * @param int $type
+     * @param bool $allow_null
+     * @return string
      */
-    protected function parseImplementation($var, $type, $allow_null) {
+    protected function parseImplementation($var, $type, $allow_null)
+    {
         return $var;
     }
 
     /**
      * Throws an exception.
+     * @throws HTMLPurifier_VarParserException
      */
-    protected function error($msg) {
+    protected function error($msg)
+    {
         throw new HTMLPurifier_VarParserException($msg);
     }
 
@@ -126,29 +154,45 @@ class HTMLPurifier_VarParser
      * @note This should not ever be called. It would be called if we
      *       extend the allowed values of HTMLPurifier_VarParser without
      *       updating subclasses.
+     * @param string $class
+     * @param int $type
+     * @throws HTMLPurifier_Exception
      */
-    protected function errorInconsistent($class, $type) {
-        throw new HTMLPurifier_Exception("Inconsistency in $class: ".HTMLPurifier_VarParser::getTypeName($type)." not implemented");
+    protected function errorInconsistent($class, $type)
+    {
+        throw new HTMLPurifier_Exception(
+            "Inconsistency in $class: " . HTMLPurifier_VarParser::getTypeName($type) .
+            " not implemented"
+        );
     }
 
     /**
      * Generic error for if a type didn't work.
+     * @param mixed $var
+     * @param int $type
      */
-    protected function errorGeneric($var, $type) {
+    protected function errorGeneric($var, $type)
+    {
         $vtype = gettype($var);
-        $this->error("Expected type ".HTMLPurifier_VarParser::getTypeName($type).", got $vtype");
+        $this->error("Expected type " . HTMLPurifier_VarParser::getTypeName($type) . ", got $vtype");
     }
 
-    static public function getTypeName($type) {
+    /**
+     * @param int $type
+     * @return string
+     */
+    public static function getTypeName($type)
+    {
         static $lookup;
         if (!$lookup) {
             // Lazy load the alternative lookup table
             $lookup = array_flip(HTMLPurifier_VarParser::$types);
         }
-        if (!isset($lookup[$type])) return 'unknown';
+        if (!isset($lookup[$type])) {
+            return 'unknown';
+        }
         return $lookup[$type];
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/VarParser/Flexible.php
+++ b/library/HTMLPurifier/VarParser/Flexible.php
@@ -7,28 +7,41 @@
  */
 class HTMLPurifier_VarParser_Flexible extends HTMLPurifier_VarParser
 {
-
-    protected function parseImplementation($var, $type, $allow_null) {
-        if ($allow_null && $var === null) return null;
+    /**
+     * @param mixed $var
+     * @param int $type
+     * @param bool $allow_null
+     * @return array|bool|float|int|mixed|null|string
+     * @throws HTMLPurifier_VarParserException
+     */
+    protected function parseImplementation($var, $type, $allow_null)
+    {
+        if ($allow_null && $var === null) {
+            return null;
+        }
         switch ($type) {
             // Note: if code "breaks" from the switch, it triggers a generic
             // exception to be thrown. Specific errors can be specifically
             // done here.
-            case self::MIXED :
-            case self::ISTRING :
-            case self::STRING :
-            case self::TEXT :
-            case self::ITEXT :
+            case self::MIXED:
+            case self::ISTRING:
+            case self::STRING:
+            case self::TEXT:
+            case self::ITEXT:
                 return $var;
-            case self::INT :
-                if (is_string($var) && ctype_digit($var)) $var = (int) $var;
+            case self::INT:
+                if (is_string($var) && ctype_digit($var)) {
+                    $var = (int)$var;
+                }
                 return $var;
-            case self::FLOAT :
-                if ((is_string($var) && is_numeric($var)) || is_int($var)) $var = (float) $var;
+            case self::FLOAT:
+                if ((is_string($var) && is_numeric($var)) || is_int($var)) {
+                    $var = (float)$var;
+                }
                 return $var;
-            case self::BOOL :
+            case self::BOOL:
                 if (is_int($var) && ($var === 0 || $var === 1)) {
-                    $var = (bool) $var;
+                    $var = (bool)$var;
                 } elseif (is_string($var)) {
                     if ($var == 'on' || $var == 'true' || $var == '1') {
                         $var = true;
@@ -39,45 +52,56 @@ class HTMLPurifier_VarParser_Flexible extends HTMLPurifier_VarParser
                     }
                 }
                 return $var;
-            case self::ALIST :
-            case self::HASH :
-            case self::LOOKUP :
+            case self::ALIST:
+            case self::HASH:
+            case self::LOOKUP:
                 if (is_string($var)) {
                     // special case: technically, this is an array with
                     // a single empty string item, but having an empty
                     // array is more intuitive
-                    if ($var == '') return array();
+                    if ($var == '') {
+                        return array();
+                    }
                     if (strpos($var, "\n") === false && strpos($var, "\r") === false) {
                         // simplistic string to array method that only works
                         // for simple lists of tag names or alphanumeric characters
-                        $var = explode(',',$var);
+                        $var = explode(',', $var);
                     } else {
                         $var = preg_split('/(,|[\n\r]+)/', $var);
                     }
                     // remove spaces
-                    foreach ($var as $i => $j) $var[$i] = trim($j);
+                    foreach ($var as $i => $j) {
+                        $var[$i] = trim($j);
+                    }
                     if ($type === self::HASH) {
                         // key:value,key2:value2
                         $nvar = array();
                         foreach ($var as $keypair) {
                             $c = explode(':', $keypair, 2);
-                            if (!isset($c[1])) continue;
+                            if (!isset($c[1])) {
+                                continue;
+                            }
                             $nvar[trim($c[0])] = trim($c[1]);
                         }
                         $var = $nvar;
                     }
                 }
-                if (!is_array($var)) break;
+                if (!is_array($var)) {
+                    break;
+                }
                 $keys = array_keys($var);
                 if ($keys === array_keys($keys)) {
-                    if ($type == self::ALIST) return $var;
-                    elseif ($type == self::LOOKUP) {
+                    if ($type == self::ALIST) {
+                        return $var;
+                    } elseif ($type == self::LOOKUP) {
                         $new = array();
                         foreach ($var as $key) {
                             $new[$key] = true;
                         }
                         return $new;
-                    } else break;
+                    } else {
+                        break;
+                    }
                 }
                 if ($type === self::ALIST) {
                     trigger_error("Array list did not have consecutive integer indexes", E_USER_WARNING);
@@ -86,7 +110,11 @@ class HTMLPurifier_VarParser_Flexible extends HTMLPurifier_VarParser
                 if ($type === self::LOOKUP) {
                     foreach ($var as $key => $value) {
                         if ($value !== true) {
-                            trigger_error("Lookup array has non-true value at key '$key'; maybe your input array was not indexed numerically", E_USER_WARNING);
+                            trigger_error(
+                                "Lookup array has non-true value at key '$key'; " .
+                                "maybe your input array was not indexed numerically",
+                                E_USER_WARNING
+                            );
                         }
                         $var[$key] = true;
                     }
@@ -97,7 +125,6 @@ class HTMLPurifier_VarParser_Flexible extends HTMLPurifier_VarParser
         }
         $this->errorGeneric($var, $type);
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/library/HTMLPurifier/VarParser/Native.php
+++ b/library/HTMLPurifier/VarParser/Native.php
@@ -8,11 +8,24 @@
 class HTMLPurifier_VarParser_Native extends HTMLPurifier_VarParser
 {
 
-    protected function parseImplementation($var, $type, $allow_null) {
+    /**
+     * @param mixed $var
+     * @param int $type
+     * @param bool $allow_null
+     * @return null|string
+     */
+    protected function parseImplementation($var, $type, $allow_null)
+    {
         return $this->evalExpression($var);
     }
 
-    protected function evalExpression($expr) {
+    /**
+     * @param string $expr
+     * @return mixed
+     * @throws HTMLPurifier_VarParserException
+     */
+    protected function evalExpression($expr)
+    {
         $var = null;
         $result = eval("\$var = $expr;");
         if ($result === false) {
@@ -20,7 +33,6 @@ class HTMLPurifier_VarParser_Native extends HTMLPurifier_VarParser
         }
         return $var;
     }
-
 }
 
 // vim: et sw=4 sts=4

--- a/maintenance/PH5P.php
+++ b/maintenance/PH5P.php
@@ -1,5 +1,6 @@
 <?php
-class HTML5 {
+class HTML5
+{
     private $data;
     private $char;
     private $EOF;
@@ -63,7 +64,8 @@ class HTML5 {
     const CHARACTR = 4;
     const EOF      = 5;
 
-    public function __construct($data) {
+    public function __construct($data)
+    {
         $data = str_replace("\r\n", "\n", $data);
         $date = str_replace("\r", null, $data);
 
@@ -80,17 +82,20 @@ class HTML5 {
         }
     }
 
-    public function save() {
+    public function save()
+    {
         return $this->tree->save();
     }
 
-    private function char() {
+    private function char()
+    {
         return ($this->char < $this->EOF)
             ? $this->data[$this->char]
             : false;
     }
 
-    private function character($s, $l = 0) {
+    private function character($s, $l = 0)
+    {
         if($s + $l < $this->EOF) {
             if($l === 0) {
                 return $this->data[$s];
@@ -100,11 +105,13 @@ class HTML5 {
         }
     }
 
-    private function characters($char_class, $start) {
+    private function characters($char_class, $start)
+    {
         return preg_replace('#^(['.$char_class.']+).*#s', '\\1', substr($this->data, $start));
     }
 
-    private function dataState() {
+    private function dataState()
+    {
         // Consume the next input character
         $this->char++;
         $char = $this->char();
@@ -204,7 +211,8 @@ class HTML5 {
         }
     }
 
-    private function entityDataState() {
+    private function entityDataState()
+    {
         // Attempt to consume an entity.
         $entity = $this->entity();
 
@@ -217,7 +225,8 @@ class HTML5 {
         $this->state = 'data';
     }
 
-    private function tagOpenState() {
+    private function tagOpenState()
+    {
         switch($this->content_model) {
             case self::RCDATA:
             case self::CDATA:
@@ -302,7 +311,8 @@ class HTML5 {
         }
     }
 
-    private function closeTagOpenState() {
+    private function closeTagOpenState()
+    {
         $next_node = strtolower($this->characters('A-Za-z', $this->char + 1));
         $the_same = count($this->tree->stack) > 0 && $next_node === end($this->tree->stack)->nodeName;
 
@@ -375,7 +385,8 @@ class HTML5 {
         }
     }
 
-    private function tagNameState() {
+    private function tagNameState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
@@ -419,7 +430,8 @@ class HTML5 {
         }
     }
 
-    private function beforeAttributeNameState() {
+    private function beforeAttributeNameState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
@@ -468,7 +480,8 @@ class HTML5 {
         }
     }
 
-    private function attributeNameState() {
+    private function attributeNameState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
@@ -519,7 +532,8 @@ class HTML5 {
         }
     }
 
-    private function afterAttributeNameState() {
+    private function afterAttributeNameState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
@@ -573,7 +587,8 @@ class HTML5 {
         }
     }
 
-    private function beforeAttributeValueState() {
+    private function beforeAttributeValueState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
@@ -621,7 +636,8 @@ class HTML5 {
         }
     }
 
-    private function attributeValueDoubleQuotedState() {
+    private function attributeValueDoubleQuotedState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
@@ -656,7 +672,8 @@ class HTML5 {
         }
     }
 
-    private function attributeValueSingleQuotedState() {
+    private function attributeValueSingleQuotedState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
@@ -691,7 +708,8 @@ class HTML5 {
         }
     }
 
-    private function attributeValueUnquotedState() {
+    private function attributeValueUnquotedState()
+    {
         // Consume the next input character:
         $this->char++;
         $char = $this->character($this->char);
@@ -727,7 +745,8 @@ class HTML5 {
         }
     }
 
-    private function entityInAttributeValueState() {
+    private function entityInAttributeValueState()
+    {
         // Attempt to consume an entity.
         $entity = $this->entity();
 
@@ -741,7 +760,8 @@ class HTML5 {
         $this->emitToken($char);
     }
 
-    private function bogusCommentState() {
+    private function bogusCommentState()
+    {
         /* Consume every character up to the first U+003E GREATER-THAN SIGN
         character (>) or the end of the file (EOF), whichever comes first. Emit
         a comment token whose data is the concatenation of all the characters
@@ -767,7 +787,8 @@ class HTML5 {
         }
     }
 
-    private function markupDeclarationOpenState() {
+    private function markupDeclarationOpenState()
+    {
         /* If the next two characters are both U+002D HYPHEN-MINUS (-)
         characters, consume those two characters, create a comment token whose
         data is the empty string, and switch to the comment state. */
@@ -795,7 +816,8 @@ class HTML5 {
         }
     }
 
-    private function commentState() {
+    private function commentState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
@@ -821,7 +843,8 @@ class HTML5 {
         }
     }
 
-    private function commentDashState() {
+    private function commentDashState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
@@ -848,7 +871,8 @@ class HTML5 {
         }
     }
 
-    private function commentEndState() {
+    private function commentEndState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
@@ -871,7 +895,8 @@ class HTML5 {
         }
     }
 
-    private function doctypeState() {
+    private function doctypeState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
@@ -885,7 +910,8 @@ class HTML5 {
         }
     }
 
-    private function beforeDoctypeNameState() {
+    private function beforeDoctypeNameState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
@@ -932,7 +958,8 @@ class HTML5 {
         }
     }
 
-    private function doctypeNameState() {
+    private function doctypeNameState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
@@ -961,7 +988,8 @@ class HTML5 {
             : true;
     }
 
-    private function afterDoctypeNameState() {
+    private function afterDoctypeNameState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
@@ -984,7 +1012,8 @@ class HTML5 {
         }
     }
 
-    private function bogusDoctypeState() {
+    private function bogusDoctypeState()
+    {
         /* Consume the next input character: */
         $this->char++;
         $char = $this->char();
@@ -1003,14 +1032,15 @@ class HTML5 {
         }
     }
 
-    private function entity() {
+    private function entity()
+    {
         $start = $this->char;
 
         // This section defines how to consume an entity. This definition is
         // used when parsing entities in text and in attributes.
 
         // The behaviour depends on the identity of the next character (the
-        // one immediately after the U+0026 AMPERSAND character): 
+        // one immediately after the U+0026 AMPERSAND character):
 
         switch($this->character($this->char + 1)) {
             // U+0023 NUMBER SIGN (#)
@@ -1088,7 +1118,8 @@ class HTML5 {
         return html_entity_decode('&'.$entity.';', ENT_QUOTES, 'UTF-8');
     }
 
-    private function emitToken($token) {
+    private function emitToken($token)
+    {
         $emit = $this->tree->emitToken($token);
 
         if(is_int($emit)) {
@@ -1099,7 +1130,8 @@ class HTML5 {
         }
     }
 
-    private function EOF() {
+    private function EOF()
+    {
         $this->state = null;
         $this->tree->emitToken(array(
             'type' => self::EOF
@@ -1107,7 +1139,8 @@ class HTML5 {
     }
 }
 
-class HTML5TreeConstructer {
+class HTML5TreeConstructer
+{
     public $stack = array();
 
     private $phase;
@@ -1159,7 +1192,8 @@ class HTML5TreeConstructer {
 
     const MARKER     = 0;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->phase = self::INIT_PHASE;
         $this->mode = self::BEFOR_HEAD;
         $this->dom = new DOMDocument;
@@ -1171,7 +1205,8 @@ class HTML5TreeConstructer {
     }
 
     // Process tag tokens
-    public function emitToken($token) {
+    public function emitToken($token)
+    {
         switch($this->phase) {
             case self::INIT_PHASE: return $this->initPhase($token); break;
             case self::ROOT_PHASE: return $this->rootElementPhase($token); break;
@@ -1180,7 +1215,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function initPhase($token) {
+    private function initPhase($token)
+    {
         /* Initially, the tree construction stage must handle each token
         emitted from the tokenisation stage as follows: */
 
@@ -1230,7 +1266,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function rootElementPhase($token) {
+    private function rootElementPhase($token)
+    {
         /* After the initial phase, as each token is emitted from the tokenisation
         stage, it must be processed as described in this section. */
 
@@ -1277,7 +1314,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function mainPhase($token) {
+    private function mainPhase($token)
+    {
         /* Tokens in the main phase must be handled as follows: */
 
         /* A DOCTYPE token */
@@ -1327,7 +1365,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function beforeHead($token) {
+    private function beforeHead($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
@@ -1381,7 +1420,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function inHead($token) {
+    private function inHead($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
@@ -1505,7 +1545,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function afterHead($token) {
+    private function afterHead($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
@@ -1561,7 +1602,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function inBody($token) {
+    private function inBody($token)
+    {
         /* Handle the token as follows: */
 
         switch($token['type']) {
@@ -2161,7 +2203,7 @@ class HTML5TreeConstructer {
                     if($this->elementInScope($token['name'])) {
                         $this->generateImpliedEndTags();
 
-                    } 
+                    }
 
                     if(end($this->stack)->nodeName !== $token['name']) {
                         /* Now, if the current node is not an element with the
@@ -2540,7 +2582,7 @@ class HTML5TreeConstructer {
                             for($x = count($this->stack) - $n; $x >= $n; $x--) {
                                 array_pop($this->stack);
                             }
-                                    
+
                         } else {
                             $category = $this->getElementCategory($node);
 
@@ -2559,7 +2601,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function inTable($token) {
+    private function inTable($token)
+    {
         $clear = array('html', 'table');
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
@@ -2736,7 +2779,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function inCaption($token) {
+    private function inCaption($token)
+    {
         /* An end tag whose tag name is "caption" */
         if($token['type'] === HTML5::ENDTAG && $token['name'] === 'caption') {
             /* If the stack of open elements does not have an element in table
@@ -2804,7 +2848,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function inColumnGroup($token) {
+    private function inColumnGroup($token)
+    {
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
         U+000A LINE FEED (LF), U+000B LINE TABULATION, U+000C FORM FEED (FF),
         or U+0020 SPACE */
@@ -2861,7 +2906,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function inTableBody($token) {
+    private function inTableBody($token)
+    {
         $clear = array('tbody', 'tfoot', 'thead', 'html');
 
         /* A start tag whose tag name is "tr" */
@@ -2947,7 +2993,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function inRow($token) {
+    private function inRow($token)
+    {
         $clear = array('tr', 'html');
 
         /* A start tag whose tag name is one of: "th", "td" */
@@ -3032,7 +3079,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function inCell($token) {
+    private function inCell($token)
+    {
         /* An end tag whose tag name is one of: "td", "th" */
         if($token['type'] === HTML5::ENDTAG &&
         ($token['name'] === 'td' || $token['name'] === 'th')) {
@@ -3139,7 +3187,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function inSelect($token) {
+    private function inSelect($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token */
@@ -3288,7 +3337,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function afterBody($token) {
+    private function afterBody($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
@@ -3327,7 +3377,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function inFrameset($token) {
+    private function inFrameset($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
@@ -3390,7 +3441,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function afterFrameset($token) {
+    private function afterFrameset($token)
+    {
         /* Handle the token as follows: */
 
         /* A character token that is one of one of U+0009 CHARACTER TABULATION,
@@ -3425,7 +3477,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function trailingEndPhase($token) {
+    private function trailingEndPhase($token)
+    {
         /* After the main phase, as each token is emitted from the tokenisation
         stage, it must be processed as described in this section. */
 
@@ -3465,7 +3518,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function insertElement($token, $append = true) {
+    private function insertElement($token, $append = true)
+    {
         $el = $this->dom->createElement($token['name']);
 
         foreach($token['attr'] as $attr) {
@@ -3480,17 +3534,20 @@ class HTML5TreeConstructer {
         return $el;
     }
 
-    private function insertText($data) {
+    private function insertText($data)
+    {
         $text = $this->dom->createTextNode($data);
         $this->appendToRealParent($text);
     }
 
-    private function insertComment($data) {
+    private function insertComment($data)
+    {
         $comment = $this->dom->createComment($data);
         $this->appendToRealParent($comment);
     }
 
-    private function appendToRealParent($node) {
+    private function appendToRealParent($node)
+    {
         if($this->foster_parent === null) {
             end($this->stack)->appendChild($node);
 
@@ -3518,7 +3575,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function elementInScope($el, $table = false) {
+    private function elementInScope($el, $table = false)
+    {
         if(is_array($el)) {
             foreach($el as $element) {
                 if($this->elementInScope($element, $table)) {
@@ -3567,7 +3625,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function reconstructActiveFormattingElements() {
+    private function reconstructActiveFormattingElements()
+    {
         /* 1. If there are no entries in the list of active formatting elements,
         then there is nothing to reconstruct; stop this algorithm. */
         $formatting_elements = count($this->a_formatting);
@@ -3638,7 +3697,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function clearTheActiveFormattingElementsUpToTheLastMarker() {
+    private function clearTheActiveFormattingElementsUpToTheLastMarker()
+    {
         /* When the steps below require the UA to clear the list of active
         formatting elements up to the last marker, the UA must perform the
         following steps: */
@@ -3659,7 +3719,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function generateImpliedEndTags(array $exclude = array()) {
+    private function generateImpliedEndTags(array $exclude = array())
+    {
         /* When the steps below require the UA to generate implied end tags,
         then, if the current node is a dd element, a dt element, an li element,
         a p element, a td element, a th  element, or a tr element, the UA must
@@ -3673,7 +3734,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function getElementCategory($name) {
+    private function getElementCategory($name)
+    {
         if(in_array($name, $this->special))
             return self::SPECIAL;
 
@@ -3687,7 +3749,8 @@ class HTML5TreeConstructer {
             return self::PHRASING;
     }
 
-    private function clearStackToTableContext($elements) {
+    private function clearStackToTableContext($elements)
+    {
         /* When the steps above require the UA to clear the stack back to a
         table context, it means that the UA must, while the current node is not
         a table element or an html element, pop elements from the stack of open
@@ -3704,7 +3767,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function resetInsertionMode() {
+    private function resetInsertionMode()
+    {
         /* 1. Let last be false. */
         $last = false;
         $leng = count($this->stack);
@@ -3802,7 +3866,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    private function closeCell() {
+    private function closeCell()
+    {
         /* If the stack of open elements has a td or th element in table scope,
         then act as if an end tag token with that tag name had been seen. */
         foreach(array('td', 'th') as $cell) {
@@ -3817,8 +3882,8 @@ class HTML5TreeConstructer {
         }
     }
 
-    public function save() {
+    public function save()
+    {
         return $this->dom;
     }
 }
-?>

--- a/maintenance/common.php
+++ b/maintenance/common.php
@@ -1,6 +1,7 @@
 <?php
 
-function assertCli() {
+function assertCli()
+{
     if (php_sapi_name() != 'cli' && !getenv('PHP_IS_CLI')) {
         echo 'Script cannot be called from web-browser (if you are indeed calling via cli,
 set environment variable PHP_IS_CLI to work around this).';
@@ -8,11 +9,13 @@ set environment variable PHP_IS_CLI to work around this).';
     }
 }
 
-function prefix_is($comp, $subject) {
+function prefix_is($comp, $subject)
+{
     return strncmp($comp, $subject, strlen($comp)) === 0;
 }
 
-function postfix_is($comp, $subject) {
+function postfix_is($comp, $subject)
+{
     return strlen($subject) < $comp ? false : substr($subject, -strlen($comp)) === $comp;
 }
 

--- a/maintenance/config-scanner.php
+++ b/maintenance/config-scanner.php
@@ -34,7 +34,8 @@ foreach ($raw_files as $file) {
 /**
  * Moves the $i cursor to the next non-whitespace token
  */
-function consumeWhitespace($tokens, &$i) {
+function consumeWhitespace($tokens, &$i)
+{
     do {$i++;} while (is_array($tokens[$i]) && $tokens[$i][0] === T_WHITESPACE);
 }
 
@@ -45,7 +46,8 @@ function consumeWhitespace($tokens, &$i) {
  *      - ($token, $expect_token, $expect_value): tests if token is $expect_token type, and
  *        its string representation is $expect_value
  */
-function testToken($token, $value_or_token, $value = null) {
+function testToken($token, $value_or_token, $value = null)
+{
     if (is_null($value)) {
         if (is_int($value_or_token)) return is_array($token) && $token[0] === $value_or_token;
         else return $token === $value_or_token;

--- a/maintenance/flush.php
+++ b/maintenance/flush.php
@@ -11,7 +11,8 @@ assertCli();
  * generated files are up-to-date.
  */
 
-function e($cmd) {
+function e($cmd)
+{
     echo "\$ $cmd\n";
     passthru($cmd, $status);
     echo "\n";

--- a/maintenance/generate-entity-file.php
+++ b/maintenance/generate-entity-file.php
@@ -21,10 +21,11 @@ $entity_dir = '../docs/entities/';
 $output_file = '../library/HTMLPurifier/EntityLookup/entities.ser';
 
 // courtesy of a PHP manual comment
-function unichr($dec) {
+function unichr($dec)
+{
     if ($dec < 128) {
         $utf  = chr($dec);
-    } else if ($dec < 2048) {
+    } elseif ($dec < 2048) {
         $utf  = chr(192 + (($dec - ($dec % 64)) / 64));
         $utf .= chr(128 + ($dec % 64));
     } else {

--- a/maintenance/generate-includes.php
+++ b/maintenance/generate-includes.php
@@ -61,12 +61,13 @@ echo "done!\n";
  *
  * @note This function expects that format $name extends $parent on one line
  *
- * @param $file
+ * @param string $file
  *      File to check dependencies of.
- * @return
+ * @return array
  *      Lookup array of files the file is dependent on, sorted accordingly.
  */
-function get_dependency_lookup($file) {
+function get_dependency_lookup($file)
+{
     static $cache = array();
     if (isset($cache[$file])) return $cache[$file];
     if (!file_exists($file)) {
@@ -108,7 +109,8 @@ function get_dependency_lookup($file) {
  * @return
  *      Sorted array ($files is not modified by reference!)
  */
-function dep_sort($files) {
+function dep_sort($files)
+{
     $ret = array();
     $cache = array();
     foreach ($files as $file) {

--- a/maintenance/generate-standalone.php
+++ b/maintenance/generate-standalone.php
@@ -24,14 +24,16 @@ $GLOBALS['loaded'] = array();
  */
 class MergeLibraryFSTools extends FSTools
 {
-    function copyable($entry) {
+    public function copyable($entry)
+    {
         // Skip hidden files
         if ($entry[0] == '.') {
             return false;
         }
         return true;
     }
-    function copy($source, $dest) {
+    public function copy($source, $dest)
+    {
         copy_and_remove_includes($source, $dest);
     }
 }
@@ -42,7 +44,8 @@ $FS = new MergeLibraryFSTools();
  * source.
  * @param string $text PHP source code to replace includes from
  */
-function replace_includes($text) {
+function replace_includes($text)
+{
     // also remove vim modelines
     return preg_replace_callback(
         "/require(?:_once)? ['\"]([^'\"]+)['\"];/",
@@ -57,7 +60,8 @@ function replace_includes($text) {
  * @note This is safe for files that have internal <?php
  * @param string $text Text to have leading PHP tag from
  */
-function remove_php_tags($text) {
+function remove_php_tags($text)
+{
     $text = preg_replace('#// vim:.+#', '', $text);
     return substr($text, 5);
 }
@@ -66,7 +70,8 @@ function remove_php_tags($text) {
  * Copies the contents of a directory to the standalone directory
  * @param string $dir Directory to copy
  */
-function make_dir_standalone($dir) {
+function make_dir_standalone($dir)
+{
     global $FS;
     return $FS->copyr($dir, 'standalone/' . $dir);
 }
@@ -75,7 +80,8 @@ function make_dir_standalone($dir) {
  * Copies the contents of a file to the standalone directory
  * @param string $file File to copy
  */
-function make_file_standalone($file) {
+function make_file_standalone($file)
+{
     global $FS;
     $FS->mkdirr('standalone/' . dirname($file));
     copy_and_remove_includes($file, 'standalone/' . $file);
@@ -88,7 +94,8 @@ function make_file_standalone($file) {
  * @param string $file Original file
  * @param string $sfile New location of file
  */
-function copy_and_remove_includes($file, $sfile) {
+function copy_and_remove_includes($file, $sfile)
+{
     $contents = file_get_contents($file);
     if (strrchr($file, '.') === '.php') $contents = replace_includes($contents);
     return file_put_contents($sfile, $contents);
@@ -98,7 +105,8 @@ function copy_and_remove_includes($file, $sfile) {
  * @param $matches preg_replace_callback matches array, where index 1
  *        is the filename to include
  */
-function replace_includes_callback($matches) {
+function replace_includes_callback($matches)
+{
     $file = $matches[1];
     $preserve = array(
       // PEAR (external)

--- a/maintenance/old-extract-schema.php
+++ b/maintenance/old-extract-schema.php
@@ -29,7 +29,8 @@ require_once 'HTMLPurifier/Filter/ExtractStyleBlocks.php';
 /**
  * Takes a hash and saves its contents to library/HTMLPurifier/ConfigSchema/
  */
-function saveHash($hash) {
+function saveHash($hash)
+{
     if ($hash === false) return;
     $dir = realpath(dirname(__FILE__) . '/../library/HTMLPurifier/ConfigSchema');
     $name = $hash['ID'] . '.txt';

--- a/maintenance/update-freshmeat.php
+++ b/maintenance/update-freshmeat.php
@@ -39,7 +39,8 @@ class XmlRpc_Freshmeat
      * @param $username Username to login with
      * @param $password Password to login with
      */
-    public function __construct($username = null, $password = null) {
+    public function __construct($username = null, $password = null)
+    {
         if ($username && $password) {
             $this->login($username, $password);
         }
@@ -48,7 +49,8 @@ class XmlRpc_Freshmeat
     /**
      * Performs a raw XML RPC call to self::URL
      */
-    protected function call($method, $params) {
+    protected function call($method, $params)
+    {
         $request = xmlrpc_encode_request($method, $params, $this->encodeOptions);
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, self::URL);
@@ -73,7 +75,8 @@ class XmlRpc_Freshmeat
      * @param $name Name of method to call, can be methodName or method_name
      * @param $args Arguments of call, in form array('key1', 'val1', 'key2' ...)
      */
-    public function __call($name, $args) {
+    public function __call($name, $args)
+    {
         $method = $this->camelToUnderscore($name);
         $params = array();
         if ($this->sid) $params['SID'] = $this->sid;
@@ -102,7 +105,8 @@ class XmlRpc_Freshmeat
     /**
      * Munge methodName to method_name
      */
-    private function camelToUnderscore($name) {
+    private function camelToUnderscore($name)
+    {
         $method = '';
         for ($i = 0, $c = strlen($name); $i < $c; $i++) {
             $v = $name[$i];
@@ -115,7 +119,8 @@ class XmlRpc_Freshmeat
     /**
      * Automatically logout at end of scope
      */
-    public function __destruct() {
+    public function __destruct()
+    {
         if ($this->sid) $this->logout();
     }
 

--- a/plugins/phorum/htmlpurifier.php
+++ b/plugins/phorum/htmlpurifier.php
@@ -126,7 +126,8 @@ function phorum_htmlpurifier_format($data)
 /**
  * Generates a signature based on a message array
  */
-function phorum_htmlpurifier_generate_sig($row) {
+function phorum_htmlpurifier_generate_sig($row)
+{
     $phorum_sig = '';
     if(isset($row["user"]["signature"])
        && isset($row['meta']['show_signature']) && $row['meta']['show_signature']==1){
@@ -141,7 +142,8 @@ function phorum_htmlpurifier_generate_sig($row) {
 /**
  * Generates an edit message based on a message array
  */
-function phorum_htmlpurifier_generate_editmessage($row) {
+function phorum_htmlpurifier_generate_editmessage($row)
+{
     $PHORUM = $GLOBALS['PHORUM'];
     $editmessage = '';
     if(isset($row['meta']['edit_count']) && $row['meta']['edit_count'] > 0) {
@@ -160,7 +162,8 @@ function phorum_htmlpurifier_generate_editmessage($row) {
  * Removes the signature and edit message from a message
  * @param $row Message passed by reference
  */
-function phorum_htmlpurifier_remove_sig_and_editmessage(&$row) {
+function phorum_htmlpurifier_remove_sig_and_editmessage(&$row)
+{
     $signature = phorum_htmlpurifier_generate_sig($row);
     $editmessage = phorum_htmlpurifier_generate_editmessage($row);
     $replacements = array();
@@ -178,7 +181,8 @@ function phorum_htmlpurifier_remove_sig_and_editmessage(&$row) {
  * @note This function could generate the actual cache entries, but
  *       since there's data missing that must be deferred to the first read
  */
-function phorum_htmlpurifier_posting($message) {
+function phorum_htmlpurifier_posting($message)
+{
     $PHORUM = $GLOBALS["PHORUM"];
     unset($message['meta']['body_cache']); // invalidate the cache
     $message['meta']['body_cache_serial'] = $PHORUM['mod_htmlpurifier']['body_cache_serial'];
@@ -188,7 +192,8 @@ function phorum_htmlpurifier_posting($message) {
 /**
  * Overload quoting mechanism to prevent default, mail-style quote from happening
  */
-function phorum_htmlpurifier_quote($array) {
+function phorum_htmlpurifier_quote($array)
+{
     $PHORUM = $GLOBALS["PHORUM"];
     $purifier =& HTMLPurifier::getInstance();
     $text = $purifier->purify($array[1]);
@@ -200,8 +205,8 @@ function phorum_htmlpurifier_quote($array) {
  * Ensure that our format hook is processed last. Also, loads the library.
  * @credits <http://secretsauce.phorum.org/snippets/make_bbcode_last_formatter.php.txt>
  */
-function phorum_htmlpurifier_common() {
-
+function phorum_htmlpurifier_common()
+{
     require_once(dirname(__FILE__).'/htmlpurifier/HTMLPurifier.auto.php');
     require(dirname(__FILE__).'/init-config.php');
 
@@ -232,7 +237,8 @@ function phorum_htmlpurifier_common() {
  * Pre-emptively performs purification if it looks like a WYSIWYG editor
  * is being used
  */
-function phorum_htmlpurifier_before_editor($message) {
+function phorum_htmlpurifier_before_editor($message)
+{
     if (!empty($GLOBALS['PHORUM']['mod_htmlpurifier']['wysiwyg'])) {
         if (!empty($message['body'])) {
             $body = $message['body'];
@@ -248,7 +254,8 @@ function phorum_htmlpurifier_before_editor($message) {
     return $message;
 }
 
-function phorum_htmlpurifier_editor_after_subject() {
+function phorum_htmlpurifier_editor_after_subject()
+{
     // don't show this message if it's a WYSIWYG editor, since it will
     // then be handled automatically
     if (!empty($GLOBALS['PHORUM']['mod_htmlpurifier']['wysiwyg'])) {

--- a/plugins/phorum/init-config.php
+++ b/plugins/phorum/init-config.php
@@ -5,7 +5,8 @@
  * or a module configuration value
  * @return Instance of HTMLPurifier_Config
  */
-function phorum_htmlpurifier_get_config($default = false) {
+function phorum_htmlpurifier_get_config($default = false)
+{
     global $PHORUM;
     $config_exists = phorum_htmlpurifier_config_file_exists();
     if ($default || $config_exists || !isset($PHORUM['mod_htmlpurifier']['config'])) {
@@ -21,7 +22,8 @@ function phorum_htmlpurifier_get_config($default = false) {
     return $config;
 }
 
-function phorum_htmlpurifier_config_file_exists() {
+function phorum_htmlpurifier_config_file_exists()
+{
     return file_exists(dirname(__FILE__) . '/config.php');
 }
 

--- a/plugins/phorum/migrate.bbcode.php
+++ b/plugins/phorum/migrate.bbcode.php
@@ -23,7 +23,8 @@ require_once(dirname(__FILE__) . "/../bbcode/bbcode.php");
  * 'format' hook style function that will be called to convert
  * legacy markup into HTML.
  */
-function phorum_htmlpurifier_migrate($data) {
+function phorum_htmlpurifier_migrate($data)
+{
     return phorum_mod_bbcode_format($data); // bbcode's 'format' hook
 }
 

--- a/plugins/phorum/settings/form.php
+++ b/plugins/phorum/settings/form.php
@@ -1,6 +1,7 @@
 <?php
 
-function phorum_htmlpurifier_show_form() {
+function phorum_htmlpurifier_show_form()
+{
     if (phorum_htmlpurifier_config_file_exists()) {
         phorum_htmlpurifier_show_config_info();
         return;
@@ -61,7 +62,8 @@ function phorum_htmlpurifier_show_form() {
     $frm->show();
 }
 
-function phorum_htmlpurifier_show_config_info() {
+function phorum_htmlpurifier_show_config_info()
+{
     global $PHORUM;
 
     // update mod_htmlpurifier for housekeeping

--- a/plugins/phorum/settings/migrate-sigs-form.php
+++ b/plugins/phorum/settings/migrate-sigs-form.php
@@ -1,7 +1,7 @@
 <?php
 
-function phorum_htmlpurifier_show_migrate_sigs_form() {
-
+function phorum_htmlpurifier_show_migrate_sigs_form()
+{
     $frm = new PhorumInputForm ('', "post", "Migrate");
     $frm->hidden("module", "modsettings");
     $frm->hidden("mod", "htmlpurifier");

--- a/plugins/phorum/settings/migrate-sigs.php
+++ b/plugins/phorum/settings/migrate-sigs.php
@@ -1,6 +1,7 @@
 <?php
 
-function phorum_htmlpurifier_migrate_sigs_check() {
+function phorum_htmlpurifier_migrate_sigs_check()
+{
     global $PHORUM;
     $offset = 0;
     if (!empty($_POST['migrate-sigs'])) {
@@ -17,7 +18,8 @@ function phorum_htmlpurifier_migrate_sigs_check() {
     return $offset;
 }
 
-function phorum_htmlpurifier_migrate_sigs($offset) {
+function phorum_htmlpurifier_migrate_sigs($offset)
+{
     global $PHORUM;
 
     if(!$offset) return; // bail out quick if $offset == 0

--- a/plugins/phorum/settings/save.php
+++ b/plugins/phorum/settings/save.php
@@ -1,6 +1,7 @@
 <?php
 
-function phorum_htmlpurifier_save_settings() {
+function phorum_htmlpurifier_save_settings()
+{
     global $PHORUM;
     if (phorum_htmlpurifier_config_file_exists()) {
         echo "Cannot update settings, <code>mods/htmlpurifier/config.php</code> already exists. To change
@@ -19,7 +20,8 @@ function phorum_htmlpurifier_save_settings() {
     }
 }
 
-function phorum_htmlpurifier_commit_settings() {
+function phorum_htmlpurifier_commit_settings()
+{
     global $PHORUM;
     return phorum_db_update_settings(array("mod_htmlpurifier"=>$PHORUM["mod_htmlpurifier"]));
 }

--- a/smoketests/cacheConfig.php
+++ b/smoketests/cacheConfig.php
@@ -12,4 +12,3 @@ $serial = $config->serialize();
 $result = unserialize($serial);
 $purifier = new HTMLPurifier($result);
 echo htmlspecialchars($purifier->purify('<b>Bold</b><br><i><a href="http://google.com">no</a> formatting</i>'));
-

--- a/smoketests/common.php
+++ b/smoketests/common.php
@@ -9,14 +9,16 @@ if (!isset($_GET['standalone'])) {
 }
 error_reporting(E_ALL);
 
-function escapeHTML($string) {
+function escapeHTML($string)
+{
     $string = HTMLPurifier_Encoder::cleanUTF8($string);
     $string = htmlspecialchars($string, ENT_COMPAT, 'UTF-8');
     return $string;
 }
 
 if (function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc()) {
-    function fix_magic_quotes(&$array) {
+    function fix_magic_quotes(&$array)
+    {
         foreach ($array as $k => $val) {
             if (!is_array($val)) {
                 $array[$k] = stripslashes($val);

--- a/smoketests/xssAttacks.php
+++ b/smoketests/xssAttacks.php
@@ -2,7 +2,8 @@
 
 require_once('common.php');
 
-function formatCode($string) {
+function formatCode($string)
+{
     return
         str_replace(
             array("\t", '»', '\0(null)'),

--- a/tests/CliTestCase.php
+++ b/tests/CliTestCase.php
@@ -15,19 +15,23 @@ class CliTestCase
      * @param $command Command to execute to retrieve XML
      * @param $xml Whether or not to suppress error messages
      */
-    public function __construct($command, $quiet = false, $size = false) {
+    public function __construct($command, $quiet = false, $size = false)
+    {
         $this->_command = $command;
         $this->_quiet   = $quiet;
         $this->_size    = $size;
     }
-    public function getLabel() {
+    public function getLabel()
+    {
         return $this->_command;
     }
-    public function run($reporter) {
+    public function run($reporter)
+    {
         if (!$this->_quiet) $reporter->paintFormattedMessage('Running ['.$this->_command.']');
         return $this->_invokeCommand($this->_command, $reporter);
     }
-    public function _invokeCommand($command, $reporter) {
+    public function _invokeCommand($command, $reporter)
+    {
        $xml = shell_exec($command);
         if (! $xml) {
             if (!$this->_quiet) {
@@ -59,11 +63,13 @@ class CliTestCase
         }
         return true;
     }
-    public function _createParser($reporter) {
+    public function _createParser($reporter)
+    {
         $parser = new SimpleTestXmlParser($reporter);
         return $parser;
     }
-    public function getSize() {
+    public function getSize()
+    {
         // This code properly does the dry run and allows for proper test
         // case reporting but it's REALLY slow, so I don't recommend it.
         if ($this->_size === false) {
@@ -73,7 +79,8 @@ class CliTestCase
         }
         return $this->_size;
     }
-    public function _errorHandler($a, $b, $c, $d) {
+    public function _errorHandler($a, $b, $c, $d)
+    {
         $this->_errors[] = array($a, $b, $c, $d); // see set_error_handler()
     }
 }

--- a/tests/Debugger.php
+++ b/tests/Debugger.php
@@ -21,35 +21,43 @@ TODO
 /**#@+
  * Convenience global functions. Corresponds to method on Debugger.
  */
-function paint($mixed) {
+function paint($mixed)
+{
     $Debugger =& Debugger::instance();
     return $Debugger->paint($mixed);
 }
-function paintIf($mixed, $conditional) {
+function paintIf($mixed, $conditional)
+{
     $Debugger =& Debugger::instance();
     return $Debugger->paintIf($mixed, $conditional);
 }
-function paintWhen($mixed, $scopes = array()) {
+function paintWhen($mixed, $scopes = array())
+{
     $Debugger =& Debugger::instance();
     return $Debugger->paintWhen($mixed, $scopes);
 }
-function paintIfWhen($mixed, $conditional, $scopes = array()) {
+function paintIfWhen($mixed, $conditional, $scopes = array())
+{
     $Debugger =& Debugger::instance();
     return $Debugger->paintIfWhen($mixed, $conditional, $scopes);
 }
-function addScope($id = false) {
+function addScope($id = false)
+{
     $Debugger =& Debugger::instance();
     return $Debugger->addScope($id);
 }
-function removeScope($id) {
+function removeScope($id)
+{
     $Debugger =& Debugger::instance();
     return $Debugger->removeScope($id);
 }
-function resetScopes() {
+function resetScopes()
+{
     $Debugger =& Debugger::instance();
     return $Debugger->resetScopes();
 }
-function isInScopes($array = array()) {
+function isInScopes($array = array())
+{
     $Debugger =& Debugger::instance();
     return $Debugger->isInScopes($array);
 }
@@ -68,7 +76,8 @@ class Debugger
     public $scope_nextID = 1;
     public $add_pre = true;
 
-    public function Debugger() {
+    public function Debugger()
+    {
         $this->add_pre = !extension_loaded('xdebug');
     }
 
@@ -78,46 +87,54 @@ class Debugger
         return $soleInstance;
     }
 
-    public function paintIf($mixed, $conditional)  {
+    public function paintIf($mixed, $conditional)
+    {
         if (!$conditional) return;
         $this->paint($mixed);
     }
 
-    public function paintWhen($mixed, $scopes = array()) {
+    public function paintWhen($mixed, $scopes = array())
+    {
         if (!$this->isInScopes($scopes)) return;
         $this->paint($mixed);
     }
 
-    public function paintIfWhen($mixed, $conditional, $scopes = array()) {
+    public function paintIfWhen($mixed, $conditional, $scopes = array())
+    {
         if (!$conditional) return;
         if (!$this->isInScopes($scopes)) return;
         $this->paint($mixed);
     }
 
-    public function paint($mixed) {
+    public function paint($mixed)
+    {
         $this->paints++;
         if($this->add_pre) echo '<pre>';
         var_dump($mixed);
         if($this->add_pre) echo '</pre>';
     }
 
-    public function addScope($id = false) {
+    public function addScope($id = false)
+    {
         if ($id == false) {
             $id = $this->scope_nextID++;
         }
         $this->current_scopes[$id] = true;
     }
 
-    public function removeScope($id) {
+    public function removeScope($id)
+    {
         if (isset($this->current_scopes[$id])) unset($this->current_scopes[$id]);
     }
 
-    public function resetScopes() {
+    public function resetScopes()
+    {
         $this->current_scopes = array();
         $this->scope_nextID = 1;
     }
 
-    public function isInScopes($scopes = array()) {
+    public function isInScopes($scopes = array())
+    {
         if (empty($this->current_scopes)) {
             return false;
         }

--- a/tests/FSTools/FileSystemHarness.php
+++ b/tests/FSTools/FileSystemHarness.php
@@ -11,7 +11,8 @@ class FSTools_FileSystemHarness extends UnitTestCase
 
     protected $dir, $oldDir;
 
-    function __construct() {
+    public function __construct()
+    {
         parent::__construct();
         $this->dir = 'tmp/' . md5(uniqid(rand(), true)) . '/';
         mkdir($this->dir);
@@ -19,15 +20,18 @@ class FSTools_FileSystemHarness extends UnitTestCase
 
     }
 
-    function __destruct() {
+    public function __destruct()
+    {
         FSTools::singleton()->rmdirr($this->dir);
     }
 
-    function setup() {
+    public function setup()
+    {
         chdir($this->dir);
     }
 
-    function tearDown() {
+    public function tearDown()
+    {
         chdir($this->oldDir);
     }
 

--- a/tests/FSTools/FileTest.php
+++ b/tests/FSTools/FileTest.php
@@ -8,7 +8,8 @@ require_once 'FSTools/FileSystemHarness.php';
 class FSTools_FileTest extends FSTools_FileSystemHarness
 {
 
-    function test() {
+    public function test()
+    {
         $name = 'test.txt';
         $file = new FSTools_File($name);
         $this->assertFalse($file->exists());
@@ -19,14 +20,16 @@ class FSTools_FileTest extends FSTools_FileSystemHarness
         $this->assertFalse($file->exists());
     }
 
-    function testGetNonExistent() {
+    public function testGetNonExistent()
+    {
         $name = 'notfound.txt';
         $file = new FSTools_File($name);
         $this->expectError();
         $this->assertFalse($file->get());
     }
 
-    function testHandle() {
+    public function testHandle()
+    {
         $file = new FSTools_File('foo.txt');
         $this->assertFalse($file->exists());
         $file->open('w');

--- a/tests/HTMLPurifier/AttrCollectionsTest.php
+++ b/tests/HTMLPurifier/AttrCollectionsTest.php
@@ -9,8 +9,8 @@ Mock::generatePartial(
 class HTMLPurifier_AttrCollectionsTest extends HTMLPurifier_Harness
 {
 
-    function testConstruction() {
-
+    public function testConstruction()
+    {
         generate_mock_once('HTMLPurifier_AttrTypes');
 
         $collections = new HTMLPurifier_AttrCollections_TestForConstruct();
@@ -61,8 +61,8 @@ class HTMLPurifier_AttrCollectionsTest extends HTMLPurifier_Harness
 
     }
 
-    function test_performInclusions() {
-
+    public function test_performInclusions()
+    {
         generate_mock_once('HTMLPurifier_AttrTypes');
 
         $types = new HTMLPurifier_AttrTypesMock();
@@ -99,8 +99,8 @@ class HTMLPurifier_AttrCollectionsTest extends HTMLPurifier_Harness
 
     }
 
-    function test_expandIdentifiers() {
-
+    public function test_expandIdentifiers()
+    {
         generate_mock_once('HTMLPurifier_AttrTypes');
 
         $types = new HTMLPurifier_AttrTypesMock();

--- a/tests/HTMLPurifier/AttrDef/CSS/AlphaValueTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/AlphaValueTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_AlphaValueTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_AlphaValue();
 
         $this->assertDef('0');

--- a/tests/HTMLPurifier/AttrDef/CSS/BackgroundPositionTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/BackgroundPositionTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_BackgroundPositionTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_BackgroundPosition();
 
         // explicitly cited in spec

--- a/tests/HTMLPurifier/AttrDef/CSS/BackgroundTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/BackgroundTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_BackgroundTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $this->def = new HTMLPurifier_AttrDef_CSS_Background($config);
 

--- a/tests/HTMLPurifier/AttrDef/CSS/BorderTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/BorderTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_BorderTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $this->def = new HTMLPurifier_AttrDef_CSS_Border($config);
 

--- a/tests/HTMLPurifier/AttrDef/CSS/ColorTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/ColorTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_ColorTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_Color();
 
         $this->assertDef('#F00');

--- a/tests/HTMLPurifier/AttrDef/CSS/CompositeTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/CompositeTest.php
@@ -5,7 +5,8 @@ class HTMLPurifier_AttrDef_CSS_Composite_Testable extends
 {
 
     // we need to pass by ref to get the mocks in
-    function HTMLPurifier_AttrDef_CSS_Composite_Testable(&$defs) {
+    public function HTMLPurifier_AttrDef_CSS_Composite_Testable(&$defs)
+    {
         $this->defs =& $defs;
     }
 
@@ -16,8 +17,8 @@ class HTMLPurifier_AttrDef_CSS_CompositeTest extends HTMLPurifier_AttrDefHarness
 
     protected $def1, $def2;
 
-    function test() {
-
+    public function test()
+    {
         generate_mock_once('HTMLPurifier_AttrDef');
 
         $config = HTMLPurifier_Config::createDefault();

--- a/tests/HTMLPurifier/AttrDef/CSS/FilterTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/FilterTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_FilterTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_Filter();
 
         $this->assertDef('none');

--- a/tests/HTMLPurifier/AttrDef/CSS/FontFamilyTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/FontFamilyTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_FontFamilyTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_FontFamily();
 
         $this->assertDef('Gill, Helvetica, sans-serif');
@@ -36,7 +36,8 @@ class HTMLPurifier_AttrDef_CSS_FontFamilyTest extends HTMLPurifier_AttrDefHarnes
         //$this->assertDef('"\'"', "\"'\"");
     }
 
-    function testAllowed() {
+    public function testAllowed()
+    {
         $this->config->set('CSS.AllowedFonts', array('serif', 'Times New Roman'));
 
         $this->assertDef('serif');

--- a/tests/HTMLPurifier/AttrDef/CSS/FontTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/FontTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_FontTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $this->def = new HTMLPurifier_AttrDef_CSS_Font($config);
 

--- a/tests/HTMLPurifier/AttrDef/CSS/ImportantDecoratorTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/ImportantDecoratorTest.php
@@ -6,39 +6,46 @@ class HTMLPurifier_AttrDef_CSS_ImportantDecoratorTest extends HTMLPurifier_AttrD
     /** Mock AttrDef decorator is wrapping */
     protected $mock;
 
-    function setUp() {
+    public function setUp()
+    {
         generate_mock_once('HTMLPurifier_AttrDef');
         $this->mock = new HTMLPurifier_AttrDefMock();
         $this->def  = new HTMLPurifier_AttrDef_CSS_ImportantDecorator($this->mock, true);
     }
 
-    protected function setMock($input, $output = null) {
+    protected function setMock($input, $output = null)
+    {
         if ($output === null) $output = $input;
         $this->mock->expectOnce('validate', array($input, $this->config, $this->context));
         $this->mock->setReturnValue('validate', $output);
     }
 
-    function testImportant() {
+    public function testImportant()
+    {
         $this->setMock('23');
         $this->assertDef('23 !important');
     }
 
-    function testImportantInternalDefChanged() {
+    public function testImportantInternalDefChanged()
+    {
         $this->setMock('23', '24');
         $this->assertDef('23 !important', '24 !important');
     }
 
-    function testImportantWithSpace() {
+    public function testImportantWithSpace()
+    {
         $this->setMock('23');
         $this->assertDef('23 !  important  ', '23 !important');
     }
 
-    function testFakeImportant() {
+    public function testFakeImportant()
+    {
         $this->setMock('! foo important');
         $this->assertDef('! foo important');
     }
 
-    function testStrip() {
+    public function testStrip()
+    {
         $this->def  = new HTMLPurifier_AttrDef_CSS_ImportantDecorator($this->mock, false);
         $this->setMock('23');
         $this->assertDef('23 !  important  ', '23');

--- a/tests/HTMLPurifier/AttrDef/CSS/LengthTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/LengthTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_LengthTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_Length();
 
         $this->assertDef('0');
@@ -26,8 +26,8 @@ class HTMLPurifier_AttrDef_CSS_LengthTest extends HTMLPurifier_AttrDefHarness
 
     }
 
-    function testNonNegative() {
-
+    public function testNonNegative()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_Length('0');
 
         $this->assertDef('3cm');
@@ -35,7 +35,8 @@ class HTMLPurifier_AttrDef_CSS_LengthTest extends HTMLPurifier_AttrDefHarness
 
     }
 
-    function testBounding() {
+    public function testBounding()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_Length('-1in', '1in');
         $this->assertDef('1cm');
         $this->assertDef('-1cm');

--- a/tests/HTMLPurifier/AttrDef/CSS/ListStyleTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/ListStyleTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_ListStyleTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $this->def = new HTMLPurifier_AttrDef_CSS_ListStyle($config);
 

--- a/tests/HTMLPurifier/AttrDef/CSS/MultipleTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/MultipleTest.php
@@ -4,7 +4,8 @@
 class HTMLPurifier_AttrDef_CSS_MultipleTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_Multiple(
             new HTMLPurifier_AttrDef_Integer()
         );

--- a/tests/HTMLPurifier/AttrDef/CSS/NumberTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/NumberTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_NumberTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_Number();
 
         $this->assertDef('0');
@@ -38,8 +38,8 @@ class HTMLPurifier_AttrDef_CSS_NumberTest extends HTMLPurifier_AttrDefHarness
 
     }
 
-    function testNonNegative() {
-
+    public function testNonNegative()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_Number(true);
         $this->assertDef('23');
         $this->assertDef('-12', false);

--- a/tests/HTMLPurifier/AttrDef/CSS/PercentageTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/PercentageTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_PercentageTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_Percentage();
 
         $this->assertDef('10%');

--- a/tests/HTMLPurifier/AttrDef/CSS/TextDecorationTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/TextDecorationTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_TextDecorationTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function testCaseInsensitive() {
-
+    public function testCaseInsensitive()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_TextDecoration();
 
         $this->assertDef('none');

--- a/tests/HTMLPurifier/AttrDef/CSS/URITest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/URITest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_CSS_URITest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_CSS_URI();
 
         $this->assertDef('', false);

--- a/tests/HTMLPurifier/AttrDef/CSSTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSSTest.php
@@ -3,13 +3,14 @@
 class HTMLPurifier_AttrDef_CSSTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function setup() {
+    public function setup()
+    {
         parent::setup();
         $this->def = new HTMLPurifier_AttrDef_CSS();
     }
 
-    function test() {
-
+    public function test()
+    {
         // regular cases, singular
         $this->assertDef('text-align:right;');
         $this->assertDef('border-left-style:solid;');
@@ -115,7 +116,8 @@ class HTMLPurifier_AttrDef_CSSTest extends HTMLPurifier_AttrDefHarness
 
     }
 
-    function testProprietary() {
+    public function testProprietary()
+    {
         $this->config->set('CSS.Proprietary', true);
 
         $this->assertDef('scrollbar-arrow-color:#ff0;');
@@ -132,25 +134,29 @@ class HTMLPurifier_AttrDef_CSSTest extends HTMLPurifier_AttrDefHarness
 
     }
 
-    function testImportant() {
+    public function testImportant()
+    {
         $this->config->set('CSS.AllowImportant', true);
         $this->assertDef('float:left !important;');
     }
 
-    function testTricky() {
+    public function testTricky()
+    {
         $this->config->set('CSS.AllowTricky', true);
         $this->assertDef('display:none;');
         $this->assertDef('visibility:visible;');
         $this->assertDef('overflow:scroll;');
     }
 
-    function testForbidden() {
+    public function testForbidden()
+    {
         $this->config->set('CSS.ForbiddenProperties', 'float');
         $this->assertDef('float:left;', false);
         $this->assertDef('text-align:right;');
     }
 
-    function testTrusted() {
+    public function testTrusted()
+    {
         $this->config->set('CSS.Trusted', true);
         $this->assertDef('position:relative;');
         $this->assertDef('left:2px;');

--- a/tests/HTMLPurifier/AttrDef/EnumTest.php
+++ b/tests/HTMLPurifier/AttrDef/EnumTest.php
@@ -3,24 +3,28 @@
 class HTMLPurifier_AttrDef_EnumTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function testCaseInsensitive() {
+    public function testCaseInsensitive()
+    {
         $this->def = new HTMLPurifier_AttrDef_Enum(array('one', 'two'));
         $this->assertDef('one');
         $this->assertDef('ONE', 'one');
     }
 
-    function testCaseSensitive() {
+    public function testCaseSensitive()
+    {
         $this->def = new HTMLPurifier_AttrDef_Enum(array('one', 'two'), true);
         $this->assertDef('one');
         $this->assertDef('ONE', false);
     }
 
-    function testFixing() {
+    public function testFixing()
+    {
         $this->def = new HTMLPurifier_AttrDef_Enum(array('one'));
         $this->assertDef(' one ', 'one');
     }
 
-    function test_make() {
+    public function test_make()
+    {
         $factory = new HTMLPurifier_AttrDef_Enum();
 
         $def = $factory->make('foo,bar');

--- a/tests/HTMLPurifier/AttrDef/HTML/BoolTest.php
+++ b/tests/HTMLPurifier/AttrDef/HTML/BoolTest.php
@@ -3,14 +3,16 @@
 class HTMLPurifier_AttrDef_HTML_BoolTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_HTML_Bool('foo');
         $this->assertDef('foo');
         $this->assertDef('', false);
         $this->assertDef('bar', 'foo');
     }
 
-    function test_make() {
+    public function test_make()
+    {
         $factory = new HTMLPurifier_AttrDef_HTML_Bool();
         $def = $factory->make('foo');
         $def2 = new HTMLPurifier_AttrDef_HTML_Bool('foo');

--- a/tests/HTMLPurifier/AttrDef/HTML/ClassTest.php
+++ b/tests/HTMLPurifier/AttrDef/HTML/ClassTest.php
@@ -2,23 +2,27 @@
 
 class HTMLPurifier_AttrDef_HTML_ClassTest extends HTMLPurifier_AttrDef_HTML_NmtokensTest
 {
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->def = new HTMLPurifier_AttrDef_HTML_Class();
     }
-    function testAllowedClasses() {
+    public function testAllowedClasses()
+    {
         $this->config->set('Attr.AllowedClasses', array('foo'));
         $this->assertDef('foo');
         $this->assertDef('bar', false);
         $this->assertDef('foo bar', 'foo');
     }
-    function testForbiddenClasses() {
+    public function testForbiddenClasses()
+    {
         $this->config->set('Attr.ForbiddenClasses', array('bar'));
         $this->assertDef('foo');
         $this->assertDef('bar', false);
         $this->assertDef('foo bar', 'foo');
     }
-    function testDefault() {
+    public function testDefault()
+    {
         $this->assertDef('valid');
         $this->assertDef('a0-_');
         $this->assertDef('-valid');
@@ -40,7 +44,8 @@ class HTMLPurifier_AttrDef_HTML_ClassTest extends HTMLPurifier_AttrDef_HTML_Nmto
         // test duplicate removal
         $this->assertDef('valid valid', 'valid');
     }
-    function testXHTML11Behavior() {
+    public function testXHTML11Behavior()
+    {
         $this->config->set('HTML.Doctype', 'XHTML 1.1');
         $this->assertDef('0invalid', false);
         $this->assertDef('valid valid', 'valid');

--- a/tests/HTMLPurifier/AttrDef/HTML/ColorTest.php
+++ b/tests/HTMLPurifier/AttrDef/HTML/ColorTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_AttrDef_HTML_ColorTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_HTML_Color();
         $this->assertDef('', false);
         $this->assertDef('foo', false);

--- a/tests/HTMLPurifier/AttrDef/HTML/FrameTargetTest.php
+++ b/tests/HTMLPurifier/AttrDef/HTML/FrameTargetTest.php
@@ -3,19 +3,22 @@
 class HTMLPurifier_AttrDef_HTML_FrameTargetTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function setup() {
+    public function setup()
+    {
         parent::setup();
         $this->def = new HTMLPurifier_AttrDef_HTML_FrameTarget();
     }
 
-    function testNoneAllowed() {
+    public function testNoneAllowed()
+    {
         $this->assertDef('', false);
         $this->assertDef('foo', false);
         $this->assertDef('_blank', false);
         $this->assertDef('baz', false);
     }
 
-    function test() {
+    public function test()
+    {
         $this->config->set('Attr.AllowedFrameTargets', 'foo,_blank');
         $this->assertDef('', false);
         $this->assertDef('foo');

--- a/tests/HTMLPurifier/AttrDef/HTML/IDTest.php
+++ b/tests/HTMLPurifier/AttrDef/HTML/IDTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_AttrDef_HTML_IDTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
 
         $id_accumulator = new HTMLPurifier_IDAccumulator();
@@ -13,8 +14,8 @@ class HTMLPurifier_AttrDef_HTML_IDTest extends HTMLPurifier_AttrDefHarness
 
     }
 
-    function test() {
-
+    public function test()
+    {
         // valid ID names
         $this->assertDef('alpha');
         $this->assertDef('al_ha');
@@ -35,8 +36,8 @@ class HTMLPurifier_AttrDef_HTML_IDTest extends HTMLPurifier_AttrDefHarness
 
     }
 
-    function testPrefix() {
-
+    public function testPrefix()
+    {
         $this->config->set('Attr.IDPrefix', 'user_');
 
         $this->assertDef('alpha', 'user_alpha');
@@ -50,8 +51,8 @@ class HTMLPurifier_AttrDef_HTML_IDTest extends HTMLPurifier_AttrDefHarness
 
     }
 
-    function testTwoPrefixes() {
-
+    public function testTwoPrefixes()
+    {
         $this->config->set('Attr.IDPrefix', 'user_');
         $this->config->set('Attr.IDPrefixLocal', 'story95_');
 
@@ -64,7 +65,8 @@ class HTMLPurifier_AttrDef_HTML_IDTest extends HTMLPurifier_AttrDefHarness
         $this->assertDef('user_alas', 'user_story95_user_alas'); // !
     }
 
-    function testLocalPrefixWithoutMainPrefix() {
+    public function testLocalPrefixWithoutMainPrefix()
+    {
         // no effect when IDPrefix isn't set
         $this->config->set('Attr.IDPrefix', '');
         $this->config->set('Attr.IDPrefixLocal', 'story95_');
@@ -75,8 +77,8 @@ class HTMLPurifier_AttrDef_HTML_IDTest extends HTMLPurifier_AttrDefHarness
     }
 
     // reference functionality is disabled for now
-    function disabled_testIDReference() {
-
+    public function disabled_testIDReference()
+    {
         $this->def = new HTMLPurifier_AttrDef_HTML_ID(true);
 
         $this->assertDef('good_id');
@@ -94,8 +96,8 @@ class HTMLPurifier_AttrDef_HTML_IDTest extends HTMLPurifier_AttrDefHarness
 
     }
 
-    function testRegexp() {
-
+    public function testRegexp()
+    {
         $this->config->set('Attr.IDBlacklistRegexp', '/^g_/');
 
         $this->assertDef('good_id');

--- a/tests/HTMLPurifier/AttrDef/HTML/LengthTest.php
+++ b/tests/HTMLPurifier/AttrDef/HTML/LengthTest.php
@@ -3,12 +3,13 @@
 class HTMLPurifier_AttrDef_HTML_LengthTest extends HTMLPurifier_AttrDef_HTML_PixelsTest
 {
 
-    function setup() {
+    public function setup()
+    {
         $this->def = new HTMLPurifier_AttrDef_HTML_Length();
     }
 
-    function test() {
-
+    public function test()
+    {
         // pixel check
         parent::test();
 

--- a/tests/HTMLPurifier/AttrDef/HTML/LinkTypesTest.php
+++ b/tests/HTMLPurifier/AttrDef/HTML/LinkTypesTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_HTML_LinkTypesTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function testNull() {
-
+    public function testNull()
+    {
         $this->def = new HTMLPurifier_AttrDef_HTML_LinkTypes('rel');
         $this->config->set('Attr.AllowedRel', array('nofollow', 'foo'));
 

--- a/tests/HTMLPurifier/AttrDef/HTML/MultiLengthTest.php
+++ b/tests/HTMLPurifier/AttrDef/HTML/MultiLengthTest.php
@@ -3,12 +3,13 @@
 class HTMLPurifier_AttrDef_HTML_MultiLengthTest extends HTMLPurifier_AttrDef_HTML_LengthTest
 {
 
-    function setup() {
+    public function setup()
+    {
         $this->def = new HTMLPurifier_AttrDef_HTML_MultiLength();
     }
 
-    function test() {
-
+    public function test()
+    {
         // length check
         parent::test();
 

--- a/tests/HTMLPurifier/AttrDef/HTML/NmtokensTest.php
+++ b/tests/HTMLPurifier/AttrDef/HTML/NmtokensTest.php
@@ -3,13 +3,14 @@
 class HTMLPurifier_AttrDef_HTML_NmtokensTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->def = new HTMLPurifier_AttrDef_HTML_Nmtokens();
     }
 
-    function testDefault() {
-
+    public function testDefault()
+    {
         $this->assertDef('valid');
         $this->assertDef('a0-_');
         $this->assertDef('-valid');

--- a/tests/HTMLPurifier/AttrDef/HTML/PixelsTest.php
+++ b/tests/HTMLPurifier/AttrDef/HTML/PixelsTest.php
@@ -3,12 +3,13 @@
 class HTMLPurifier_AttrDef_HTML_PixelsTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function setup() {
+    public function setup()
+    {
         $this->def = new HTMLPurifier_AttrDef_HTML_Pixels();
     }
 
-    function test() {
-
+    public function test()
+    {
         $this->assertDef('1');
         $this->assertDef('0');
 
@@ -33,7 +34,8 @@ class HTMLPurifier_AttrDef_HTML_PixelsTest extends HTMLPurifier_AttrDefHarness
 
     }
 
-    function test_make() {
+    public function test_make()
+    {
         $factory = new HTMLPurifier_AttrDef_HTML_Pixels();
         $this->def = $factory->make('30');
         $this->assertDef('25');

--- a/tests/HTMLPurifier/AttrDef/IntegerTest.php
+++ b/tests/HTMLPurifier/AttrDef/IntegerTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_IntegerTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_Integer();
 
         $this->assertDef('0');
@@ -23,7 +23,8 @@ class HTMLPurifier_AttrDef_IntegerTest extends HTMLPurifier_AttrDefHarness
 
     }
 
-    function assertRange($negative, $zero, $positive) {
+    public function assertRange($negative, $zero, $positive)
+    {
         $this->assertDef('-100', $negative);
         $this->assertDef('-1', $negative);
         $this->assertDef('0', $zero);
@@ -31,8 +32,8 @@ class HTMLPurifier_AttrDef_IntegerTest extends HTMLPurifier_AttrDefHarness
         $this->assertDef('42', $positive);
     }
 
-    function testRange() {
-
+    public function testRange()
+    {
         $this->def = new HTMLPurifier_AttrDef_Integer(false);
         $this->assertRange(false, true, true); // non-negative
 

--- a/tests/HTMLPurifier/AttrDef/LangTest.php
+++ b/tests/HTMLPurifier/AttrDef/LangTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_LangTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_Lang();
 
         // basic good uses

--- a/tests/HTMLPurifier/AttrDef/SwitchTest.php
+++ b/tests/HTMLPurifier/AttrDef/SwitchTest.php
@@ -5,7 +5,8 @@ class HTMLPurifier_AttrDef_SwitchTest extends HTMLPurifier_AttrDefHarness
 
     protected $with, $without;
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         generate_mock_once('HTMLPurifier_AttrDef');
         $this->with = new HTMLPurifier_AttrDefMock();
@@ -13,7 +14,8 @@ class HTMLPurifier_AttrDef_SwitchTest extends HTMLPurifier_AttrDefHarness
         $this->def = new HTMLPurifier_AttrDef_Switch('tag', $this->with, $this->without);
     }
 
-    function testWith() {
+    public function testWith()
+    {
         $token = new HTMLPurifier_Token_Start('tag');
         $this->context->register('CurrentToken', $token);
         $this->with->expectOnce('validate');
@@ -21,7 +23,8 @@ class HTMLPurifier_AttrDef_SwitchTest extends HTMLPurifier_AttrDefHarness
         $this->assertDef('bar', 'foo');
     }
 
-    function testWithout() {
+    public function testWithout()
+    {
         $token = new HTMLPurifier_Token_Start('other-tag');
         $this->context->register('CurrentToken', $token);
         $this->without->expectOnce('validate');

--- a/tests/HTMLPurifier/AttrDef/TextTest.php
+++ b/tests/HTMLPurifier/AttrDef/TextTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_AttrDef_TextTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_Text();
 
         $this->assertDef('This is spiffy text!');

--- a/tests/HTMLPurifier/AttrDef/URI/Email/SimpleCheckTest.php
+++ b/tests/HTMLPurifier/AttrDef/URI/Email/SimpleCheckTest.php
@@ -4,7 +4,8 @@ class HTMLPurifier_AttrDef_URI_Email_SimpleCheckTest
     extends HTMLPurifier_AttrDef_URI_EmailHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         $this->def = new HTMLPurifier_AttrDef_URI_Email_SimpleCheck();
     }
 

--- a/tests/HTMLPurifier/AttrDef/URI/EmailHarness.php
+++ b/tests/HTMLPurifier/AttrDef/URI/EmailHarness.php
@@ -6,7 +6,8 @@ class HTMLPurifier_AttrDef_URI_EmailHarness extends HTMLPurifier_AttrDefHarness
     /**
      * Tests common email strings that are obviously pass/fail
      */
-    function testCore() {
+    public function testCore()
+    {
         $this->assertDef('bob@example.com');
         $this->assertDef('  bob@example.com  ', 'bob@example.com');
         $this->assertDef('bob.thebuilder@example.net');

--- a/tests/HTMLPurifier/AttrDef/URI/HostTest.php
+++ b/tests/HTMLPurifier/AttrDef/URI/HostTest.php
@@ -6,8 +6,8 @@
 class HTMLPurifier_AttrDef_URI_HostTest extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_URI_Host();
 
         $this->assertDef('[2001:DB8:0:0:8:800:200C:417A]'); // IPv6
@@ -40,7 +40,8 @@ class HTMLPurifier_AttrDef_URI_HostTest extends HTMLPurifier_AttrDefHarness
 
     }
 
-    function testIDNA() {
+    public function testIDNA()
+    {
         if (!$GLOBALS['HTMLPurifierTest']['Net_IDNA2']) {
             return false;
         }

--- a/tests/HTMLPurifier/AttrDef/URI/IPv4Test.php
+++ b/tests/HTMLPurifier/AttrDef/URI/IPv4Test.php
@@ -6,8 +6,8 @@
 class HTMLPurifier_AttrDef_URI_IPv4Test extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_URI_IPv4();
 
         $this->assertDef('127.0.0.1'); // standard IPv4, loopback, non-routable

--- a/tests/HTMLPurifier/AttrDef/URI/IPv6Test.php
+++ b/tests/HTMLPurifier/AttrDef/URI/IPv6Test.php
@@ -6,8 +6,8 @@
 class HTMLPurifier_AttrDef_URI_IPv6Test extends HTMLPurifier_AttrDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->def = new HTMLPurifier_AttrDef_URI_IPv6();
 
         $this->assertDef('2001:DB8:0:0:8:800:200C:417A'); // unicast, full

--- a/tests/HTMLPurifier/AttrDef/URITest.php
+++ b/tests/HTMLPurifier/AttrDef/URITest.php
@@ -6,12 +6,14 @@
 class HTMLPurifier_AttrDef_URITest extends HTMLPurifier_AttrDefHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         $this->def = new HTMLPurifier_AttrDef_URI();
         parent::setUp();
     }
 
-    function testIntegration() {
+    public function testIntegration()
+    {
         $this->assertDef('http://www.google.com/');
         $this->assertDef('http:', '');
         $this->assertDef('http:/foo', '/foo');
@@ -22,33 +24,38 @@ class HTMLPurifier_AttrDef_URITest extends HTMLPurifier_AttrDefHarness
         $this->assertDef('mailto:bob@example.com');
     }
 
-    function testIntegrationWithPercentEncoder() {
+    public function testIntegrationWithPercentEncoder()
+    {
         $this->assertDef(
             'http://www.example.com/%56%fc%GJ%5%FC',
             'http://www.example.com/V%FC%25GJ%255%FC'
         );
     }
 
-    function testPercentEncoding() {
+    public function testPercentEncoding()
+    {
         $this->assertDef(
             'http:colon:mercenary',
             'colon%3Amercenary'
         );
     }
 
-    function testPercentEncodingPreserve() {
+    public function testPercentEncodingPreserve()
+    {
         $this->assertDef(
             'http://www.example.com/abcABC123-_.!~*()\''
         );
     }
 
-    function testEmbeds() {
+    public function testEmbeds()
+    {
         $this->def = new HTMLPurifier_AttrDef_URI(true);
         $this->assertDef('http://sub.example.com/alas?foo=asd');
         $this->assertDef('mailto:foo@example.com', false);
     }
 
-    function testConfigMunge() {
+    public function testConfigMunge()
+    {
         $this->config->set('URI.Munge', 'http://www.google.com/url?q=%s');
         $this->assertDef(
             'http://www.example.com/',
@@ -58,32 +65,39 @@ class HTMLPurifier_AttrDef_URITest extends HTMLPurifier_AttrDefHarness
         $this->assertDef('javascript:foobar();', false);
     }
 
-    function testDefaultSchemeRemovedInBlank() {
+    public function testDefaultSchemeRemovedInBlank()
+    {
         $this->assertDef('http:', '');
     }
 
-    function testDefaultSchemeRemovedInRelativeURI() {
+    public function testDefaultSchemeRemovedInRelativeURI()
+    {
         $this->assertDef('http:/foo/bar', '/foo/bar');
     }
 
-    function testDefaultSchemeNotRemovedInAbsoluteURI() {
+    public function testDefaultSchemeNotRemovedInAbsoluteURI()
+    {
         $this->assertDef('http://example.com/foo/bar');
     }
 
-    function testAltSchemeNotRemoved() {
+    public function testAltSchemeNotRemoved()
+    {
         $this->assertDef('mailto:this-looks-like-a-path@example.com');
     }
 
-    function testResolveNullSchemeAmbiguity() {
+    public function testResolveNullSchemeAmbiguity()
+    {
         $this->assertDef('///foo', '/foo');
     }
 
-    function testResolveNullSchemeDoubleAmbiguity() {
+    public function testResolveNullSchemeDoubleAmbiguity()
+    {
         $this->config->set('URI.Host', 'example.com');
         $this->assertDef('////foo', '//example.com//foo');
     }
 
-    function testURIDefinitionValidation() {
+    public function testURIDefinitionValidation()
+    {
         $parser = new HTMLPurifier_URIParser();
         $uri = $parser->parse('http://example.com');
         $this->config->set('URI.DefinitionID', 'HTMLPurifier_AttrDef_URITest->testURIDefinitionValidation');
@@ -116,7 +130,8 @@ class HTMLPurifier_AttrDef_URITest extends HTMLPurifier_AttrDefHarness
         HTMLPurifier_DefinitionCacheFactory::instance($old);
     }
 
-    function test_make() {
+    public function test_make()
+    {
         $factory = new HTMLPurifier_AttrDef_URI();
         $def = $factory->make('');
         $def2 = new HTMLPurifier_AttrDef_URI();
@@ -128,8 +143,8 @@ class HTMLPurifier_AttrDef_URITest extends HTMLPurifier_AttrDefHarness
     }
 
     /*
-    function test_validate_configWhitelist() {
-
+    public function test_validate_configWhitelist()
+    {
         $this->config->set('URI.HostPolicy', 'DenyAll');
         $this->config->set('URI.HostWhitelist', array(null, 'google.com'));
 

--- a/tests/HTMLPurifier/AttrDefHarness.php
+++ b/tests/HTMLPurifier/AttrDefHarness.php
@@ -6,13 +6,15 @@ class HTMLPurifier_AttrDefHarness extends HTMLPurifier_Harness
     protected $def;
     protected $context, $config;
 
-    public function setUp() {
+    public function setUp()
+    {
         $this->config = HTMLPurifier_Config::createDefault();
         $this->context = new HTMLPurifier_Context();
     }
 
     // cannot be used for accumulator
-    function assertDef($string, $expect = true) {
+    public function assertDef($string, $expect = true)
+    {
         // $expect can be a string or bool
         $result = $this->def->validate($string, $this->config, $this->context);
         if ($expect === true) {

--- a/tests/HTMLPurifier/AttrDefTest.php
+++ b/tests/HTMLPurifier/AttrDefTest.php
@@ -8,8 +8,8 @@ Mock::generatePartial(
 class HTMLPurifier_AttrDefTest extends HTMLPurifier_Harness
 {
 
-    function test_parseCDATA() {
-
+    public function test_parseCDATA()
+    {
         $def = new HTMLPurifier_AttrDefTestable();
 
         $this->assertIdentical('', $def->parseCDATA(''));
@@ -19,8 +19,8 @@ class HTMLPurifier_AttrDefTest extends HTMLPurifier_Harness
 
     }
 
-    function test_make() {
-
+    public function test_make()
+    {
         $def = new HTMLPurifier_AttrDefTestable();
         $def2 = $def->make('');
         $this->assertIdentical($def, $def2);

--- a/tests/HTMLPurifier/AttrTransform/BackgroundTest.php
+++ b/tests/HTMLPurifier/AttrTransform/BackgroundTest.php
@@ -3,30 +3,35 @@
 class HTMLPurifier_AttrTransform_BackgroundTest extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_Background();
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult( array() );
     }
 
-    function testBasicTransform() {
+    public function testBasicTransform()
+    {
         $this->assertResult(
             array('background' => 'logo.png'),
             array('style' => 'background-image:url(logo.png);')
         );
     }
 
-    function testPrependNewCSS() {
+    public function testPrependNewCSS()
+    {
         $this->assertResult(
             array('background' => 'logo.png', 'style' => 'font-weight:bold'),
             array('style' => 'background-image:url(logo.png);font-weight:bold')
         );
     }
 
-    function testLenientTreatmentOfInvalidInput() {
+    public function testLenientTreatmentOfInvalidInput()
+    {
         // notice that we rely on the CSS validator later to fix this invalid
         // stuff
         $this->assertResult(

--- a/tests/HTMLPurifier/AttrTransform/BdoDirTest.php
+++ b/tests/HTMLPurifier/AttrTransform/BdoDirTest.php
@@ -3,20 +3,24 @@
 class HTMLPurifier_AttrTransform_BdoDirTest extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_BdoDir();
     }
 
-    function testAddDefaultDir() {
+    public function testAddDefaultDir()
+    {
         $this->assertResult( array(), array('dir' => 'ltr') );
     }
 
-    function testPreserveExistingDir() {
+    public function testPreserveExistingDir()
+    {
         $this->assertResult( array('dir' => 'rtl') );
     }
 
-    function testAlternateDefault() {
+    public function testAlternateDefault()
+    {
         $this->config->set('Attr.DefaultTextDir', 'rtl');
         $this->assertResult(
             array(),

--- a/tests/HTMLPurifier/AttrTransform/BgColorTest.php
+++ b/tests/HTMLPurifier/AttrTransform/BgColorTest.php
@@ -7,30 +7,35 @@
 class HTMLPurifier_AttrTransform_BgColorTest extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_BgColor();
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult( array() );
     }
 
-    function testBasicTransform() {
+    public function testBasicTransform()
+    {
         $this->assertResult(
             array('bgcolor' => '#000000'),
             array('style' => 'background-color:#000000;')
         );
     }
 
-    function testPrependNewCSS() {
+    public function testPrependNewCSS()
+    {
         $this->assertResult(
             array('bgcolor' => '#000000', 'style' => 'font-weight:bold'),
             array('style' => 'background-color:#000000;font-weight:bold')
         );
     }
 
-    function testLenientTreatmentOfInvalidInput() {
+    public function testLenientTreatmentOfInvalidInput()
+    {
         // this may change when we natively support the datatype and
         // validate its contents before forwarding it on
         $this->assertResult(

--- a/tests/HTMLPurifier/AttrTransform/BoolToCSSTest.php
+++ b/tests/HTMLPurifier/AttrTransform/BoolToCSSTest.php
@@ -3,30 +3,35 @@
 class HTMLPurifier_AttrTransform_BoolToCSSTest extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_BoolToCSS('foo', 'bar:3in;');
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult( array() );
     }
 
-    function testBasicTransform() {
+    public function testBasicTransform()
+    {
         $this->assertResult(
             array('foo' => 'foo'),
             array('style' => 'bar:3in;')
         );
     }
 
-    function testIgnoreValueOfBooleanAttribute() {
+    public function testIgnoreValueOfBooleanAttribute()
+    {
         $this->assertResult(
             array('foo' => 'no'),
             array('style' => 'bar:3in;')
         );
     }
 
-    function testPrependCSS() {
+    public function testPrependCSS()
+    {
         $this->assertResult(
             array('foo' => 'foo', 'style' => 'background-color:#F00;'),
             array('style' => 'bar:3in;background-color:#F00;')

--- a/tests/HTMLPurifier/AttrTransform/BorderTest.php
+++ b/tests/HTMLPurifier/AttrTransform/BorderTest.php
@@ -3,30 +3,35 @@
 class HTMLPurifier_AttrTransform_BorderTest extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_Border();
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult( array() );
     }
 
-    function testBasicTransform() {
+    public function testBasicTransform()
+    {
         $this->assertResult(
             array('border' => '1'),
             array('style' => 'border:1px solid;')
         );
     }
 
-    function testLenientTreatmentOfInvalidInput() {
+    public function testLenientTreatmentOfInvalidInput()
+    {
         $this->assertResult(
             array('border' => '10%'),
             array('style' => 'border:10%px solid;')
         );
     }
 
-    function testPrependNewCSS() {
+    public function testPrependNewCSS()
+    {
         $this->assertResult(
             array('border' => '23', 'style' => 'font-weight:bold;'),
             array('style' => 'border:23px solid;font-weight:bold;')

--- a/tests/HTMLPurifier/AttrTransform/EnumToCSSTest.php
+++ b/tests/HTMLPurifier/AttrTransform/EnumToCSSTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_AttrTransform_EnumToCSSTest extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_EnumToCSS('align', array(
             'left'  => 'text-align:left;',
@@ -11,36 +12,42 @@ class HTMLPurifier_AttrTransform_EnumToCSSTest extends HTMLPurifier_AttrTransfor
         ));
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult( array() );
     }
 
-    function testPreserveArraysWithoutInterestingAttributes() {
+    public function testPreserveArraysWithoutInterestingAttributes()
+    {
         $this->assertResult( array('style' => 'font-weight:bold;') );
     }
 
-    function testConvertAlignLeft() {
+    public function testConvertAlignLeft()
+    {
         $this->assertResult(
             array('align' => 'left'),
             array('style' => 'text-align:left;')
         );
     }
 
-    function testConvertAlignRight() {
+    public function testConvertAlignRight()
+    {
         $this->assertResult(
             array('align' => 'right'),
             array('style' => 'text-align:right;')
         );
     }
 
-    function testRemoveInvalidAlign() {
+    public function testRemoveInvalidAlign()
+    {
         $this->assertResult(
             array('align' => 'invalid'),
             array()
         );
     }
 
-    function testPrependNewCSS() {
+    public function testPrependNewCSS()
+    {
         $this->assertResult(
             array('align' => 'left', 'style' => 'font-weight:bold;'),
             array('style' => 'text-align:left;font-weight:bold;')
@@ -48,7 +55,8 @@ class HTMLPurifier_AttrTransform_EnumToCSSTest extends HTMLPurifier_AttrTransfor
 
     }
 
-    function testCaseInsensitive() {
+    public function testCaseInsensitive()
+    {
         $this->obj = new HTMLPurifier_AttrTransform_EnumToCSS('align', array(
             'right' => 'text-align:right;'
         ));
@@ -58,7 +66,8 @@ class HTMLPurifier_AttrTransform_EnumToCSSTest extends HTMLPurifier_AttrTransfor
         );
     }
 
-    function testCaseSensitive() {
+    public function testCaseSensitive()
+    {
         $this->obj = new HTMLPurifier_AttrTransform_EnumToCSS('align', array(
             'right' => 'text-align:right;'
         ), true);

--- a/tests/HTMLPurifier/AttrTransform/ImgRequiredTest.php
+++ b/tests/HTMLPurifier/AttrTransform/ImgRequiredTest.php
@@ -3,12 +3,14 @@
 class HTMLPurifier_AttrTransform_ImgRequiredTest extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_ImgRequired();
     }
 
-    function testAddMissingAttr() {
+    public function testAddMissingAttr()
+    {
         $this->config->set('Core.RemoveInvalidImg', false);
         $this->assertResult(
             array(),
@@ -16,7 +18,8 @@ class HTMLPurifier_AttrTransform_ImgRequiredTest extends HTMLPurifier_AttrTransf
         );
     }
 
-    function testAlternateDefaults() {
+    public function testAlternateDefaults()
+    {
         $this->config->set('Attr.DefaultInvalidImage', 'blank.png');
         $this->config->set('Attr.DefaultInvalidImageAlt', 'Pawned!');
         $this->config->set('Attr.DefaultImageAlt', 'not pawned');
@@ -27,14 +30,16 @@ class HTMLPurifier_AttrTransform_ImgRequiredTest extends HTMLPurifier_AttrTransf
         );
     }
 
-    function testGenerateAlt() {
+    public function testGenerateAlt()
+    {
         $this->assertResult(
             array('src' => '/path/to/foobar.png'),
             array('src' => '/path/to/foobar.png', 'alt' => 'foobar.png')
         );
     }
 
-    function testAddDefaultSrc() {
+    public function testAddDefaultSrc()
+    {
         $this->config->set('Core.RemoveInvalidImg', false);
         $this->assertResult(
             array('alt' => 'intrigue'),
@@ -42,7 +47,8 @@ class HTMLPurifier_AttrTransform_ImgRequiredTest extends HTMLPurifier_AttrTransf
         );
     }
 
-    function testAddDefaultAlt() {
+    public function testAddDefaultAlt()
+    {
         $this->config->set('Attr.DefaultImageAlt', 'default');
         $this->assertResult(
             array('src' => ''),

--- a/tests/HTMLPurifier/AttrTransform/ImgSpaceTest.php
+++ b/tests/HTMLPurifier/AttrTransform/ImgSpaceTest.php
@@ -3,37 +3,43 @@
 class HTMLPurifier_AttrTransform_ImgSpaceTest extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_ImgSpace('vspace');
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult( array() );
     }
 
-    function testVerticalBasicUsage() {
+    public function testVerticalBasicUsage()
+    {
         $this->assertResult(
             array('vspace' => '1'),
             array('style' => 'margin-top:1px;margin-bottom:1px;')
         );
     }
 
-    function testLenientHandlingOfInvalidInput() {
+    public function testLenientHandlingOfInvalidInput()
+    {
         $this->assertResult(
             array('vspace' => '10%'),
             array('style' => 'margin-top:10%px;margin-bottom:10%px;')
         );
     }
 
-    function testPrependNewCSS() {
+    public function testPrependNewCSS()
+    {
         $this->assertResult(
             array('vspace' => '23', 'style' => 'font-weight:bold;'),
             array('style' => 'margin-top:23px;margin-bottom:23px;font-weight:bold;')
         );
     }
 
-    function testHorizontalBasicUsage() {
+    public function testHorizontalBasicUsage()
+    {
         $this->obj = new HTMLPurifier_AttrTransform_ImgSpace('hspace');
         $this->assertResult(
             array('hspace' => '1'),
@@ -41,7 +47,8 @@ class HTMLPurifier_AttrTransform_ImgSpaceTest extends HTMLPurifier_AttrTransform
         );
     }
 
-    function testInvalidConstructionParameter() {
+    public function testInvalidConstructionParameter()
+    {
         $this->expectError('ispace is not valid space attribute');
         $this->obj = new HTMLPurifier_AttrTransform_ImgSpace('ispace');
         $this->assertResult(

--- a/tests/HTMLPurifier/AttrTransform/InputTest.php
+++ b/tests/HTMLPurifier/AttrTransform/InputTest.php
@@ -3,20 +3,24 @@
 class HTMLPurifier_AttrTransform_InputTest extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_Input();
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult(array());
     }
 
-    function testInvalidCheckedWithEmpty() {
+    public function testInvalidCheckedWithEmpty()
+    {
         $this->assertResult(array('checked' => 'checked'), array());
     }
 
-    function testInvalidCheckedWithPassword() {
+    public function testInvalidCheckedWithPassword()
+    {
         $this->assertResult(array(
             'checked' => 'checked',
             'type' => 'password'
@@ -25,7 +29,8 @@ class HTMLPurifier_AttrTransform_InputTest extends HTMLPurifier_AttrTransformHar
         ));
     }
 
-    function testValidCheckedWithUcCheckbox() {
+    public function testValidCheckedWithUcCheckbox()
+    {
         $this->assertResult(array(
             'checked' => 'checked',
             'type' => 'CHECKBOX',
@@ -33,7 +38,8 @@ class HTMLPurifier_AttrTransform_InputTest extends HTMLPurifier_AttrTransformHar
         ));
     }
 
-    function testInvalidMaxlength() {
+    public function testInvalidMaxlength()
+    {
         $this->assertResult(array(
             'maxlength' => '10',
             'type' => 'checkbox',
@@ -44,7 +50,8 @@ class HTMLPurifier_AttrTransform_InputTest extends HTMLPurifier_AttrTransformHar
         ));
     }
 
-    function testValidMaxLength() {
+    public function testValidMaxLength()
+    {
         $this->assertResult(array(
             'maxlength' => '10',
         ));
@@ -52,7 +59,8 @@ class HTMLPurifier_AttrTransform_InputTest extends HTMLPurifier_AttrTransformHar
 
     // these two are really bad test-cases
 
-    function testSizeWithCheckbox() {
+    public function testSizeWithCheckbox()
+    {
         $this->assertResult(array(
             'type' => 'checkbox',
             'value' => 'foo',
@@ -64,7 +72,8 @@ class HTMLPurifier_AttrTransform_InputTest extends HTMLPurifier_AttrTransformHar
         ));
     }
 
-    function testSizeWithText() {
+    public function testSizeWithText()
+    {
         $this->assertResult(array(
             'type' => 'password',
             'size' => '100px', // spurious value, to indicate no validation takes place
@@ -74,13 +83,15 @@ class HTMLPurifier_AttrTransform_InputTest extends HTMLPurifier_AttrTransformHar
         ));
     }
 
-    function testInvalidSrc() {
+    public function testInvalidSrc()
+    {
         $this->assertResult(array(
             'src' => 'img.png',
         ), array());
     }
 
-    function testMissingValue() {
+    public function testMissingValue()
+    {
         $this->assertResult(array(
             'type' => 'checkbox',
         ), array(

--- a/tests/HTMLPurifier/AttrTransform/LangTest.php
+++ b/tests/HTMLPurifier/AttrTransform/LangTest.php
@@ -4,37 +4,43 @@ class HTMLPurifier_AttrTransform_LangTest
     extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_Lang();
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult(array());
     }
 
-    function testCopyLangToXMLLang() {
+    public function testCopyLangToXMLLang()
+    {
         $this->assertResult(
             array('lang' => 'en'),
             array('lang' => 'en', 'xml:lang' => 'en')
         );
     }
 
-    function testPreserveAttributes() {
+    public function testPreserveAttributes()
+    {
         $this->assertResult(
             array('src' => 'vert.png', 'lang' => 'fr'),
             array('src' => 'vert.png', 'lang' => 'fr', 'xml:lang' => 'fr')
         );
     }
 
-    function testCopyXMLLangToLang() {
+    public function testCopyXMLLangToLang()
+    {
         $this->assertResult(
             array('xml:lang' => 'en'),
             array('xml:lang' => 'en', 'lang' => 'en')
         );
     }
 
-    function testXMLLangOverridesLang() {
+    public function testXMLLangOverridesLang()
+    {
         $this->assertResult(
             array('lang' => 'fr', 'xml:lang' => 'de'),
             array('lang' => 'de', 'xml:lang' => 'de')

--- a/tests/HTMLPurifier/AttrTransform/LengthTest.php
+++ b/tests/HTMLPurifier/AttrTransform/LengthTest.php
@@ -3,37 +3,43 @@
 class HTMLPurifier_AttrTransform_LengthTest extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_Length('width');
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult( array() );
     }
 
-    function testTransformPixel() {
+    public function testTransformPixel()
+    {
         $this->assertResult(
             array('width' => '10'),
             array('style' => 'width:10px;')
         );
     }
 
-    function testTransformPercentage() {
+    public function testTransformPercentage()
+    {
         $this->assertResult(
             array('width' => '10%'),
             array('style' => 'width:10%;')
         );
     }
 
-    function testPrependNewCSS() {
+    public function testPrependNewCSS()
+    {
         $this->assertResult(
             array('width' => '10%', 'style' => 'font-weight:bold'),
             array('style' => 'width:10%;font-weight:bold')
         );
     }
 
-    function testLenientTreatmentOfInvalidInput() {
+    public function testLenientTreatmentOfInvalidInput()
+    {
         $this->assertResult(
             array('width' => 'asdf'),
             array('style' => 'width:asdf;')

--- a/tests/HTMLPurifier/AttrTransform/NameSyncTest.php
+++ b/tests/HTMLPurifier/AttrTransform/NameSyncTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_AttrTransform_NameSyncTest extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_NameSync();
         $this->accumulator = new HTMLPurifier_IDAccumulator();
@@ -11,23 +12,27 @@ class HTMLPurifier_AttrTransform_NameSyncTest extends HTMLPurifier_AttrTransform
         $this->config->set('Attr.EnableID', true);
     }
 
-    function testEmpty() {
+    public function testEmpty()
+    {
         $this->assertResult( array() );
     }
 
-    function testAllowSame() {
+    public function testAllowSame()
+    {
         $this->assertResult(
             array('name' => 'free', 'id' => 'free')
         );
     }
 
-    function testAllowDifferent() {
+    public function testAllowDifferent()
+    {
         $this->assertResult(
             array('name' => 'tryit', 'id' => 'thisgood')
         );
     }
 
-    function testCheckName() {
+    public function testCheckName()
+    {
         $this->accumulator->add('notok');
         $this->assertResult(
             array('name' => 'notok', 'id' => 'ok'),

--- a/tests/HTMLPurifier/AttrTransform/NameTest.php
+++ b/tests/HTMLPurifier/AttrTransform/NameTest.php
@@ -3,23 +3,27 @@
 class HTMLPurifier_AttrTransform_NameTest extends HTMLPurifier_AttrTransformHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_AttrTransform_Name();
     }
 
-    function testEmpty() {
+    public function testEmpty()
+    {
         $this->assertResult( array() );
     }
 
-    function testTransformNameToID() {
+    public function testTransformNameToID()
+    {
         $this->assertResult(
             array('name' => 'free'),
             array('id' => 'free')
         );
     }
 
-    function testExistingIDOverridesName() {
+    public function testExistingIDOverridesName()
+    {
         $this->assertResult(
             array('name' => 'tryit', 'id' => 'tobad'),
             array('id' => 'tobad')

--- a/tests/HTMLPurifier/AttrTransformHarness.php
+++ b/tests/HTMLPurifier/AttrTransformHarness.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_AttrTransformHarness extends HTMLPurifier_ComplexHarness
 {
 
-    public function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->func = 'transform';
     }

--- a/tests/HTMLPurifier/AttrTransformTest.php
+++ b/tests/HTMLPurifier/AttrTransformTest.php
@@ -8,8 +8,8 @@ Mock::generatePartial(
 class HTMLPurifier_AttrTransformTest extends HTMLPurifier_Harness
 {
 
-    function test_prependCSS() {
-
+    public function test_prependCSS()
+    {
         $t = new HTMLPurifier_AttrTransformTestable();
 
         $attr = array();
@@ -26,8 +26,8 @@ class HTMLPurifier_AttrTransformTest extends HTMLPurifier_Harness
 
     }
 
-    function test_confiscateAttr() {
-
+    public function test_confiscateAttr()
+    {
         $t = new HTMLPurifier_AttrTransformTestable();
 
         $attr = array('flavor' => 'sweet');

--- a/tests/HTMLPurifier/AttrTypesTest.php
+++ b/tests/HTMLPurifier/AttrTypesTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_AttrTypesTest extends HTMLPurifier_Harness
 {
 
-    function test_get() {
+    public function test_get()
+    {
         $types = new HTMLPurifier_AttrTypes();
 
         $this->assertIdentical(

--- a/tests/HTMLPurifier/AttrValidator_ErrorsTest.php
+++ b/tests/HTMLPurifier/AttrValidator_ErrorsTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_AttrValidator_ErrorsTest extends HTMLPurifier_ErrorsHarness
 {
 
-    public function setup() {
+    public function setup()
+    {
         parent::setup();
         $config = HTMLPurifier_Config::createDefault();
         $this->language = HTMLPurifier_LanguageFactory::instance()->create($config, $this->context);
@@ -12,12 +13,14 @@ class HTMLPurifier_AttrValidator_ErrorsTest extends HTMLPurifier_ErrorsHarness
         $this->context->register('Generator', new HTMLPurifier_Generator($config, $this->context));
     }
 
-    protected function invoke($input) {
+    protected function invoke($input)
+    {
         $validator = new HTMLPurifier_AttrValidator();
         $validator->validateToken($input, $this->config, $this->context);
     }
 
-    function testAttributesTransformedGlobalPre() {
+    public function testAttributesTransformedGlobalPre()
+    {
         $def = $this->config->getHTMLDefinition(true);
         generate_mock_once('HTMLPurifier_AttrTransform');
         $transform = new HTMLPurifier_AttrTransformMock();
@@ -36,7 +39,8 @@ class HTMLPurifier_AttrValidator_ErrorsTest extends HTMLPurifier_ErrorsHarness
         $this->assertIdentical($result, $expect);
     }
 
-    function testAttributesTransformedLocalPre() {
+    public function testAttributesTransformedLocalPre()
+    {
         $this->config->set('HTML.TidyLevel', 'heavy');
         $input = array('align' => 'right');
         $output = array('style' => 'text-align:right;');
@@ -51,7 +55,8 @@ class HTMLPurifier_AttrValidator_ErrorsTest extends HTMLPurifier_ErrorsHarness
 
     // too lazy to check for global post and global pre
 
-    function testAttributeRemoved() {
+    public function testAttributeRemoved()
+    {
         $token = new HTMLPurifier_Token_Start('p', array('foobar' => 'right'), 1);
         $this->invoke($token);
         $result = $this->collector->getRaw();

--- a/tests/HTMLPurifier/ChildDef/ChameleonTest.php
+++ b/tests/HTMLPurifier/ChildDef/ChameleonTest.php
@@ -5,7 +5,8 @@ class HTMLPurifier_ChildDef_ChameleonTest extends HTMLPurifier_ChildDefHarness
 
     protected $isInline;
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_ChildDef_Chameleon(
             'b | i',      // allowed only when in inline context
@@ -14,21 +15,24 @@ class HTMLPurifier_ChildDef_ChameleonTest extends HTMLPurifier_ChildDefHarness
         $this->context->register('IsInline', $this->isInline);
     }
 
-    function testInlineAlwaysAllowed() {
+    public function testInlineAlwaysAllowed()
+    {
         $this->isInline = true;
         $this->assertResult(
             '<b>Allowed.</b>'
         );
     }
 
-    function testBlockNotAllowedInInline() {
+    public function testBlockNotAllowedInInline()
+    {
         $this->isInline = true;
         $this->assertResult(
             '<div>Not allowed.</div>', ''
         );
     }
 
-    function testBlockAllowedInNonInline() {
+    public function testBlockAllowedInNonInline()
+    {
         $this->isInline = false;
         $this->assertResult(
             '<div>Allowed.</div>'

--- a/tests/HTMLPurifier/ChildDef/CustomTest.php
+++ b/tests/HTMLPurifier/ChildDef/CustomTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_ChildDef_CustomTest extends HTMLPurifier_ChildDefHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         $this->obj = new HTMLPurifier_ChildDef_Custom('(a,b?,c*,d+,(a,b)*)');
 
         $this->assertEqual($this->obj->elements, array('a' => true,
@@ -19,7 +19,8 @@ class HTMLPurifier_ChildDef_CustomTest extends HTMLPurifier_ChildDefHarness
 
     }
 
-    function testNesting() {
+    public function testNesting()
+    {
         $this->obj = new HTMLPurifier_ChildDef_Custom('(a,b,(c|d))+');
         $this->assertEqual($this->obj->elements, array('a' => true,
             'b' => true, 'c' => true, 'd' => true));
@@ -28,7 +29,8 @@ class HTMLPurifier_ChildDef_CustomTest extends HTMLPurifier_ChildDefHarness
         $this->assertResult('<a /><b /><c /><d />', false);
     }
 
-    function testNestedEitherOr() {
+    public function testNestedEitherOr()
+    {
         $this->obj = new HTMLPurifier_ChildDef_Custom('b,(a|(c|d))+');
         $this->assertEqual($this->obj->elements, array('a' => true,
             'b' => true, 'c' => true, 'd' => true));
@@ -39,7 +41,8 @@ class HTMLPurifier_ChildDef_CustomTest extends HTMLPurifier_ChildDefHarness
         $this->assertResult('<acd />', false);
     }
 
-    function testNestedQuantifier() {
+    public function testNestedQuantifier()
+    {
         $this->obj = new HTMLPurifier_ChildDef_Custom('(b,c+)*');
         $this->assertEqual($this->obj->elements, array('b' => true, 'c' => true));
         $this->assertResult('');
@@ -49,8 +52,8 @@ class HTMLPurifier_ChildDef_CustomTest extends HTMLPurifier_ChildDefHarness
         $this->assertResult('<b /><c /><b />', false);
     }
 
-    function testEitherOr() {
-
+    public function testEitherOr()
+    {
         $this->obj = new HTMLPurifier_ChildDef_Custom('a|b');
         $this->assertEqual($this->obj->elements, array('a' => true, 'b' => true));
         $this->assertResult('', false);
@@ -60,8 +63,8 @@ class HTMLPurifier_ChildDef_CustomTest extends HTMLPurifier_ChildDefHarness
 
     }
 
-    function testCommafication() {
-
+    public function testCommafication()
+    {
         $this->obj = new HTMLPurifier_ChildDef_Custom('a,b');
         $this->assertEqual($this->obj->elements, array('a' => true, 'b' => true));
         $this->assertResult('<a /><b />');
@@ -69,14 +72,16 @@ class HTMLPurifier_ChildDef_CustomTest extends HTMLPurifier_ChildDefHarness
 
     }
 
-    function testPcdata() {
+    public function testPcdata()
+    {
         $this->obj = new HTMLPurifier_ChildDef_Custom('#PCDATA,a');
         $this->assertEqual($this->obj->elements, array('#PCDATA' => true, 'a' => true));
         $this->assertResult('foo<a />');
         $this->assertResult('<a />', false);
     }
 
-    function testWhitespace() {
+    public function testWhitespace()
+    {
         $this->obj = new HTMLPurifier_ChildDef_Custom('a');
         $this->assertEqual($this->obj->elements, array('a' => true));
         $this->assertResult('foo<a />', false);

--- a/tests/HTMLPurifier/ChildDef/ListTest.php
+++ b/tests/HTMLPurifier/ChildDef/ListTest.php
@@ -3,45 +3,55 @@
 class HTMLPurifier_ChildDef_ListTest extends HTMLPurifier_ChildDefHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_ChildDef_List();
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult('', false);
     }
 
-    function testSingleLi() {
+    public function testSingleLi()
+    {
         $this->assertResult('<li />');
     }
 
-    function testSomeLi() {
+    public function testSomeLi()
+    {
         $this->assertResult('<li>asdf</li><li />');
     }
 
-    function testIllegal() {
+    public function testIllegal()
+    {
         // XXX actually this never gets triggered in practice
         $this->assertResult('<li /><b />', '<li /><li><b /></li>');
     }
 
-    function testOlAtBeginning() {
+    public function testOlAtBeginning()
+    {
         $this->assertResult('<ol />', '<li><ol /></li>');
     }
 
-    function testOlAtBeginningWithOtherJunk() {
+    public function testOlAtBeginningWithOtherJunk()
+    {
         $this->assertResult('<ol /><li />', '<li><ol /></li><li />');
     }
 
-    function testOlInMiddle() {
+    public function testOlInMiddle()
+    {
         $this->assertResult('<li>Foo</li><ol><li>Bar</li></ol>', '<li>Foo<ol><li>Bar</li></ol></li>');
     }
 
-    function testMultipleOl() {
+    public function testMultipleOl()
+    {
         $this->assertResult('<li /><ol /><ol />', '<li><ol /><ol /></li>');
     }
 
-    function testUlAtBeginning() {
+    public function testUlAtBeginning()
+    {
         $this->assertResult('<ul />', '<li><ul /></li>');
     }
 

--- a/tests/HTMLPurifier/ChildDef/OptionalTest.php
+++ b/tests/HTMLPurifier/ChildDef/OptionalTest.php
@@ -3,28 +3,34 @@
 class HTMLPurifier_ChildDef_OptionalTest extends HTMLPurifier_ChildDefHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_ChildDef_Optional('b | i');
     }
 
-    function testBasicUsage() {
+    public function testBasicUsage()
+    {
         $this->assertResult('<b>Bold text</b><img />', '<b>Bold text</b>');
     }
 
-    function testRemoveForbiddenText() {
+    public function testRemoveForbiddenText()
+    {
         $this->assertResult('Not allowed text', '');
     }
 
-    function testEmpty() {
+    public function testEmpty()
+    {
         $this->assertResult('');
     }
 
-    function testWhitespace() {
+    public function testWhitespace()
+    {
         $this->assertResult(' ');
     }
 
-    function testMultipleWhitespace() {
+    public function testMultipleWhitespace()
+    {
         $this->assertResult('    ');
     }
 

--- a/tests/HTMLPurifier/ChildDef/RequiredTest.php
+++ b/tests/HTMLPurifier/ChildDef/RequiredTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_ChildDef_RequiredTest extends HTMLPurifier_ChildDefHarness
 {
 
-    function testPrepareString() {
+    public function testPrepareString()
+    {
         $def = new HTMLPurifier_ChildDef_Required('foobar | bang |gizmo');
         $this->assertIdentical($def->elements,
           array(
@@ -13,7 +14,8 @@ class HTMLPurifier_ChildDef_RequiredTest extends HTMLPurifier_ChildDefHarness
           ));
     }
 
-    function testPrepareArray() {
+    public function testPrepareArray()
+    {
         $def = new HTMLPurifier_ChildDef_Required(array('href', 'src'));
         $this->assertIdentical($def->elements,
           array(
@@ -22,16 +24,19 @@ class HTMLPurifier_ChildDef_RequiredTest extends HTMLPurifier_ChildDefHarness
           ));
     }
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_ChildDef_Required('dt | dd');
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult('', false);
     }
 
-    function testRemoveIllegalTagsAndElements() {
+    public function testRemoveIllegalTagsAndElements()
+    {
         $this->assertResult(
           '<dt>Term</dt>Text in an illegal location'.
              '<dd>Definition</dd><b>Illegal tag</b>',
@@ -39,28 +44,33 @@ class HTMLPurifier_ChildDef_RequiredTest extends HTMLPurifier_ChildDefHarness
         $this->assertResult('How do you do!', false);
     }
 
-    function testIgnoreWhitespace() {
+    public function testIgnoreWhitespace()
+    {
         // whitespace shouldn't trigger it
         $this->assertResult("\n<dd>Definition</dd>       ");
     }
 
-    function testPreserveWhitespaceAfterRemoval() {
+    public function testPreserveWhitespaceAfterRemoval()
+    {
         $this->assertResult(
           '<dd>Definition</dd>       <b></b>       ',
           '<dd>Definition</dd>              '
         );
     }
 
-    function testDeleteNodeIfOnlyWhitespace() {
+    public function testDeleteNodeIfOnlyWhitespace()
+    {
         $this->assertResult("\t      ", false);
     }
 
-    function testPCDATAAllowed() {
+    public function testPCDATAAllowed()
+    {
         $this->obj = new HTMLPurifier_ChildDef_Required('#PCDATA | b');
         $this->assertResult('Out <b>Bold text</b><img />', 'Out <b>Bold text</b>');
     }
 
-    function testPCDATAAllowedWithEscaping() {
+    public function testPCDATAAllowedWithEscaping()
+    {
         $this->obj = new HTMLPurifier_ChildDef_Required('#PCDATA | b');
         $this->config->set('Core.EscapeInvalidChildren', true);
         $this->assertResult(

--- a/tests/HTMLPurifier/ChildDef/StrictBlockquoteTest.php
+++ b/tests/HTMLPurifier/ChildDef/StrictBlockquoteTest.php
@@ -4,73 +4,86 @@ class   HTMLPurifier_ChildDef_StrictBlockquoteTest
 extends HTMLPurifier_ChildDefHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_ChildDef_StrictBlockquote('div | p');
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult('');
     }
 
-    function testPreserveValidP() {
+    public function testPreserveValidP()
+    {
         $this->assertResult('<p>Valid</p>');
     }
 
-    function testPreserveValidDiv() {
+    public function testPreserveValidDiv()
+    {
         $this->assertResult('<div>Still valid</div>');
     }
 
-    function testWrapTextWithP() {
+    public function testWrapTextWithP()
+    {
         $this->assertResult('Needs wrap', '<p>Needs wrap</p>');
     }
 
-    function testNoWrapForWhitespaceOrValidElements() {
+    public function testNoWrapForWhitespaceOrValidElements()
+    {
         $this->assertResult('<p>Do not wrap</p>    <p>Whitespace</p>');
     }
 
-    function testWrapTextNextToValidElements() {
+    public function testWrapTextNextToValidElements()
+    {
         $this->assertResult(
                'Wrap'. '<p>Do not wrap</p>',
             '<p>Wrap</p><p>Do not wrap</p>'
         );
     }
 
-    function testWrapInlineElements() {
+    public function testWrapInlineElements()
+    {
         $this->assertResult(
             '<p>Do not</p>'.'<b>Wrap</b>',
             '<p>Do not</p><p><b>Wrap</b></p>'
         );
     }
 
-    function testWrapAndRemoveInvalidTags() {
+    public function testWrapAndRemoveInvalidTags()
+    {
         $this->assertResult(
             '<li>Not allowed</li>Paragraph.<p>Hmm.</p>',
             '<p>Not allowedParagraph.</p><p>Hmm.</p>'
         );
     }
 
-    function testWrapComplicatedSring() {
+    public function testWrapComplicatedSring()
+    {
         $this->assertResult(
             $var = 'He said<br />perhaps<br />we should <b>nuke</b> them.',
             "<p>$var</p>"
         );
     }
 
-    function testWrapAndRemoveInvalidTagsComplex() {
+    public function testWrapAndRemoveInvalidTagsComplex()
+    {
         $this->assertResult(
             '<foo>Bar</foo><bas /><b>People</b>Conniving.'. '<p>Fools!</p>',
               '<p>Bar'.          '<b>People</b>Conniving.</p><p>Fools!</p>'
         );
     }
 
-    function testAlternateWrapper() {
+    public function testAlternateWrapper()
+    {
         $this->config->set('HTML.BlockWrapper', 'div');
         $this->assertResult('Needs wrap', '<div>Needs wrap</div>');
 
     }
 
-    function testError() {
+    public function testError()
+    {
         $this->expectError('Cannot use non-block element as block wrapper');
         $this->obj = new HTMLPurifier_ChildDef_StrictBlockquote('div | p');
         $this->config->set('HTML.BlockWrapper', 'dav');

--- a/tests/HTMLPurifier/ChildDef/TableTest.php
+++ b/tests/HTMLPurifier/ChildDef/TableTest.php
@@ -6,62 +6,73 @@
 class HTMLPurifier_ChildDef_TableTest extends HTMLPurifier_ChildDefHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_ChildDef_Table();
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult('', false);
     }
 
-    function testSingleRow() {
+    public function testSingleRow()
+    {
         $this->assertResult('<tr />');
     }
 
-    function testComplexContents() {
+    public function testComplexContents()
+    {
         $this->assertResult('<caption /><col /><thead /><tfoot /><tbody>'.
             '<tr><td>asdf</td></tr></tbody>');
         $this->assertResult('<col /><col /><col /><tr />');
     }
 
-    function testReorderContents() {
+    public function testReorderContents()
+    {
         $this->assertResult(
           '<col /><colgroup /><tbody /><tfoot /><thead /><tr>1</tr><caption /><tr />',
           '<caption /><col /><colgroup /><thead /><tfoot /><tbody /><tbody><tr>1</tr><tr /></tbody>');
     }
 
-    function testXhtml11Illegal() {
+    public function testXhtml11Illegal()
+    {
         $this->assertResult(
             '<thead><tr><th>a</th></tr></thead><tr><td>a</td></tr>',
             '<thead><tr><th>a</th></tr></thead><tbody><tr><td>a</td></tr></tbody>'
         );
     }
 
-    function testTrOverflowAndClose() {
+    public function testTrOverflowAndClose()
+    {
         $this->assertResult(
             '<tr><td>a</td></tr><tr><td>b</td></tr><tbody><tr><td>c</td></tr></tbody><tr><td>d</td></tr>',
             '<tbody><tr><td>a</td></tr><tr><td>b</td></tr></tbody><tbody><tr><td>c</td></tr></tbody><tbody><tr><td>d</td></tr></tbody>'
         );
     }
 
-    function testDuplicateProcessing() {
+    public function testDuplicateProcessing()
+    {
         $this->assertResult(
           '<caption>1</caption><caption /><tbody /><tbody /><tfoot>1</tfoot><tfoot />',
           '<caption>1</caption><tfoot>1</tfoot><tbody /><tbody /><tbody />'
         );
     }
 
-    function testRemoveText() {
+    public function testRemoveText()
+    {
         $this->assertResult('foo', false);
     }
 
-    function testStickyWhitespaceOnTr() {
+    public function testStickyWhitespaceOnTr()
+    {
         $this->config->set('Output.Newline', "\n");
         $this->assertResult("\n   <tr />\n  <tr />\n ");
     }
 
-    function testStickyWhitespaceOnTSection() {
+    public function testStickyWhitespaceOnTSection()
+    {
         $this->config->set('Output.Newline', "\n");
         $this->assertResult(
           "\n\t<tbody />\n\t\t<tfoot />\n\t\t\t",

--- a/tests/HTMLPurifier/ChildDefHarness.php
+++ b/tests/HTMLPurifier/ChildDefHarness.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_ChildDefHarness extends HTMLPurifier_ComplexHarness
 {
 
-    public function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj       = null;
         $this->func      = 'validateChildren';

--- a/tests/HTMLPurifier/ComplexHarness.php
+++ b/tests/HTMLPurifier/ComplexHarness.php
@@ -9,48 +9,51 @@ class HTMLPurifier_ComplexHarness extends HTMLPurifier_Harness
 {
 
     /**
-     * Instance of the object that will execute the method
+     * Instance of the object that will execute the method.
+     * @type object
      */
     protected $obj;
 
     /**
-     * Name of the function to be executed
+     * Name of the function to be executed.
+     * @type string
      */
     protected $func;
 
     /**
-     * Whether or not the method deals in tokens. If set to true, assertResult()
+     * Whether or not the method deals in tokens.
+     * If set to true, assertResult()
      * will transparently convert HTML to and back from tokens.
+     * @type bool
      */
     protected $to_tokens = false;
 
     /**
      * Whether or not to convert tokens back into HTML before performing
      * equality check, has no effect on bools.
+     * @type bool
      */
     protected $to_html = false;
 
     /**
      * Instance of an HTMLPurifier_Lexer implementation.
+     * @type HTMLPurifier_Lexer
      */
     protected $lexer;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->lexer     = new HTMLPurifier_Lexer_DirectLex();
         parent::__construct();
     }
 
     /**
      * Asserts a specific result from a one parameter + config/context function
-     * @param $input Input parameter
-     * @param $expect Expectation
-     * @param $config Configuration array in form of Ns.Directive => Value.
-     *                Has no effect if $this->config is set.
-     * @param $context_array Context array in form of Key => Value or an actual
-     *                       context object.
+     * @param string $input Input parameter
+     * @param bool|string $expect Expectation
      */
-    protected function assertResult($input, $expect = true) {
-
+    protected function assertResult($input, $expect = true)
+    {
         if ($this->to_tokens && is_string($input)) {
             // $func may cause $input to change, so "clone" another copy
             // to sacrifice
@@ -89,14 +92,16 @@ class HTMLPurifier_ComplexHarness extends HTMLPurifier_Harness
     /**
      * Tokenize HTML into tokens, uses member variables for common variables
      */
-    protected function tokenize($html) {
+    protected function tokenize($html)
+    {
         return $this->lexer->tokenizeHTML($html, $this->config, $this->context);
     }
 
     /**
      * Generate textual HTML from tokens
      */
-    protected function generate($tokens) {
+    protected function generate($tokens)
+    {
         $generator = new HTMLPurifier_Generator($this->config, $this->context);
         return $generator->generateFromTokens($tokens);
     }

--- a/tests/HTMLPurifier/ConfigSchema/InterchangeTest.php
+++ b/tests/HTMLPurifier/ConfigSchema/InterchangeTest.php
@@ -5,11 +5,13 @@ class HTMLPurifier_ConfigSchema_InterchangeTest extends UnitTestCase
 
     protected $interchange;
 
-    public function setup() {
+    public function setup()
+    {
         $this->interchange = new HTMLPurifier_ConfigSchema_Interchange();
     }
 
-    function testAddDirective() {
+    public function testAddDirective()
+    {
         $v = new HTMLPurifier_ConfigSchema_Interchange_Directive();
         $v->id = new HTMLPurifier_ConfigSchema_Interchange_Id('Namespace.Directive');
         $this->interchange->addDirective($v);

--- a/tests/HTMLPurifier/ConfigSchema/ValidatorAtomTest.php
+++ b/tests/HTMLPurifier/ConfigSchema/ValidatorAtomTest.php
@@ -3,87 +3,105 @@
 class HTMLPurifier_ConfigSchema_ValidatorAtomTest extends UnitTestCase
 {
 
-    protected function expectValidationException($msg) {
+    protected function expectValidationException($msg)
+    {
         $this->expectException(new HTMLPurifier_ConfigSchema_Exception($msg));
     }
 
-    protected function makeAtom($value) {
+    protected function makeAtom($value)
+    {
         $obj = new stdClass();
         $obj->property = $value;
         // Note that 'property' and 'context' are magic wildcard values
         return new HTMLPurifier_ConfigSchema_ValidatorAtom('context', $obj, 'property');
     }
 
-    function testAssertIsString() {
+    public function testAssertIsString()
+    {
         $this->makeAtom('foo')->assertIsString();
     }
 
-    function testAssertIsStringFail() {
+    public function testAssertIsStringFail()
+    {
         $this->expectValidationException("Property in context must be a string");
         $this->makeAtom(3)->assertIsString();
     }
 
-    function testAssertNotNull() {
+    public function testAssertNotNull()
+    {
         $this->makeAtom('foo')->assertNotNull();
     }
 
-    function testAssertNotNullFail() {
+    public function testAssertNotNullFail()
+    {
         $this->expectValidationException("Property in context must not be null");
         $this->makeAtom(null)->assertNotNull();
     }
 
-    function testAssertAlnum() {
+    public function testAssertAlnum()
+    {
         $this->makeAtom('foo2')->assertAlnum();
     }
 
-    function testAssertAlnumFail() {
+    public function testAssertAlnumFail()
+    {
         $this->expectValidationException("Property in context must be alphanumeric");
         $this->makeAtom('%a')->assertAlnum();
     }
 
-    function testAssertAlnumFailIsString() {
+    public function testAssertAlnumFailIsString()
+    {
         $this->expectValidationException("Property in context must be a string");
         $this->makeAtom(3)->assertAlnum();
     }
 
-    function testAssertNotEmpty() {
+    public function testAssertNotEmpty()
+    {
         $this->makeAtom('foo')->assertNotEmpty();
     }
 
-    function testAssertNotEmptyFail() {
+    public function testAssertNotEmptyFail()
+    {
         $this->expectValidationException("Property in context must not be empty");
         $this->makeAtom('')->assertNotEmpty();
     }
 
-    function testAssertIsBool() {
+    public function testAssertIsBool()
+    {
         $this->makeAtom(false)->assertIsBool();
     }
 
-    function testAssertIsBoolFail() {
+    public function testAssertIsBoolFail()
+    {
         $this->expectValidationException("Property in context must be a boolean");
         $this->makeAtom('0')->assertIsBool();
     }
 
-    function testAssertIsArray() {
+    public function testAssertIsArray()
+    {
         $this->makeAtom(array())->assertIsArray();
     }
 
-    function testAssertIsArrayFail() {
+    public function testAssertIsArrayFail()
+    {
         $this->expectValidationException("Property in context must be an array");
         $this->makeAtom('asdf')->assertIsArray();
     }
 
 
-    function testAssertIsLookup() {
+    public function testAssertIsLookup()
+    {
         $this->makeAtom(array('foo' => true))->assertIsLookup();
     }
 
-    function testAssertIsLookupFail() {
+    public function testAssertIsLookupFail()
+    {
         $this->expectValidationException("Property in context must be a lookup array");
         $this->makeAtom(array('foo' => 4))->assertIsLookup();
     }
 
-    function testAssertIsLookupFailIsArray() {
+    public function testAssertIsLookupFailIsArray()
+    {
         $this->expectValidationException("Property in context must be an array");
         $this->makeAtom('asdf')->assertIsLookup();
     }

--- a/tests/HTMLPurifier/ConfigSchema/ValidatorTest.php
+++ b/tests/HTMLPurifier/ConfigSchema/ValidatorTest.php
@@ -8,19 +8,22 @@ class HTMLPurifier_ConfigSchema_ValidatorTest extends UnitTestCase
 {
     public $validator, $interchange;
 
-    public function setup() {
+    public function setup()
+    {
         $this->validator = new HTMLPurifier_ConfigSchema_Validator();
         $this->interchange = new HTMLPurifier_ConfigSchema_Interchange();
     }
 
-    function testDirectiveIntegrityViolation() {
+    public function testDirectiveIntegrityViolation()
+    {
         $d = $this->makeDirective('Ns.Dir');
         $d->id = new HTMLPurifier_ConfigSchema_Interchange_Id('Ns.Dir2');
         $this->expectValidationException("Integrity violation: key 'Ns.Dir' does not match internal id 'Ns.Dir2'");
         $this->validator->validate($this->interchange);
     }
 
-    function testDirectiveTypeNotEmpty() {
+    public function testDirectiveTypeNotEmpty()
+    {
         $d = $this->makeDirective('Ns.Dir');
         $d->default = 0;
         $d->description = 'Description';
@@ -29,7 +32,8 @@ class HTMLPurifier_ConfigSchema_ValidatorTest extends UnitTestCase
         $this->validator->validate($this->interchange);
     }
 
-    function testDirectiveDefaultInvalid() {
+    public function testDirectiveDefaultInvalid()
+    {
         $d = $this->makeDirective('Ns.Dir');
         $d->default = 'asdf';
         $d->type = 'int';
@@ -39,7 +43,8 @@ class HTMLPurifier_ConfigSchema_ValidatorTest extends UnitTestCase
         $this->validator->validate($this->interchange);
     }
 
-    function testDirectiveIdIsString() {
+    public function testDirectiveIdIsString()
+    {
         $d = $this->makeDirective(3);
         $d->default = 0;
         $d->type = 'int';
@@ -49,7 +54,8 @@ class HTMLPurifier_ConfigSchema_ValidatorTest extends UnitTestCase
         $this->validator->validate($this->interchange);
     }
 
-    function testDirectiveTypeAllowsNullIsBool() {
+    public function testDirectiveTypeAllowsNullIsBool()
+    {
         $d = $this->makeDirective('Ns.Dir');
         $d->default = 0;
         $d->type = 'int';
@@ -60,7 +66,8 @@ class HTMLPurifier_ConfigSchema_ValidatorTest extends UnitTestCase
         $this->validator->validate($this->interchange);
     }
 
-    function testDirectiveValueAliasesIsArray() {
+    public function testDirectiveValueAliasesIsArray()
+    {
         $d = $this->makeDirective('Ns.Dir');
         $d->default = 'a';
         $d->type = 'string';
@@ -71,7 +78,8 @@ class HTMLPurifier_ConfigSchema_ValidatorTest extends UnitTestCase
         $this->validator->validate($this->interchange);
     }
 
-    function testDirectiveAllowedIsLookup() {
+    public function testDirectiveAllowedIsLookup()
+    {
         $d = $this->makeDirective('Ns.Dir');
         $d->default = 'foo';
         $d->type = 'string';
@@ -85,14 +93,16 @@ class HTMLPurifier_ConfigSchema_ValidatorTest extends UnitTestCase
     // helper functions
 
 
-    protected function makeDirective($key) {
+    protected function makeDirective($key)
+    {
         $directive = new HTMLPurifier_ConfigSchema_Interchange_Directive();
         $directive->id = new HTMLPurifier_ConfigSchema_Interchange_Id($key);
         $this->interchange->addDirective($directive);
         return $directive;
     }
 
-    protected function expectValidationException($msg) {
+    protected function expectValidationException($msg)
+    {
         $this->expectException(new HTMLPurifier_ConfigSchema_Exception($msg));
     }
 

--- a/tests/HTMLPurifier/ConfigSchema/ValidatorTestCase.php
+++ b/tests/HTMLPurifier/ConfigSchema/ValidatorTestCase.php
@@ -9,18 +9,21 @@ class HTMLPurifier_ConfigSchema_ValidatorTestCase extends UnitTestCase
     protected $_path, $_parser, $_builder;
     public $validator;
 
-    public function __construct($path) {
+    public function __construct($path)
+    {
         $this->_path = $path;
         $this->_parser  = new HTMLPurifier_StringHashParser();
         $this->_builder = new HTMLPurifier_ConfigSchema_InterchangeBuilder();
         parent::__construct($path);
     }
 
-    public function setup() {
+    public function setup()
+    {
         $this->validator = new HTMLPurifier_ConfigSchema_Validator();
     }
 
-    function testValidator() {
+    public function testValidator()
+    {
         $hashes = $this->_parser->parseMultiFile($this->_path);
         $interchange = new HTMLPurifier_ConfigSchema_Interchange();
         $error = null;

--- a/tests/HTMLPurifier/ConfigSchemaTest.php
+++ b/tests/HTMLPurifier/ConfigSchemaTest.php
@@ -5,11 +5,13 @@ class HTMLPurifier_ConfigSchemaTest extends HTMLPurifier_Harness
 
     protected $schema;
 
-    public function setup() {
+    public function setup()
+    {
         $this->schema = new HTMLPurifier_ConfigSchema();
     }
 
-    function test_define() {
+    public function test_define()
+    {
         $this->schema->add('Car.Seats', 5, 'int', false);
 
         $this->assertIdentical($this->schema->defaults['Car.Seats'], 5);
@@ -22,7 +24,8 @@ class HTMLPurifier_ConfigSchemaTest extends HTMLPurifier_Harness
 
     }
 
-    function test_defineAllowedValues() {
+    public function test_defineAllowedValues()
+    {
         $this->schema->add('QuantumNumber.Spin', 0.5, 'float', false);
         $this->schema->add('QuantumNumber.Current', 's', 'string', false);
         $this->schema->add('QuantumNumber.Difficulty', null, 'string', true);
@@ -44,7 +47,8 @@ class HTMLPurifier_ConfigSchemaTest extends HTMLPurifier_Harness
 
     }
 
-    function test_defineValueAliases() {
+    public function test_defineValueAliases()
+    {
         $this->schema->add('Abbrev.HTH', 'Happy to Help', 'string', false);
         $this->schema->addAllowedValues(
             'Abbrev.HTH', array(
@@ -84,7 +88,8 @@ class HTMLPurifier_ConfigSchemaTest extends HTMLPurifier_Harness
 
     }
 
-    function testAlias() {
+    public function testAlias()
+    {
         $this->schema->add('Home.Rug', 3, 'int', false);
         $this->schema->addAlias('Home.Carpet', 'Home.Rug');
 

--- a/tests/HTMLPurifier/ConfigTest.php
+++ b/tests/HTMLPurifier/ConfigTest.php
@@ -6,14 +6,16 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
     protected $schema;
     protected $oldFactory;
 
-    public function setUp() {
+    public function setUp()
+    {
         // set up a dummy schema object for testing
         $this->schema = new HTMLPurifier_ConfigSchema();
     }
 
     // test functionality based on ConfigSchema
 
-    function testNormal() {
+    public function testNormal()
+    {
         $this->schema->add('Element.Abbr', 'H', 'string', false);
         $this->schema->add('Element.Name', 'hydrogen', 'istring', false);
         $this->schema->add('Element.Number', 1, 'int', false);
@@ -72,8 +74,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
 
     }
 
-    function testEnumerated() {
-
+    public function testEnumerated()
+    {
         // case sensitive
         $this->schema->add('Instrument.Manufacturer', 'Yamaha', 'string', false);
         $this->schema->addAllowedValues('Instrument.Manufacturer', array(
@@ -121,8 +123,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
 
     }
 
-    function testNull() {
-
+    public function testNull()
+    {
         $this->schema->add('ReportCard.English', null, 'string', true);
         $this->schema->add('ReportCard.Absences', 0, 'int', false);
 
@@ -142,8 +144,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
 
     }
 
-    function testAliases() {
-
+    public function testAliases()
+    {
         $this->schema->add('Home.Rug', 3, 'int', false);
         $this->schema->addAlias('Home.Carpet', 'Home.Rug');
 
@@ -164,8 +166,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
 
     // test functionality based on method
 
-    function test_getBatch() {
-
+    public function test_getBatch()
+    {
         $this->schema->add('Variables.TangentialAcceleration', 'a_tan', 'string', false);
         $this->schema->add('Variables.AngularAcceleration', 'alpha', 'string', false);
 
@@ -188,8 +190,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
 
     }
 
-    function test_loadIni() {
-
+    public function test_loadIni()
+    {
         $this->schema->add('Shortcut.Copy', 'c', 'istring', false);
         $this->schema->add('Shortcut.Paste', 'v', 'istring', false);
         $this->schema->add('Shortcut.Cut', 'x', 'istring', false);
@@ -205,8 +207,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
 
     }
 
-    function test_getHTMLDefinition() {
-
+    public function test_getHTMLDefinition()
+    {
         // we actually want to use the old copy, because the definition
         // generation routines have dependencies on configuration values
 
@@ -233,7 +235,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
 
     }
 
-    function test_getHTMLDefinition_deprecatedRawError() {
+    public function test_getHTMLDefinition_deprecatedRawError()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $config->chatty = false;
         // test deprecated retrieval of raw definition
@@ -248,13 +251,15 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
         $this->assertTrue($def->setup);
     }
 
-    function test_getHTMLDefinition_optimizedRawError() {
+    public function test_getHTMLDefinition_optimizedRawError()
+    {
         $this->expectException(new HTMLPurifier_Exception("Cannot set optimized = true when raw = false"));
         $config = HTMLPurifier_Config::createDefault();
         $config->getHTMLDefinition(false, true);
     }
 
-    function test_getHTMLDefinition_rawAfterSetupError() {
+    public function test_getHTMLDefinition_rawAfterSetupError()
+    {
         $this->expectException(new HTMLPurifier_Exception("Cannot retrieve raw definition after it has already been setup"));
         $config = HTMLPurifier_Config::createDefault();
         $config->chatty = false;
@@ -262,7 +267,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
         $config->getHTMLDefinition(true);
     }
 
-    function test_getHTMLDefinition_inconsistentOptimizedError() {
+    public function test_getHTMLDefinition_inconsistentOptimizedError()
+    {
         $this->expectError("Useless DefinitionID declaration");
         $this->expectException(new HTMLPurifier_Exception("Inconsistent use of optimized and unoptimized raw definition retrievals"));
         $config = HTMLPurifier_Config::create(array('HTML.DefinitionID' => 'HTMLPurifier_ConfigTest->test_getHTMLDefinition_inconsistentOptimizedError'));
@@ -271,7 +277,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
         $config->getHTMLDefinition(true, true);
     }
 
-    function test_getHTMLDefinition_inconsistentOptimizedError2() {
+    public function test_getHTMLDefinition_inconsistentOptimizedError2()
+    {
         $this->expectException(new HTMLPurifier_Exception("Inconsistent use of optimized and unoptimized raw definition retrievals"));
         $config = HTMLPurifier_Config::create(array('HTML.DefinitionID' => 'HTMLPurifier_ConfigTest->test_getHTMLDefinition_inconsistentOptimizedError2'));
         $config->chatty = false;
@@ -279,26 +286,30 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
         $config->getHTMLDefinition(true, false);
     }
 
-    function test_getHTMLDefinition_rawError() {
+    public function test_getHTMLDefinition_rawError()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $this->expectException(new HTMLPurifier_Exception('Cannot retrieve raw version without specifying %HTML.DefinitionID'));
         $def = $config->getHTMLDefinition(true, true);
     }
 
-    function test_getCSSDefinition() {
+    public function test_getCSSDefinition()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $def = $config->getCSSDefinition();
         $this->assertIsA($def, 'HTMLPurifier_CSSDefinition');
     }
 
-    function test_getDefinition() {
+    public function test_getDefinition()
+    {
         $this->schema->add('Cache.DefinitionImpl', null, 'string', true);
         $config = new HTMLPurifier_Config($this->schema);
         $this->expectException(new HTMLPurifier_Exception("Definition of Crust type not supported"));
         $config->getDefinition('Crust');
     }
 
-    function test_loadArray() {
+    public function test_loadArray()
+    {
         // setup a few dummy namespaces/directives for our testing
         $this->schema->add('Zoo.Aadvark', 0, 'int', false);
         $this->schema->add('Zoo.Boar',    0, 'int', false);
@@ -337,8 +348,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
 
     }
 
-    function test_create() {
-
+    public function test_create()
+    {
         $this->schema->add('Cake.Sprinkles', 666, 'int', false);
         $this->schema->add('Cake.Flavor', 'vanilla', 'string', false);
 
@@ -359,8 +370,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
 
     }
 
-    function test_finalize() {
-
+    public function test_finalize()
+    {
         // test finalization
 
         $this->schema->add('Poem.Meter', 'iambic', 'string', false);
@@ -384,8 +395,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
 
     }
 
-    function test_loadArrayFromForm() {
-
+    public function test_loadArrayFromForm()
+    {
         $this->schema->add('Pancake.Mix', 'buttermilk', 'string', false);
         $this->schema->add('Pancake.Served', true, 'bool', false);
         $this->schema->add('Toppings.Syrup', true, 'bool', false);
@@ -444,7 +455,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
         */
     }
 
-    function test_getAllowedDirectivesForForm() {
+    public function test_getAllowedDirectivesForForm()
+    {
         $this->schema->add('Unused.Unused', 'Foobar', 'string', false);
         $this->schema->add('Partial.Allowed', true, 'bool', false);
         $this->schema->add('Partial.Unused', 'Foobar', 'string', false);
@@ -464,7 +476,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
 
     }
 
-    function testDeprecatedAPI() {
+    public function testDeprecatedAPI()
+    {
         $this->schema->add('Foo.Bar', 2, 'int', false);
         $config = new HTMLPurifier_Config($this->schema);
         $config->chatty = false;
@@ -474,7 +487,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
         $this->assertIdentical($config->get('Foo', 'Bar'), 4);
     }
 
-    function testInherit() {
+    public function testInherit()
+    {
         $this->schema->add('Phantom.Masked', 25, 'int', false);
         $this->schema->add('Phantom.Unmasked', 89, 'int', false);
         $this->schema->add('Phantom.Latemasked', 11, 'int', false);
@@ -487,14 +501,16 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
         $this->assertIdentical($subconfig->get('Phantom.Latemasked'), 100);
     }
 
-    function testSerialize() {
+    public function testSerialize()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $config->set('HTML.Allowed', 'a');
         $config2 = unserialize($config->serialize());
         $this->assertIdentical($config->get('HTML.Allowed'), $config2->get('HTML.Allowed'));
     }
 
-    function testDefinitionCachingNothing() {
+    public function testDefinitionCachingNothing()
+    {
         list($mock, $config) = $this->setupCacheMock('HTML');
         // should not touch the cache
         $mock->expectNever('get');
@@ -506,7 +522,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
         $this->teardownCacheMock();
     }
 
-    function testDefinitionCachingOptimized() {
+    public function testDefinitionCachingOptimized()
+    {
         list($mock, $config) = $this->setupCacheMock('HTML');
         $mock->expectNever('set');
         $config->set('HTML.DefinitionID', 'HTMLPurifier_ConfigTest->testDefinitionCachingOptimized');
@@ -519,7 +536,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
         $this->teardownCacheMock();
     }
 
-    function testDefinitionCachingOptimizedHit() {
+    public function testDefinitionCachingOptimizedHit()
+    {
         $fake_config = HTMLPurifier_Config::createDefault();
         $fake_def = $fake_config->getHTMLDefinition();
         list($mock, $config) = $this->setupCacheMock('HTML');
@@ -535,7 +553,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
         $this->teardownCacheMock();
     }
 
-    protected function setupCacheMock($type) {
+    protected function setupCacheMock($type)
+    {
         // inject our definition cache mock globally (borrowed from
         // DefinitionFactoryTest)
         generate_mock_once("HTMLPurifier_DefinitionCacheFactory");
@@ -548,7 +567,8 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
         $factory->setReturnValue('create', $mock, array($type, $config));
         return array($mock, $config);
     }
-    protected function teardownCacheMock() {
+    protected function teardownCacheMock()
+    {
         HTMLPurifier_DefinitionCacheFactory::instance($this->oldFactory);
     }
 

--- a/tests/HTMLPurifier/ContextTest.php
+++ b/tests/HTMLPurifier/ContextTest.php
@@ -6,12 +6,13 @@ class HTMLPurifier_ContextTest extends HTMLPurifier_Harness
 
     protected $context;
 
-    public function setUp() {
+    public function setUp()
+    {
         $this->context = new HTMLPurifier_Context();
     }
 
-    function testStandardUsage() {
-
+    public function testStandardUsage()
+    {
         generate_mock_once('HTMLPurifier_IDAccumulator');
 
         $this->assertFalse($this->context->exists('IDAccumulator'));
@@ -35,8 +36,8 @@ class HTMLPurifier_ContextTest extends HTMLPurifier_Harness
 
     }
 
-    function testReRegister() {
-
+    public function testReRegister()
+    {
         $var = true;
         $this->context->register('OnceOnly', $var);
 
@@ -49,8 +50,8 @@ class HTMLPurifier_ContextTest extends HTMLPurifier_Harness
 
     }
 
-    function test_loadArray() {
-
+    public function test_loadArray()
+    {
         // references can be *really* wonky!
 
         $context_manual = new HTMLPurifier_Context();

--- a/tests/HTMLPurifier/DefinitionCache/Decorator/CleanupTest.php
+++ b/tests/HTMLPurifier/DefinitionCache/Decorator/CleanupTest.php
@@ -5,48 +5,56 @@ generate_mock_once('HTMLPurifier_DefinitionCache');
 class HTMLPurifier_DefinitionCache_Decorator_CleanupTest extends HTMLPurifier_DefinitionCache_DecoratorHarness
 {
 
-    function setup() {
+    public function setup()
+    {
         $this->cache = new HTMLPurifier_DefinitionCache_Decorator_Cleanup();
         parent::setup();
     }
 
-    function setupMockForSuccess($op) {
+    public function setupMockForSuccess($op)
+    {
         $this->mock->expectOnce($op, array($this->def, $this->config));
         $this->mock->setReturnValue($op, true, array($this->def, $this->config));
         $this->mock->expectNever('cleanup');
     }
 
-    function setupMockForFailure($op) {
+    public function setupMockForFailure($op)
+    {
         $this->mock->expectOnce($op, array($this->def, $this->config));
         $this->mock->setReturnValue($op, false, array($this->def, $this->config));
         $this->mock->expectOnce('cleanup', array($this->config));
     }
 
-    function test_get() {
+    public function test_get()
+    {
         $this->mock->expectOnce('get', array($this->config));
         $this->mock->setReturnValue('get', true, array($this->config));
         $this->mock->expectNever('cleanup');
         $this->assertEqual($this->cache->get($this->config), $this->def);
     }
 
-    function test_get_failure() {
+    public function test_get_failure()
+    {
         $this->mock->expectOnce('get', array($this->config));
         $this->mock->setReturnValue('get', false, array($this->config));
         $this->mock->expectOnce('cleanup', array($this->config));
         $this->assertEqual($this->cache->get($this->config), false);
     }
 
-    function test_set() {
+    public function test_set()
+    {
         $this->setupMockForSuccess('set');
         $this->assertEqual($this->cache->set($this->def, $this->config), true);
     }
 
-    function test_replace() {
+    public function test_replace()
+    {
         $this->setupMockForSuccess('replace');
         $this->assertEqual($this->cache->replace($this->def, $this->config), true);
     }
 
-    function test_add() {
+    public function test_add()
+    {
         $this->setupMockForSuccess('add');
         $this->assertEqual($this->cache->add($this->def, $this->config), true);
     }

--- a/tests/HTMLPurifier/DefinitionCache/Decorator/MemoryTest.php
+++ b/tests/HTMLPurifier/DefinitionCache/Decorator/MemoryTest.php
@@ -5,61 +5,71 @@ generate_mock_once('HTMLPurifier_DefinitionCache');
 class HTMLPurifier_DefinitionCache_Decorator_MemoryTest extends HTMLPurifier_DefinitionCache_DecoratorHarness
 {
 
-    function setup() {
+    public function setup()
+    {
         $this->cache = new HTMLPurifier_DefinitionCache_Decorator_Memory();
         parent::setup();
     }
 
-    function setupMockForSuccess($op) {
+    public function setupMockForSuccess($op)
+    {
         $this->mock->expectOnce($op, array($this->def, $this->config));
         $this->mock->setReturnValue($op, true, array($this->def, $this->config));
         $this->mock->expectNever('get');
     }
 
-    function setupMockForFailure($op) {
+    public function setupMockForFailure($op)
+    {
         $this->mock->expectOnce($op, array($this->def, $this->config));
         $this->mock->setReturnValue($op, false, array($this->def, $this->config));
         $this->mock->expectOnce('get', array($this->config));
     }
 
-    function test_get() {
+    public function test_get()
+    {
         $this->mock->expectOnce('get', array($this->config)); // only ONE call!
         $this->mock->setReturnValue('get', $this->def, array($this->config));
         $this->assertEqual($this->cache->get($this->config), $this->def);
         $this->assertEqual($this->cache->get($this->config), $this->def);
     }
 
-    function test_set() {
+    public function test_set()
+    {
         $this->setupMockForSuccess('set', 'get');
         $this->assertEqual($this->cache->set($this->def, $this->config), true);
         $this->assertEqual($this->cache->get($this->config), $this->def);
     }
 
-    function test_set_failure() {
+    public function test_set_failure()
+    {
         $this->setupMockForFailure('set', 'get');
         $this->assertEqual($this->cache->set($this->def, $this->config), false);
         $this->cache->get($this->config);
     }
 
-    function test_replace() {
+    public function test_replace()
+    {
         $this->setupMockForSuccess('replace', 'get');
         $this->assertEqual($this->cache->replace($this->def, $this->config), true);
         $this->assertEqual($this->cache->get($this->config), $this->def);
     }
 
-    function test_replace_failure() {
+    public function test_replace_failure()
+    {
         $this->setupMockForFailure('replace', 'get');
         $this->assertEqual($this->cache->replace($this->def, $this->config), false);
         $this->cache->get($this->config);
     }
 
-    function test_add() {
+    public function test_add()
+    {
         $this->setupMockForSuccess('add', 'get');
         $this->assertEqual($this->cache->add($this->def, $this->config), true);
         $this->assertEqual($this->cache->get($this->config), $this->def);
     }
 
-    function test_add_failure() {
+    public function test_add_failure()
+    {
         $this->setupMockForFailure('add', 'get');
         $this->assertEqual($this->cache->add($this->def, $this->config), false);
         $this->cache->get($this->config);

--- a/tests/HTMLPurifier/DefinitionCache/DecoratorHarness.php
+++ b/tests/HTMLPurifier/DefinitionCache/DecoratorHarness.php
@@ -5,7 +5,8 @@ generate_mock_once('HTMLPurifier_DefinitionCache');
 class HTMLPurifier_DefinitionCache_DecoratorHarness extends HTMLPurifier_DefinitionCacheHarness
 {
 
-    function setup() {
+    public function setup()
+    {
         $this->mock     = new HTMLPurifier_DefinitionCacheMock();
         $this->mock->type = 'Test';
         $this->cache    = $this->cache->decorate($this->mock);
@@ -13,7 +14,8 @@ class HTMLPurifier_DefinitionCache_DecoratorHarness extends HTMLPurifier_Definit
         $this->config   = $this->generateConfigMock();
     }
 
-    function teardown() {
+    public function teardown()
+    {
         unset($this->mock);
         unset($this->cache);
     }

--- a/tests/HTMLPurifier/DefinitionCache/DecoratorTest.php
+++ b/tests/HTMLPurifier/DefinitionCache/DecoratorTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_DefinitionCache_DecoratorTest extends HTMLPurifier_DefinitionCacheHarness
 {
 
-    function test() {
-
+    public function test()
+    {
         generate_mock_once('HTMLPurifier_DefinitionCache');
         $mock = new HTMLPurifier_DefinitionCacheMock();
         $mock->type = 'Test';

--- a/tests/HTMLPurifier/DefinitionCache/SerializerTest.php
+++ b/tests/HTMLPurifier/DefinitionCache/SerializerTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_DefinitionCacheHarness
 {
 
-    function test() {
+    public function test()
+    {
         // XXX SimpleTest does some really crazy stuff in the background
         // to do equality checks. Unfortunately, this makes some
         // versions of PHP segfault. So we need to define a better,
@@ -66,7 +67,8 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
 
     }
 
-    function test_errors() {
+    public function test_errors()
+    {
         $cache = new HTMLPurifier_DefinitionCache_Serializer('Test');
         $def = $this->generateDefinition();
         $def->setup = true;
@@ -83,8 +85,8 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
         $cache->replace($def, $config);
     }
 
-    function test_flush() {
-
+    public function test_flush()
+    {
         $cache = new HTMLPurifier_DefinitionCache_Serializer('Test');
 
         $config1 = $this->generateConfigMock('test1');
@@ -111,8 +113,8 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
 
     }
 
-    function testCleanup() {
-
+    public function testCleanup()
+    {
         $cache = new HTMLPurifier_DefinitionCache_Serializer('Test');
 
         // in order of age, oldest first
@@ -139,8 +141,8 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
 
     }
 
-    function testCleanupOnlySameID() {
-
+    public function testCleanupOnlySameID()
+    {
         $cache = new HTMLPurifier_DefinitionCache_Serializer('Test');
 
         $config1 = $this->generateConfigMock('serial1');
@@ -168,7 +170,8 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
     /**
      * Asserts that a file exists, ignoring the stat cache
      */
-    function assertFileExist($file) {
+    public function assertFileExist($file)
+    {
         clearstatcache();
         $this->assertTrue(file_exists($file), 'Expected ' . $file . ' exists');
     }
@@ -176,13 +179,14 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
     /**
      * Asserts that a file does not exist, ignoring the stat cache
      */
-    function assertFileNotExist($file) {
+    public function assertFileNotExist($file)
+    {
         clearstatcache();
         $this->assertFalse(file_exists($file), 'Expected ' . $file . ' does not exist');
     }
 
-    function testAlternatePath() {
-
+    public function testAlternatePath()
+    {
         $cache = new HTMLPurifier_DefinitionCache_Serializer('Test');
         $config = $this->generateConfigMock('serial');
         $config->version = '1.0.0';
@@ -199,8 +203,8 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
 
     }
 
-    function testAlternatePermissions() {
-
+    public function testAlternatePermissions()
+    {
         $cache = new HTMLPurifier_DefinitionCache_Serializer('Test');
         $config = $this->generateConfigMock('serial');
         $config->version = '1.0.0';

--- a/tests/HTMLPurifier/DefinitionCacheFactoryTest.php
+++ b/tests/HTMLPurifier/DefinitionCacheFactoryTest.php
@@ -6,23 +6,27 @@ class HTMLPurifier_DefinitionCacheFactoryTest extends HTMLPurifier_Harness
     protected $factory;
     protected $oldFactory;
 
-    public function setUp() {
+    public function setUp()
+    {
         parent::setup();
         $this->factory = new HTMLPurifier_DefinitionCacheFactory();
         $this->oldFactory = HTMLPurifier_DefinitionCacheFactory::instance();
         HTMLPurifier_DefinitionCacheFactory::instance($this->factory);
     }
 
-    public function tearDown() {
+    public function tearDown()
+    {
         HTMLPurifier_DefinitionCacheFactory::instance($this->oldFactory);
     }
 
-    function test_create() {
+    public function test_create()
+    {
         $cache = $this->factory->create('Test', $this->config);
         $this->assertEqual($cache, new HTMLPurifier_DefinitionCache_Serializer('Test'));
     }
 
-    function test_create_withDecorator() {
+    public function test_create_withDecorator()
+    {
         $this->factory->addDecorator('Memory');
         $cache = $this->factory->create('Test', $this->config);
         $cache_real = new HTMLPurifier_DefinitionCache_Decorator_Memory();
@@ -30,7 +34,8 @@ class HTMLPurifier_DefinitionCacheFactoryTest extends HTMLPurifier_Harness
         $this->assertEqual($cache, $cache_real);
     }
 
-    function test_create_withDecoratorObject() {
+    public function test_create_withDecoratorObject()
+    {
         $this->factory->addDecorator(new HTMLPurifier_DefinitionCache_Decorator_Memory());
         $cache = $this->factory->create('Test', $this->config);
         $cache_real = new HTMLPurifier_DefinitionCache_Decorator_Memory();
@@ -38,26 +43,30 @@ class HTMLPurifier_DefinitionCacheFactoryTest extends HTMLPurifier_Harness
         $this->assertEqual($cache, $cache_real);
     }
 
-    function test_create_recycling() {
+    public function test_create_recycling()
+    {
         $cache  = $this->factory->create('Test', $this->config);
         $cache2 = $this->factory->create('Test', $this->config);
         $this->assertReference($cache, $cache2);
     }
 
-    function test_create_invalid() {
+    public function test_create_invalid()
+    {
         $this->config->set('Cache.DefinitionImpl', 'Invalid');
         $this->expectError('Unrecognized DefinitionCache Invalid, using Serializer instead');
         $cache = $this->factory->create('Test', $this->config);
         $this->assertIsA($cache, 'HTMLPurifier_DefinitionCache_Serializer');
     }
 
-    function test_null() {
+    public function test_null()
+    {
         $this->config->set('Cache.DefinitionImpl', null);
         $cache = $this->factory->create('Test', $this->config);
         $this->assertEqual($cache, new HTMLPurifier_DefinitionCache_Null('Test'));
     }
 
-    function test_register() {
+    public function test_register()
+    {
         generate_mock_once('HTMLPurifier_DefinitionCache');
         $this->config->set('Cache.DefinitionImpl', 'TestCache');
         $this->factory->register('TestCache', $class = 'HTMLPurifier_DefinitionCacheMock');

--- a/tests/HTMLPurifier/DefinitionCacheHarness.php
+++ b/tests/HTMLPurifier/DefinitionCacheHarness.php
@@ -8,7 +8,8 @@ class HTMLPurifier_DefinitionCacheHarness extends HTMLPurifier_Harness
      * to a getBatch() call
      * @param $values Values to return when getBatch is invoked
      */
-    protected function generateConfigMock($serial = 'defaultserial') {
+    protected function generateConfigMock($serial = 'defaultserial')
+    {
         generate_mock_once('HTMLPurifier_Config');
         $config = new HTMLPurifier_ConfigMock();
         $config->setReturnValue('getBatchSerial', $serial, array('Test'));
@@ -19,7 +20,8 @@ class HTMLPurifier_DefinitionCacheHarness extends HTMLPurifier_Harness
     /**
      * Returns an anonymous def that has been setup and named Test
      */
-    protected function generateDefinition($member_vars = array()) {
+    protected function generateDefinition($member_vars = array())
+    {
         $def = new HTMLPurifier_DefinitionTestable();
         $def->setup = true;
         $def->type  = 'Test';

--- a/tests/HTMLPurifier/DefinitionCacheTest.php
+++ b/tests/HTMLPurifier/DefinitionCacheTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_DefinitionCacheTest extends HTMLPurifier_Harness
 {
 
-    function test_isOld() {
+    public function test_isOld()
+    {
         // using null subclass because parent is abstract
         $cache = new HTMLPurifier_DefinitionCache_Null('Test');
 

--- a/tests/HTMLPurifier/DefinitionTest.php
+++ b/tests/HTMLPurifier/DefinitionTest.php
@@ -2,13 +2,15 @@
 
 class HTMLPurifier_DefinitionTest extends HTMLPurifier_Harness
 {
-    function test_setup() {
+    public function test_setup()
+    {
         $def = new HTMLPurifier_DefinitionTestable();
         $config = HTMLPurifier_Config::createDefault();
         $def->expectOnce('doSetup', array($config));
         $def->setup($config);
     }
-    function test_setup_redundant() {
+    public function test_setup_redundant()
+    {
         $def = new HTMLPurifier_DefinitionTestable();
         $config = HTMLPurifier_Config::createDefault();
         $def->expectNever('doSetup');

--- a/tests/HTMLPurifier/DoctypeRegistryTest.php
+++ b/tests/HTMLPurifier/DoctypeRegistryTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_DoctypeRegistryTest extends HTMLPurifier_Harness
 {
 
-    function test_register() {
-
+    public function test_register()
+    {
         $registry = new HTMLPurifier_DoctypeRegistry();
 
         $d = $registry->register(
@@ -30,8 +30,8 @@ class HTMLPurifier_DoctypeRegistryTest extends HTMLPurifier_Harness
 
     }
 
-    function test_get() {
-
+    public function test_get()
+    {
         // see also alias and register tests
 
         $registry = new HTMLPurifier_DoctypeRegistry();
@@ -45,8 +45,8 @@ class HTMLPurifier_DoctypeRegistryTest extends HTMLPurifier_Harness
 
     }
 
-    function testAliases() {
-
+    public function testAliases()
+    {
         $registry = new HTMLPurifier_DoctypeRegistry();
 
         $d1 = $registry->register('Doc1', true, array(), array(), array('1'));

--- a/tests/HTMLPurifier/ElementDefTest.php
+++ b/tests/HTMLPurifier/ElementDefTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_ElementDefTest extends HTMLPurifier_Harness
 {
 
-    function test_mergeIn() {
-
+    public function test_mergeIn()
+    {
         $def1 = new HTMLPurifier_ElementDef();
         $def2 = new HTMLPurifier_ElementDef();
         $def3 = new HTMLPurifier_ElementDef();

--- a/tests/HTMLPurifier/EncoderTest.php
+++ b/tests/HTMLPurifier/EncoderTest.php
@@ -5,18 +5,21 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
 
     protected $_entity_lookup;
 
-    function setUp() {
+    public function setUp()
+    {
         $this->_entity_lookup = HTMLPurifier_EntityLookup::instance();
         parent::setUp();
     }
 
-    function assertCleanUTF8($string, $expect = null) {
+    public function assertCleanUTF8($string, $expect = null)
+    {
         if ($expect === null) $expect = $string;
         $this->assertIdentical(HTMLPurifier_Encoder::cleanUTF8($string), $expect, 'iconv: %s');
         $this->assertIdentical(HTMLPurifier_Encoder::cleanUTF8($string, true), $expect, 'PHP: %s');
     }
 
-    function test_cleanUTF8() {
+    public function test_cleanUTF8()
+    {
         $this->assertCleanUTF8('Normal string.');
         $this->assertCleanUTF8("Test\tAllowed\nControl\rCharacters");
         $this->assertCleanUTF8("null byte: \0", 'null byte: ');
@@ -29,7 +32,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         $this->assertCleanUTF8("\xED\xB0\x80", '');
     }
 
-    function test_convertToUTF8_noConvert() {
+    public function test_convertToUTF8_noConvert()
+    {
         // UTF-8 means that we don't touch it
         $this->assertIdentical(
             HTMLPurifier_Encoder::convertToUTF8("\xF6", $this->config, $this->context),
@@ -38,7 +42,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_convertToUTF8_spuriousEncoding() {
+    public function test_convertToUTF8_spuriousEncoding()
+    {
         if (!HTMLPurifier_Encoder::iconvAvailable()) return;
         $this->config->set('Core.Encoding', 'utf99');
         $this->expectError('Invalid encoding utf99');
@@ -48,7 +53,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_convertToUTF8_iso8859_1() {
+    public function test_convertToUTF8_iso8859_1()
+    {
         $this->config->set('Core.Encoding', 'ISO-8859-1');
         $this->assertIdentical(
             HTMLPurifier_Encoder::convertToUTF8("\xF6", $this->config, $this->context),
@@ -56,7 +62,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_convertToUTF8_withoutIconv() {
+    public function test_convertToUTF8_withoutIconv()
+    {
         $this->config->set('Core.Encoding', 'ISO-8859-1');
         $this->config->set('Test.ForceNoIconv', true);
         $this->assertIdentical(
@@ -66,11 +73,13 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
 
     }
 
-    function getZhongWen() {
+    public function getZhongWen()
+    {
         return "\xE4\xB8\xAD\xE6\x96\x87 (Chinese)";
     }
 
-    function test_convertFromUTF8_utf8() {
+    public function test_convertFromUTF8_utf8()
+    {
         // UTF-8 means that we don't touch it
         $this->assertIdentical(
             HTMLPurifier_Encoder::convertFromUTF8("\xC3\xB6", $this->config, $this->context),
@@ -78,7 +87,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_convertFromUTF8_iso8859_1() {
+    public function test_convertFromUTF8_iso8859_1()
+    {
         $this->config->set('Core.Encoding', 'ISO-8859-1');
         $this->assertIdentical(
             HTMLPurifier_Encoder::convertFromUTF8("\xC3\xB6", $this->config, $this->context),
@@ -87,7 +97,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_convertFromUTF8_iconvNoChars() {
+    public function test_convertFromUTF8_iconvNoChars()
+    {
         if (!HTMLPurifier_Encoder::iconvAvailable()) return;
         $this->config->set('Core.Encoding', 'ISO-8859-1');
         $this->assertIdentical(
@@ -96,7 +107,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_convertFromUTF8_phpNormal() {
+    public function test_convertFromUTF8_phpNormal()
+    {
         // Plain PHP implementation has slightly different behavior
         $this->config->set('Core.Encoding', 'ISO-8859-1');
         $this->config->set('Test.ForceNoIconv', true);
@@ -107,7 +119,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_convertFromUTF8_phpNoChars() {
+    public function test_convertFromUTF8_phpNoChars()
+    {
         $this->config->set('Core.Encoding', 'ISO-8859-1');
         $this->config->set('Test.ForceNoIconv', true);
         $this->assertIdentical(
@@ -116,7 +129,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_convertFromUTF8_withProtection() {
+    public function test_convertFromUTF8_withProtection()
+    {
         // Preserve the characters!
         $this->config->set('Core.Encoding', 'ISO-8859-1');
         $this->config->set('Core.EscapeNonASCIICharacters', true);
@@ -126,7 +140,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_convertFromUTF8_withProtectionButUtf8() {
+    public function test_convertFromUTF8_withProtectionButUtf8()
+    {
         // Preserve the characters!
         $this->config->set('Core.EscapeNonASCIICharacters', true);
         $this->assertIdentical(
@@ -135,8 +150,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_convertToASCIIDumbLossless() {
-
+    public function test_convertToASCIIDumbLossless()
+    {
         // Uppercase thorn letter
         $this->assertIdentical(
             HTMLPurifier_Encoder::convertToASCIIDumbLossless("\xC3\x9Eorn"),
@@ -156,7 +171,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
 
     }
 
-    function assertASCIISupportCheck($enc, $ret) {
+    public function assertASCIISupportCheck($enc, $ret)
+    {
         $test = HTMLPurifier_Encoder::testEncodingSupportsASCII($enc, true);
         if ($test === false) return;
         $this->assertIdentical(
@@ -169,7 +185,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_testEncodingSupportsASCII() {
+    public function test_testEncodingSupportsASCII()
+    {
         if (HTMLPurifier_Encoder::iconvAvailable()) {
             $this->assertASCIISupportCheck('Shift_JIS', array("\xC2\xA5" => '\\', "\xE2\x80\xBE" => '~'));
             $this->assertASCIISupportCheck('JOHAB', array("\xE2\x82\xA9" => '\\'));
@@ -178,7 +195,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         $this->assertASCIISupportCheck('dontexist', array()); // canary
     }
 
-    function testShiftJIS() {
+    public function testShiftJIS()
+    {
         if (!HTMLPurifier_Encoder::iconvAvailable()) return;
         $this->config->set('Core.Encoding', 'Shift_JIS');
         // This actually looks like a Yen, but we're going to treat it differently
@@ -192,7 +210,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function testIconvTruncateBug() {
+    public function testIconvTruncateBug()
+    {
         if (!HTMLPurifier_Encoder::iconvAvailable()) return;
         if (HTMLPurifier_Encoder::testIconvTruncateBug() !== HTMLPurifier_Encoder::ICONV_TRUNCATES) return;
         $this->config->set('Core.Encoding', 'ISO-8859-1');
@@ -202,7 +221,8 @@ class HTMLPurifier_EncoderTest extends HTMLPurifier_Harness
         );
     }
 
-    function testIconvChunking() {
+    public function testIconvChunking()
+    {
         if (!HTMLPurifier_Encoder::iconvAvailable()) return;
         if (HTMLPurifier_Encoder::testIconvTruncateBug() !== HTMLPurifier_Encoder::ICONV_TRUNCATES) return;
         $this->assertIdentical(HTMLPurifier_Encoder::iconv('utf-8', 'iso-8859-1//IGNORE', "a\xF3\xA0\x80\xA0b", 4), 'ab');

--- a/tests/HTMLPurifier/EntityLookupTest.php
+++ b/tests/HTMLPurifier/EntityLookupTest.php
@@ -5,8 +5,8 @@
 class HTMLPurifier_EntityLookupTest extends HTMLPurifier_Harness
 {
 
-    function test() {
-
+    public function test()
+    {
         $lookup = HTMLPurifier_EntityLookup::instance();
 
         // latin char

--- a/tests/HTMLPurifier/EntityParserTest.php
+++ b/tests/HTMLPurifier/EntityParserTest.php
@@ -5,12 +5,14 @@ class HTMLPurifier_EntityParserTest extends HTMLPurifier_Harness
 
     protected $EntityParser;
 
-    public function setUp() {
+    public function setUp()
+    {
         $this->EntityParser = new HTMLPurifier_EntityParser();
         $this->_entity_lookup = HTMLPurifier_EntityLookup::instance();
     }
 
-    function test_substituteNonSpecialEntities() {
+    public function test_substituteNonSpecialEntities()
+    {
         $char_theta = $this->_entity_lookup->table['theta'];
         $this->assertIdentical($char_theta,
             $this->EntityParser->substituteNonSpecialEntities('&theta;') );
@@ -73,7 +75,8 @@ class HTMLPurifier_EntityParserTest extends HTMLPurifier_Harness
 
     }
 
-    function test_substituteSpecialEntities() {
+    public function test_substituteSpecialEntities()
+    {
         $this->assertIdentical(
             "'",
             $this->EntityParser->substituteSpecialEntities('&#39;')

--- a/tests/HTMLPurifier/ErrorCollectorEMock.php
+++ b/tests/HTMLPurifier/ErrorCollectorEMock.php
@@ -12,18 +12,22 @@ class HTMLPurifier_ErrorCollectorEMock extends HTMLPurifier_ErrorCollectorMock
     private $_expected_context = array();
     private $_expected_context_at = array();
 
-    public function prepare($context) {
+    public function prepare($context)
+    {
         $this->_context = $context;
     }
 
-    public function expectContext($key, $value) {
+    public function expectContext($key, $value)
+    {
         $this->_expected_context[$key] = $value;
     }
-    public function expectContextAt($step, $key, $value) {
+    public function expectContextAt($step, $key, $value)
+    {
         $this->_expected_context_at[$step][$key] = $value;
     }
 
-    public function send($v1, $v2) {
+    public function send($v1, $v2)
+    {
         // test for context
         $context = SimpleTest::getContext();
         $test = $context->getTest();

--- a/tests/HTMLPurifier/ErrorCollectorTest.php
+++ b/tests/HTMLPurifier/ErrorCollectorTest.php
@@ -9,7 +9,8 @@ class HTMLPurifier_ErrorCollectorTest extends HTMLPurifier_Harness
     protected $language, $generator, $line;
     protected $collector;
 
-    public function setup() {
+    public function setup()
+    {
         generate_mock_once('HTMLPurifier_Language');
         generate_mock_once('HTMLPurifier_Generator');
         parent::setup();
@@ -26,8 +27,8 @@ class HTMLPurifier_ErrorCollectorTest extends HTMLPurifier_Harness
         $this->collector = new HTMLPurifier_ErrorCollector($this->context);
     }
 
-    function test() {
-
+    public function test()
+    {
         $language = $this->language;
         $language->setReturnValue('getMessage',    'Message 1',   array('message-1'));
         $language->setReturnValue('formatMessage', 'Message 2',   array('message-2', array(1 => 'param')));
@@ -57,7 +58,8 @@ class HTMLPurifier_ErrorCollectorTest extends HTMLPurifier_Harness
 
     }
 
-    function testNoErrors() {
+    public function testNoErrors()
+    {
         $this->language->setReturnValue('getMessage', 'No errors', array('ErrorCollector: No errors'));
 
         $formatted_result = '<p>No errors</p>';
@@ -67,7 +69,8 @@ class HTMLPurifier_ErrorCollectorTest extends HTMLPurifier_Harness
         );
     }
 
-    function testNoLineNumbers() {
+    public function testNoLineNumbers()
+    {
         $this->language->setReturnValue('getMessage', 'Message 1', array('message-1'));
         $this->language->setReturnValue('getMessage', 'Message 2', array('message-2'));
 
@@ -88,8 +91,8 @@ class HTMLPurifier_ErrorCollectorTest extends HTMLPurifier_Harness
         */
     }
 
-    function testContextSubstitutions() {
-
+    public function testContextSubstitutions()
+    {
         $current_token = false;
         $this->context->register('CurrentToken', $current_token);
 
@@ -120,7 +123,8 @@ class HTMLPurifier_ErrorCollectorTest extends HTMLPurifier_Harness
     }
 
     /*
-    function testNestedErrors() {
+    public function testNestedErrors()
+    {
         $this->language->setReturnValue('getMessage', 'Message 1',   array('message-1'));
         $this->language->setReturnValue('getMessage', 'Message 2',   array('message-2'));
         $this->language->setReturnValue('formatMessage', 'End Message', array('end-message', array(1 => 'param')));

--- a/tests/HTMLPurifier/ErrorsHarness.php
+++ b/tests/HTMLPurifier/ErrorsHarness.php
@@ -10,7 +10,8 @@ class HTMLPurifier_ErrorsHarness extends HTMLPurifier_Harness
     protected $config, $context;
     protected $collector, $generator, $callCount;
 
-    public function setup() {
+    public function setup()
+    {
         $this->config = HTMLPurifier_Config::create(array('Core.CollectErrors' => true));
         $this->context = new HTMLPurifier_Context();
         generate_mock_once('HTMLPurifier_ErrorCollector');
@@ -20,16 +21,19 @@ class HTMLPurifier_ErrorsHarness extends HTMLPurifier_Harness
         $this->callCount = 0;
     }
 
-    protected function expectNoErrorCollection() {
+    protected function expectNoErrorCollection()
+    {
         $this->collector->expectNever('send');
     }
 
-    protected function expectErrorCollection() {
+    protected function expectErrorCollection()
+    {
         $args = func_get_args();
         $this->collector->expectOnce('send', $args);
     }
 
-    protected function expectContext($key, $value) {
+    protected function expectContext($key, $value)
+    {
         $this->collector->expectContext($key, $value);
     }
 

--- a/tests/HTMLPurifier/Filter/ExtractStyleBlocksTest.php
+++ b/tests/HTMLPurifier/Filter/ExtractStyleBlocksTest.php
@@ -7,7 +7,8 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
 {
 
     // usual use case:
-    function test_tokenizeHTML_extractStyleBlocks() {
+    public function test_tokenizeHTML_extractStyleBlocks()
+    {
         $this->config->set('Filter.ExtractStyleBlocks', true);
         $purifier = new HTMLPurifier($this->config);
         $result = $purifier->purify('<style type="text/css">.foo {text-align:center;bogus:remove-me;} body.class[foo="attr"] {text-align:right;}</style>Test<style>* {font-size:12pt;}</style>');
@@ -20,7 +21,8 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         );
     }
 
-    function assertExtractStyleBlocks($html, $expect = true, $styles = array()) {
+    public function assertExtractStyleBlocks($html, $expect = true, $styles = array())
+    {
         $filter = new HTMLPurifier_Filter_ExtractStyleBlocks(); // disable cleaning
         if ($expect === true) $expect = $html;
         $this->config->set('Filter.ExtractStyleBlocks.TidyImpl', false);
@@ -29,15 +31,18 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         $this->assertIdentical($this->context->get('StyleBlocks'), $styles);
     }
 
-    function test_extractStyleBlocks_preserve() {
+    public function test_extractStyleBlocks_preserve()
+    {
         $this->assertExtractStyleBlocks('Foobar');
     }
 
-    function test_extractStyleBlocks_allStyle() {
+    public function test_extractStyleBlocks_allStyle()
+    {
         $this->assertExtractStyleBlocks('<style>foo</style>', '', array('foo'));
     }
 
-    function test_extractStyleBlocks_multipleBlocks() {
+    public function test_extractStyleBlocks_multipleBlocks()
+    {
         $this->assertExtractStyleBlocks(
           "<style>1</style><style>2</style>NOP<style>4</style>",
           "NOP",
@@ -45,7 +50,8 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_extractStyleBlocks_blockWithAttributes() {
+    public function test_extractStyleBlocks_blockWithAttributes()
+    {
         $this->assertExtractStyleBlocks(
           '<style type="text/css">css</style>',
           '',
@@ -53,7 +59,8 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_extractStyleBlocks_styleWithPadding() {
+    public function test_extractStyleBlocks_styleWithPadding()
+    {
         $this->assertExtractStyleBlocks(
           "Alas<styled>Awesome</styled>\n<style>foo</style> Trendy!",
           "Alas<styled>Awesome</styled>\n Trendy!",
@@ -61,7 +68,8 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         );
     }
 
-    function assertCleanCSS($input, $expect = true) {
+    public function assertCleanCSS($input, $expect = true)
+    {
         $filter = new HTMLPurifier_Filter_ExtractStyleBlocks();
         if ($expect === true) $expect = $input;
         $this->normalize($input);
@@ -70,15 +78,18 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         $this->assertIdentical($result, $expect);
     }
 
-    function test_cleanCSS_malformed() {
+    public function test_cleanCSS_malformed()
+    {
         $this->assertCleanCSS('</style>', '');
     }
 
-    function test_cleanCSS_selector() {
+    public function test_cleanCSS_selector()
+    {
         $this->assertCleanCSS("a .foo #id div.cl#foo {\nfont-weight:700;\n}");
     }
 
-    function test_cleanCSS_angledBrackets() {
+    public function test_cleanCSS_angledBrackets()
+    {
         // [Content] No longer can smuggle in angled brackets using
         // font-family; when we add support for 'content', reinstate
         // this test.
@@ -88,7 +99,8 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         //);
     }
 
-    function test_cleanCSS_angledBrackets2() {
+    public function test_cleanCSS_angledBrackets2()
+    {
         // CSSTidy's behavior in this case is wrong, and should be fixed
         //$this->assertCleanCSS(
         //    "span[title=\"</style>\"] {\nfont-size:12pt;\n}",
@@ -96,18 +108,21 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         //);
     }
 
-    function test_cleanCSS_bogus() {
+    public function test_cleanCSS_bogus()
+    {
         $this->assertCleanCSS("div {bogus:tree;}", "div {\n}");
     }
 
     /* [CONTENT]
-    function test_cleanCSS_escapeCodes() {
+    public function test_cleanCSS_escapeCodes()
+    {
         $this->assertCleanCSS(
             ".class {\nfont-family:\"\\3C /style\\3E \";\n}"
         );
     }
 
-    function test_cleanCSS_noEscapeCodes() {
+    public function test_cleanCSS_noEscapeCodes()
+    {
         $this->config->set('Filter.ExtractStyleBlocks.Escaping', false);
         $this->assertCleanCSS(
             ".class {\nfont-family:\"</style>\";\n}"
@@ -115,7 +130,8 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
     }
      */
 
-    function test_cleanCSS_scope() {
+    public function test_cleanCSS_scope()
+    {
         $this->config->set('Filter.ExtractStyleBlocks.Scope', '#foo');
         $this->assertCleanCSS(
             "p {\ntext-indent:1em;\n}",
@@ -123,7 +139,8 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_cleanCSS_scopeWithSelectorCommas() {
+    public function test_cleanCSS_scopeWithSelectorCommas()
+    {
         $this->config->set('Filter.ExtractStyleBlocks.Scope', '#foo');
         $this->assertCleanCSS(
             "b, i {\ntext-decoration:underline;\n}",
@@ -131,17 +148,20 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_cleanCSS_scopeWithNaughtySelector() {
+    public function test_cleanCSS_scopeWithNaughtySelector()
+    {
         $this->config->set('Filter.ExtractStyleBlocks.Scope', '#foo');
         $this->assertCleanCSS("  + p {\ntext-indent:1em;\n}", '');
     }
 
-    function test_cleanCSS_scopeWithMultipleNaughtySelectors() {
+    public function test_cleanCSS_scopeWithMultipleNaughtySelectors()
+    {
         $this->config->set('Filter.ExtractStyleBlocks.Scope', '#foo');
         $this->assertCleanCSS("  ++ ++ p {\ntext-indent:1em;\n}", '');
     }
 
-    function test_cleanCSS_scopeWithCommas() {
+    public function test_cleanCSS_scopeWithCommas()
+    {
         $this->config->set('Filter.ExtractStyleBlocks.Scope', '#foo, .bar');
         $this->assertCleanCSS(
             "p {\ntext-indent:1em;\n}",
@@ -149,7 +169,8 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_cleanCSS_scopeAllWithCommas() {
+    public function test_cleanCSS_scopeAllWithCommas()
+    {
         $this->config->set('Filter.ExtractStyleBlocks.Scope', '#foo, .bar');
         $this->assertCleanCSS(
             "p, div {\ntext-indent:1em;\n}",
@@ -157,7 +178,8 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_cleanCSS_scopeWithConflicts() {
+    public function test_cleanCSS_scopeWithConflicts()
+    {
         $this->config->set('Filter.ExtractStyleBlocks.Scope', 'p');
         $this->assertCleanCSS(
 "div {
@@ -178,7 +200,8 @@ text-align:left;
         );
     }
 
-    function test_removeComments() {
+    public function test_removeComments()
+    {
         $this->assertCleanCSS(
 "<!--
 div {
@@ -191,7 +214,8 @@ text-align:right;
         );
     }
 
-    function test_atSelector() {
+    public function test_atSelector()
+    {
         $this->assertCleanCSS(
 "{
     b { text-align: center; }
@@ -200,7 +224,8 @@ text-align:right;
             );
     }
 
-    function test_selectorValidation() {
+    public function test_selectorValidation()
+    {
         $this->assertCleanCSS(
 "&, & {
 text-align: center;
@@ -226,7 +251,8 @@ text-align:center;
         $this->assertCleanCSS("doesnt-exist { text-align:center }", "");
     }
 
-    function test_cleanCSS_caseSensitive() {
+    public function test_cleanCSS_caseSensitive()
+    {
         $this->assertCleanCSS("a .foo #ID div.cl#foo {\nbackground:url(\"http://foo/BAR\");\n}");
     }
 

--- a/tests/HTMLPurifier/GeneratorTest.php
+++ b/tests/HTMLPurifier/GeneratorTest.php
@@ -8,12 +8,14 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
      */
     private $_entity_lookup;
 
-    public function __construct() {
+    public function __construct()
+    {
         parent::__construct();
         $this->_entity_lookup = HTMLPurifier_EntityLookup::instance();
     }
 
-    public function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->config->set('Output.Newline', "\n");
     }
@@ -21,24 +23,28 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
     /**
      * Creates a generator based on config and context member variables.
      */
-    protected function createGenerator() {
+    protected function createGenerator()
+    {
         return new HTMLPurifier_Generator($this->config, $this->context);
     }
 
-    protected function assertGenerateFromToken($token, $html) {
+    protected function assertGenerateFromToken($token, $html)
+    {
         $generator = $this->createGenerator();
         $result = $generator->generateFromToken($token);
         $this->assertIdentical($result, $html);
     }
 
-    function test_generateFromToken_text() {
+    public function test_generateFromToken_text()
+    {
         $this->assertGenerateFromToken(
             new HTMLPurifier_Token_Text('Foobar.<>'),
             'Foobar.&lt;&gt;'
         );
     }
 
-    function test_generateFromToken_startWithAttr() {
+    public function test_generateFromToken_startWithAttr()
+    {
         $this->assertGenerateFromToken(
             new HTMLPurifier_Token_Start('a',
                 array('href' => 'dyn?a=foo&b=bar')
@@ -47,14 +53,16 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_generateFromToken_end() {
+    public function test_generateFromToken_end()
+    {
         $this->assertGenerateFromToken(
             new HTMLPurifier_Token_End('b'),
             '</b>'
         );
     }
 
-    function test_generateFromToken_emptyWithAttr() {
+    public function test_generateFromToken_emptyWithAttr()
+    {
         $this->assertGenerateFromToken(
             new HTMLPurifier_Token_Empty('br',
                 array('style' => 'font-family:"Courier New";')
@@ -63,26 +71,30 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_generateFromToken_startNoAttr() {
+    public function test_generateFromToken_startNoAttr()
+    {
         $this->assertGenerateFromToken(
             new HTMLPurifier_Token_Start('asdf'),
             '<asdf>'
         );
     }
 
-    function test_generateFromToken_emptyNoAttr() {
+    public function test_generateFromToken_emptyNoAttr()
+    {
         $this->assertGenerateFromToken(
             new HTMLPurifier_Token_Empty('br'),
             '<br />'
         );
     }
 
-    function test_generateFromToken_error() {
+    public function test_generateFromToken_error()
+    {
         $this->expectError('Cannot generate HTML from non-HTMLPurifier_Token object');
         $this->assertGenerateFromToken( null, '' );
     }
 
-    function test_generateFromToken_unicode() {
+    public function test_generateFromToken_unicode()
+    {
         $theta_char = $this->_entity_lookup->table['theta'];
         $this->assertGenerateFromToken(
             new HTMLPurifier_Token_Text($theta_char),
@@ -90,14 +102,16 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_generateFromToken_backtick() {
+    public function test_generateFromToken_backtick()
+    {
         $this->assertGenerateFromToken(
             new HTMLPurifier_Token_Start('img', array('alt' => '`foo')),
             '<img alt="`foo ">'
         );
     }
 
-    function test_generateFromToken_backtickDisabled() {
+    public function test_generateFromToken_backtickDisabled()
+    {
         $this->config->set('Output.FixInnerHTML', false);
         $this->assertGenerateFromToken(
             new HTMLPurifier_Token_Start('img', array('alt' => '`')),
@@ -105,52 +119,60 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_generateFromToken_backtickNoChange() {
+    public function test_generateFromToken_backtickNoChange()
+    {
         $this->assertGenerateFromToken(
             new HTMLPurifier_Token_Start('img', array('alt' => '`foo` bar')),
             '<img alt="`foo` bar">'
         );
     }
 
-    function assertGenerateAttributes($attr, $expect, $element = false) {
+    public function assertGenerateAttributes($attr, $expect, $element = false)
+    {
         $generator = $this->createGenerator();
         $result = $generator->generateAttributes($attr, $element);
         $this->assertIdentical($result, $expect);
     }
 
-    function test_generateAttributes_blank() {
+    public function test_generateAttributes_blank()
+    {
         $this->assertGenerateAttributes(array(), '');
     }
 
-    function test_generateAttributes_basic() {
+    public function test_generateAttributes_basic()
+    {
         $this->assertGenerateAttributes(
             array('href' => 'dyn?a=foo&b=bar'),
             'href="dyn?a=foo&amp;b=bar"'
         );
     }
 
-    function test_generateAttributes_doubleQuote() {
+    public function test_generateAttributes_doubleQuote()
+    {
         $this->assertGenerateAttributes(
             array('style' => 'font-family:"Courier New";'),
             'style="font-family:&quot;Courier New&quot;;"'
         );
     }
 
-    function test_generateAttributes_singleQuote() {
+    public function test_generateAttributes_singleQuote()
+    {
         $this->assertGenerateAttributes(
             array('style' => 'font-family:\'Courier New\';'),
             'style="font-family:\'Courier New\';"'
         );
     }
 
-    function test_generateAttributes_multiple() {
+    public function test_generateAttributes_multiple()
+    {
         $this->assertGenerateAttributes(
             array('src' => 'picture.jpg', 'alt' => 'Short & interesting'),
             'src="picture.jpg" alt="Short &amp; interesting"'
         );
     }
 
-    function test_generateAttributes_specialChar() {
+    public function test_generateAttributes_specialChar()
+    {
         $theta_char = $this->_entity_lookup->table['theta'];
         $this->assertGenerateAttributes(
             array('title' => 'Theta is ' . $theta_char),
@@ -159,15 +181,16 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
     }
 
 
-    function test_generateAttributes_minimized() {
+    public function test_generateAttributes_minimized()
+    {
         $this->config->set('HTML.Doctype', 'HTML 4.01 Transitional');
         $this->assertGenerateAttributes(
             array('compact' => 'compact'), 'compact', 'menu'
         );
     }
 
-    function test_generateFromTokens() {
-
+    public function test_generateFromTokens()
+    {
         $this->assertGeneration(
             array(
                 new HTMLPurifier_Token_Start('b'),
@@ -179,13 +202,15 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
 
     }
 
-    protected function assertGeneration($tokens, $expect) {
+    protected function assertGeneration($tokens, $expect)
+    {
         $generator = new HTMLPurifier_Generator($this->config, $this->context);
         $result = $generator->generateFromTokens($tokens);
         $this->assertIdentical($expect, $result);
     }
 
-    function test_generateFromTokens_Scripting() {
+    public function test_generateFromTokens_Scripting()
+    {
         $this->assertGeneration(
             array(
                 new HTMLPurifier_Token_Start('script'),
@@ -196,7 +221,8 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_generateFromTokens_Scripting_missingCloseTag() {
+    public function test_generateFromTokens_Scripting_missingCloseTag()
+    {
         $this->assertGeneration(
             array(
                 new HTMLPurifier_Token_Start('script'),
@@ -206,7 +232,8 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_generateFromTokens_Scripting_doubleBlock() {
+    public function test_generateFromTokens_Scripting_doubleBlock()
+    {
         $this->assertGeneration(
             array(
                 new HTMLPurifier_Token_Start('script'),
@@ -218,7 +245,8 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_generateFromTokens_Scripting_disableWrapper() {
+    public function test_generateFromTokens_Scripting_disableWrapper()
+    {
         $this->config->set('Output.CommentScriptContents', false);
         $this->assertGeneration(
             array(
@@ -230,7 +258,8 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_generateFromTokens_XHTMLoff() {
+    public function test_generateFromTokens_XHTMLoff()
+    {
         $this->config->set('HTML.XHTML', false);
 
         // omit trailing slash
@@ -251,7 +280,8 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
 
     }
 
-    function test_generateFromTokens_TidyFormat() {
+    public function test_generateFromTokens_TidyFormat()
+    {
         // abort test if tidy isn't loaded
         if (!extension_loaded('tidy')) return;
 
@@ -273,7 +303,8 @@ class HTMLPurifier_GeneratorTest extends HTMLPurifier_Harness
 
     }
 
-    function test_generateFromTokens_sortAttr() {
+    public function test_generateFromTokens_sortAttr()
+    {
         $this->config->set('Output.SortAttr', true);
 
         $this->assertGeneration(

--- a/tests/HTMLPurifier/HTMLDefinitionTest.php
+++ b/tests/HTMLPurifier/HTMLDefinitionTest.php
@@ -3,15 +3,16 @@
 class HTMLPurifier_HTMLDefinitionTest extends HTMLPurifier_Harness
 {
 
-    function expectError($error = false, $message = '%s') {
+    public function expectError($error = false, $message = '%s')
+    {
         // Because we're testing a definition, it's vital that the cache
         // is turned off for tests that expect errors.
         $this->config->set('Cache.DefinitionImpl', null);
         parent::expectError($error);
     }
 
-    function test_parseTinyMCEAllowedList() {
-
+    public function test_parseTinyMCEAllowedList()
+    {
         $def = new HTMLPurifier_HTMLDefinition();
 
         // note: this is case-sensitive, but its config schema
@@ -67,8 +68,8 @@ a[href|title]
 
     }
 
-    function test_Allowed() {
-
+    public function test_Allowed()
+    {
         $config1 = HTMLPurifier_Config::create(array(
             'HTML.AllowedElements' => array('b', 'i', 'p', 'a'),
             'HTML.AllowedAttributes' => array('a@href', '*@id')
@@ -82,83 +83,97 @@ a[href|title]
 
     }
 
-    function assertPurification_AllowedElements_p() {
+    public function assertPurification_AllowedElements_p()
+    {
         $this->assertPurification('<p><b>Jelly</b></p>', '<p>Jelly</p>');
     }
 
-    function test_AllowedElements() {
+    public function test_AllowedElements()
+    {
         $this->config->set('HTML.AllowedElements', 'p');
         $this->assertPurification_AllowedElements_p();
     }
 
-    function test_AllowedElements_multiple() {
+    public function test_AllowedElements_multiple()
+    {
         $this->config->set('HTML.AllowedElements', 'p,div');
         $this->assertPurification('<div><p><b>Jelly</b></p></div>', '<div><p>Jelly</p></div>');
     }
 
-    function test_AllowedElements_invalidElement() {
+    public function test_AllowedElements_invalidElement()
+    {
         $this->config->set('HTML.AllowedElements', 'obviously_invalid,p');
         $this->expectError(new PatternExpectation("/Element 'obviously_invalid' is not supported/"));
         $this->assertPurification_AllowedElements_p();
     }
 
-    function test_AllowedElements_invalidElement_xssAttempt() {
+    public function test_AllowedElements_invalidElement_xssAttempt()
+    {
         $this->config->set('HTML.AllowedElements', '<script>,p');
         $this->expectError(new PatternExpectation("/Element '&lt;script&gt;' is not supported/"));
         $this->assertPurification_AllowedElements_p();
     }
 
-    function test_AllowedElements_multipleInvalidElements() {
+    public function test_AllowedElements_multipleInvalidElements()
+    {
         $this->config->set('HTML.AllowedElements', 'dr-wiggles,dr-pepper,p');
         $this->expectError(new PatternExpectation("/Element 'dr-wiggles' is not supported/"));
         $this->expectError(new PatternExpectation("/Element 'dr-pepper' is not supported/"));
         $this->assertPurification_AllowedElements_p();
     }
 
-    function assertPurification_AllowedAttributes_global_style() {
+    public function assertPurification_AllowedAttributes_global_style()
+    {
         $this->assertPurification(
             '<p style="font-weight:bold;" class="foo">Jelly</p><br style="clear:both;" />',
             '<p style="font-weight:bold;">Jelly</p><br style="clear:both;" />');
     }
 
-    function test_AllowedAttributes_global_preferredSyntax() {
+    public function test_AllowedAttributes_global_preferredSyntax()
+    {
         $this->config->set('HTML.AllowedElements', array('p', 'br'));
         $this->config->set('HTML.AllowedAttributes', 'style');
         $this->assertPurification_AllowedAttributes_global_style();
     }
 
-    function test_AllowedAttributes_global_verboseSyntax() {
+    public function test_AllowedAttributes_global_verboseSyntax()
+    {
         $this->config->set('HTML.AllowedElements', array('p', 'br'));
         $this->config->set('HTML.AllowedAttributes', '*@style');
         $this->assertPurification_AllowedAttributes_global_style();
     }
 
-    function test_AllowedAttributes_global_discouragedSyntax() {
+    public function test_AllowedAttributes_global_discouragedSyntax()
+    {
         // Emit errors eventually
         $this->config->set('HTML.AllowedElements', array('p', 'br'));
         $this->config->set('HTML.AllowedAttributes', '*.style');
         $this->assertPurification_AllowedAttributes_global_style();
     }
 
-    function assertPurification_AllowedAttributes_local_p_style() {
+    public function assertPurification_AllowedAttributes_local_p_style()
+    {
         $this->assertPurification(
             '<p style="font-weight:bold;" class="foo">Jelly</p><br style="clear:both;" />',
             '<p style="font-weight:bold;">Jelly</p><br />');
     }
 
-    function test_AllowedAttributes_local_preferredSyntax() {
+    public function test_AllowedAttributes_local_preferredSyntax()
+    {
         $this->config->set('HTML.AllowedElements', array('p', 'br'));
         $this->config->set('HTML.AllowedAttributes', 'p@style');
         $this->assertPurification_AllowedAttributes_local_p_style();
     }
 
-    function test_AllowedAttributes_local_discouragedSyntax() {
+    public function test_AllowedAttributes_local_discouragedSyntax()
+    {
         $this->config->set('HTML.AllowedElements', array('p', 'br'));
         $this->config->set('HTML.AllowedAttributes', 'p.style');
         $this->assertPurification_AllowedAttributes_local_p_style();
     }
 
-    function test_AllowedAttributes_multiple() {
+    public function test_AllowedAttributes_multiple()
+    {
         $this->config->set('HTML.AllowedElements', array('p', 'br'));
         $this->config->set('HTML.AllowedAttributes', 'p@style,br@class,title');
         $this->assertPurification(
@@ -167,34 +182,39 @@ a[href|title]
         );
     }
 
-    function test_AllowedAttributes_local_invalidAttribute() {
+    public function test_AllowedAttributes_local_invalidAttribute()
+    {
         $this->config->set('HTML.AllowedElements', array('p', 'br'));
         $this->config->set('HTML.AllowedAttributes', array('p@style', 'p@<foo>'));
         $this->expectError(new PatternExpectation("/Attribute '&lt;foo&gt;' in element 'p' not supported/"));
         $this->assertPurification_AllowedAttributes_local_p_style();
     }
 
-    function test_AllowedAttributes_global_invalidAttribute() {
+    public function test_AllowedAttributes_global_invalidAttribute()
+    {
         $this->config->set('HTML.AllowedElements', array('p', 'br'));
         $this->config->set('HTML.AllowedAttributes', array('style', '<foo>'));
         $this->expectError(new PatternExpectation("/Global attribute '&lt;foo&gt;' is not supported in any elements/"));
         $this->assertPurification_AllowedAttributes_global_style();
     }
 
-    function test_AllowedAttributes_local_invalidAttributeDueToMissingElement() {
+    public function test_AllowedAttributes_local_invalidAttributeDueToMissingElement()
+    {
         $this->config->set('HTML.AllowedElements', array('p', 'br'));
         $this->config->set('HTML.AllowedAttributes', 'p.style,foo.style');
         $this->expectError(new PatternExpectation("/Cannot allow attribute 'style' if element 'foo' is not allowed\/supported/"));
         $this->assertPurification_AllowedAttributes_local_p_style();
     }
 
-    function test_AllowedAttributes_duplicate() {
+    public function test_AllowedAttributes_duplicate()
+    {
         $this->config->set('HTML.AllowedElements', array('p', 'br'));
         $this->config->set('HTML.AllowedAttributes', 'p.style,p@style');
         $this->assertPurification_AllowedAttributes_local_p_style();
     }
 
-    function test_AllowedAttributes_multipleErrors() {
+    public function test_AllowedAttributes_multipleErrors()
+    {
         $this->config->set('HTML.AllowedElements', array('p', 'br'));
         $this->config->set('HTML.AllowedAttributes', 'p.style,foo.style,<foo>');
         $this->expectError(new PatternExpectation("/Cannot allow attribute 'style' if element 'foo' is not allowed\/supported/"));
@@ -202,58 +222,67 @@ a[href|title]
         $this->assertPurification_AllowedAttributes_local_p_style();
     }
 
-    function test_ForbiddenElements() {
+    public function test_ForbiddenElements()
+    {
         $this->config->set('HTML.ForbiddenElements', 'b');
         $this->assertPurification('<b>b</b><i>i</i>', 'b<i>i</i>');
     }
 
-    function test_ForbiddenElements_invalidElement() {
+    public function test_ForbiddenElements_invalidElement()
+    {
         $this->config->set('HTML.ForbiddenElements', 'obviously_incorrect');
         // no error!
         $this->assertPurification('<i>i</i>');
     }
 
-    function assertPurification_ForbiddenAttributes_b_style() {
+    public function assertPurification_ForbiddenAttributes_b_style()
+    {
         $this->assertPurification(
             '<b style="float:left;">b</b><i style="float:left;">i</i>',
             '<b>b</b><i style="float:left;">i</i>');
     }
 
-    function test_ForbiddenAttributes() {
+    public function test_ForbiddenAttributes()
+    {
         $this->config->set('HTML.ForbiddenAttributes', 'b@style');
         $this->assertPurification_ForbiddenAttributes_b_style();
     }
 
-    function test_ForbiddenAttributes_incorrectSyntax() {
+    public function test_ForbiddenAttributes_incorrectSyntax()
+    {
         $this->config->set('HTML.ForbiddenAttributes', 'b.style');
         $this->expectError("Error with b.style: tag.attr syntax not supported for HTML.ForbiddenAttributes; use tag@attr instead");
         $this->assertPurification('<b style="float:left;">Test</b>');
     }
 
-    function test_ForbiddenAttributes_incorrectGlobalSyntax() {
+    public function test_ForbiddenAttributes_incorrectGlobalSyntax()
+    {
         $this->config->set('HTML.ForbiddenAttributes', '*.style');
         $this->expectError("Error with *.style: *.attr syntax not supported for HTML.ForbiddenAttributes; use attr instead");
         $this->assertPurification('<b style="float:left;">Test</b>');
     }
 
-    function assertPurification_ForbiddenAttributes_style() {
+    public function assertPurification_ForbiddenAttributes_style()
+    {
         $this->assertPurification(
             '<b class="foo" style="float:left;">b</b><i style="float:left;">i</i>',
             '<b class="foo">b</b><i>i</i>');
     }
 
-    function test_ForbiddenAttributes_global() {
+    public function test_ForbiddenAttributes_global()
+    {
         $this->config->set('HTML.ForbiddenAttributes', 'style');
         $this->assertPurification_ForbiddenAttributes_style();
     }
 
-    function test_ForbiddenAttributes_globalVerboseFormat() {
+    public function test_ForbiddenAttributes_globalVerboseFormat()
+    {
         $this->config->set('HTML.ForbiddenAttributes', '*@style');
         $this->assertPurification_ForbiddenAttributes_style();
     }
 
-    function test_addAttribute() {
-
+    public function test_addAttribute()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $def = $config->getHTMLDefinition(true);
         $def->addAttribute('span', 'custom', 'Enum#attribute');
@@ -265,8 +294,8 @@ a[href|title]
 
     }
 
-    function test_addAttribute_multiple() {
-
+    public function test_addAttribute_multiple()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $def = $config->getHTMLDefinition(true);
         $def->addAttribute('span', 'custom', 'Enum#attribute');
@@ -279,8 +308,8 @@ a[href|title]
 
     }
 
-    function test_addElement() {
-
+    public function test_addElement()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $def = $config->getHTMLDefinition(true);
         $def->addElement('marquee', 'Inline', 'Inline', 'Common', array('width' => 'Length'));
@@ -292,7 +321,8 @@ a[href|title]
 
     }
 
-    function test_injector() {
+    public function test_injector()
+    {
         generate_mock_once('HTMLPurifier_Injector');
         $injector = new HTMLPurifier_InjectorMock();
         $injector->name = 'MyInjector';
@@ -308,7 +338,8 @@ a[href|title]
         );
     }
 
-    function test_injectorMissingNeeded() {
+    public function test_injectorMissingNeeded()
+    {
         generate_mock_once('HTMLPurifier_Injector');
         $injector = new HTMLPurifier_InjectorMock();
         $injector->name = 'MyInjector';
@@ -322,7 +353,8 @@ a[href|title]
         );
     }
 
-    function test_injectorIntegration() {
+    public function test_injectorIntegration()
+    {
         $module = $this->config->getHTMLDefinition(true)->getAnonymousModule();
         $module->info_injector[] = 'Linkify';
 
@@ -332,7 +364,8 @@ a[href|title]
         );
     }
 
-    function test_injectorIntegrationFail() {
+    public function test_injectorIntegrationFail()
+    {
         $this->config->set('HTML.Allowed', 'p');
 
         $module = $this->config->getHTMLDefinition(true)->getAnonymousModule();
@@ -344,7 +377,8 @@ a[href|title]
         );
     }
 
-    function test_notAllowedRequiredAttributeError() {
+    public function test_notAllowedRequiredAttributeError()
+    {
         $this->expectError("Required attribute 'src' in element 'img' was not allowed, which means 'img' will not be allowed either");
         $this->config->set('HTML.Allowed', 'img[alt]');
         $this->config->getHTMLDefinition();

--- a/tests/HTMLPurifier/HTMLModule/FormsTest.php
+++ b/tests/HTMLPurifier/HTMLModule/FormsTest.php
@@ -3,13 +3,15 @@
 class HTMLPurifier_HTMLModule_FormsTest extends HTMLPurifier_HTMLModuleHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->config->set('HTML.Trusted', true);
         $this->config->set('Attr.EnableID', true);
     }
 
-    function testBasicUse() {
+    public function testBasicUse()
+    {
         $this->config->set('HTML.Doctype', 'HTML 4.01 Strict');
         $this->assertResult( // need support for label for later
             '
@@ -29,7 +31,8 @@ class HTMLPurifier_HTMLModule_FormsTest extends HTMLPurifier_HTMLModuleHarness
         );
     }
 
-    function testSelectOption() {
+    public function testSelectOption()
+    {
         $this->config->set('HTML.Doctype', 'HTML 4.01 Strict');
         $this->assertResult('
 <form action="http://somesite.com/prog/component-select" method="post">
@@ -49,7 +52,8 @@ class HTMLPurifier_HTMLModule_FormsTest extends HTMLPurifier_HTMLModuleHarness
         ');
     }
 
-    function testSelectOptgroup() {
+    public function testSelectOptgroup()
+    {
         $this->config->set('HTML.Doctype', 'HTML 4.01 Strict');
         $this->assertResult('
 <form action="http://somesite.com/prog/someprog" method="post">
@@ -75,7 +79,8 @@ class HTMLPurifier_HTMLModule_FormsTest extends HTMLPurifier_HTMLModuleHarness
         ');
     }
 
-    function testTextarea() {
+    public function testTextarea()
+    {
         $this->config->set('HTML.Doctype', 'HTML 4.01 Strict');
         $this->assertResult('
 <form action="http://somesite.com/prog/text-read" method="post">
@@ -92,7 +97,8 @@ class HTMLPurifier_HTMLModule_FormsTest extends HTMLPurifier_HTMLModuleHarness
 
     // label tests omitted
 
-    function testFieldset() {
+    public function testFieldset()
+    {
         $this->config->set('HTML.Doctype', 'HTML 4.01 Strict');
         $this->assertResult('
 <form action="..." method="post">
@@ -125,27 +131,32 @@ class HTMLPurifier_HTMLModule_FormsTest extends HTMLPurifier_HTMLModuleHarness
         ');
     }
 
-    function testInputTransform() {
+    public function testInputTransform()
+    {
         $this->config->set('HTML.Doctype', 'XHTML 1.0 Strict');
         $this->assertResult('<input type="checkbox" />', '<input type="checkbox" value="" />');
     }
 
-    function testTextareaTransform() {
+    public function testTextareaTransform()
+    {
         $this->config->set('HTML.Doctype', 'HTML 4.01 Strict');
         $this->assertResult('<textarea></textarea>', '<textarea cols="22" rows="3"></textarea>');
     }
 
-    function testTextInFieldset() {
+    public function testTextInFieldset()
+    {
         $this->config->set('HTML.Doctype', 'HTML 4.01 Strict');
         $this->assertResult('<fieldset>   <legend></legend>foo</fieldset>');
     }
 
-    function testStrict() {
+    public function testStrict()
+    {
         $this->config->set('HTML.Doctype', 'HTML 4.01 Strict');
         $this->assertResult('<form action=""></form>', '');
     }
 
-    function testLegacy() {
+    public function testLegacy()
+    {
         $this->assertResult('<form action=""></form>');
         $this->assertResult('<form action=""><input align="left" /></form>');
     }

--- a/tests/HTMLPurifier/HTMLModule/ImageTest.php
+++ b/tests/HTMLPurifier/HTMLModule/ImageTest.php
@@ -4,25 +4,29 @@ class HTMLPurifier_HTMLModule_ImageTest extends HTMLPurifier_HTMLModuleHarness
 {
 
 
-    function testNormal() {
+    public function testNormal()
+    {
         $this->assertResult('<img height="40" width="40" src="" alt="" />');
     }
 
-    function testLengthTooLarge() {
+    public function testLengthTooLarge()
+    {
         $this->assertResult(
             '<img height="40000" width="40000" src="" alt="" />',
             '<img height="1200" width="1200" src="" alt="" />'
         );
     }
 
-    function testLengthPercentage() {
+    public function testLengthPercentage()
+    {
         $this->assertResult(
             '<img height="100%" width="100%" src="" alt="" />',
             '<img src="" alt="" />'
         );
     }
 
-    function testLengthCustomMax() {
+    public function testLengthCustomMax()
+    {
         $this->config->set('HTML.MaxImgLength', 20);
         $this->assertResult(
             '<img height="30" width="30" src="" alt="" />',
@@ -30,7 +34,8 @@ class HTMLPurifier_HTMLModule_ImageTest extends HTMLPurifier_HTMLModuleHarness
         );
     }
 
-    function testLengthCrashFixDisabled() {
+    public function testLengthCrashFixDisabled()
+    {
         $this->config->set('HTML.MaxImgLength', null);
         $this->assertResult(
             '<img height="100%" width="100%" src="" alt="" />'
@@ -40,7 +45,8 @@ class HTMLPurifier_HTMLModule_ImageTest extends HTMLPurifier_HTMLModuleHarness
         );
     }
 
-    function testLengthTrusted() {
+    public function testLengthTrusted()
+    {
         $this->config->set('HTML.Trusted', true);
         $this->assertResult(
             '<img height="100%" width="100%" src="" alt="" />'

--- a/tests/HTMLPurifier/HTMLModule/NameTest.php
+++ b/tests/HTMLPurifier/HTMLModule/NameTest.php
@@ -3,25 +3,29 @@
 class HTMLPurifier_HTMLModule_NameTest extends HTMLPurifier_HTMLModuleHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
     }
 
-    function testBasicUse() {
+    public function testBasicUse()
+    {
         $this->config->set('Attr.EnableID', true);
         $this->assertResult(
             '<a name="foo">bar</a>'
         );
     }
 
-    function testCDATA() {
+    public function testCDATA()
+    {
         $this->config->set('HTML.Attr.Name.UseCDATA', true);
         $this->assertResult(
             '<a name="2">Baz</a><a name="2">Bar</a>'
         );
     }
 
-    function testCDATAWithHeavyTidy() {
+    public function testCDATAWithHeavyTidy()
+    {
         $this->config->set('HTML.Attr.Name.UseCDATA', true);
         $this->config->set('HTML.TidyLevel', 'heavy');
         $this->assertResult('<a name="2">Baz</a>');

--- a/tests/HTMLPurifier/HTMLModule/NofollowTest.php
+++ b/tests/HTMLPurifier/HTMLModule/NofollowTest.php
@@ -3,20 +3,23 @@
 class HTMLPurifier_HTMLModule_NofollowTest extends HTMLPurifier_HTMLModuleHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->config->set('HTML.Nofollow', true);
         $this->config->set('Attr.AllowedRel', array("nofollow", "blah"));
     }
 
-    function testNofollow() {
+    public function testNofollow()
+    {
         $this->assertResult(
             '<a href="http://google.com">x</a><a href="http://google.com" rel="blah">a</a><a href="/local">b</a><a href="mailto:foo@example.com">c</a>',
             '<a href="http://google.com" rel="nofollow">x</a><a href="http://google.com" rel="blah nofollow">a</a><a href="/local">b</a><a href="mailto:foo@example.com">c</a>'
         );
     }
 
-    function testNofollowDupe() {
+    public function testNofollowDupe()
+    {
         $this->assertResult(
             '<a href="http://google.com" rel="nofollow">x</a><a href="http://google.com" rel="blah nofollow">a</a><a href="/local">b</a><a href="mailto:foo@example.com">c</a>'
         );

--- a/tests/HTMLPurifier/HTMLModule/ObjectTest.php
+++ b/tests/HTMLPurifier/HTMLModule/ObjectTest.php
@@ -3,23 +3,27 @@
 class HTMLPurifier_HTMLModule_ObjectTest extends HTMLPurifier_HTMLModuleHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->config->set('HTML.Trusted', true);
     }
 
-    function testDefaultRemoval() {
+    public function testDefaultRemoval()
+    {
         $this->config->set('HTML.Trusted', false);
         $this->assertResult(
             '<object></object>', ''
         );
     }
 
-    function testMinimal() {
+    public function testMinimal()
+    {
         $this->assertResult('<object></object>');
     }
 
-    function testStandardUseCase() {
+    public function testStandardUseCase()
+    {
         $this->assertResult(
 '<object type="video/x-ms-wmv" data="http://domain.com/video.wmv" width="320" height="256">
 <param name="src" value="http://domain.com/video.wmv" />

--- a/tests/HTMLPurifier/HTMLModule/ProprietaryTest.php
+++ b/tests/HTMLPurifier/HTMLModule/ProprietaryTest.php
@@ -3,12 +3,14 @@
 class HTMLPurifier_HTMLModule_ProprietaryTest extends HTMLPurifier_HTMLModuleHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->config->set('HTML.Proprietary', true);
     }
 
-    function testMarquee() {
+    public function testMarquee()
+    {
         $this->assertResult(
             '<span><marquee
                 width="20%"

--- a/tests/HTMLPurifier/HTMLModule/RubyTest.php
+++ b/tests/HTMLPurifier/HTMLModule/RubyTest.php
@@ -3,24 +3,28 @@
 class HTMLPurifier_HTMLModule_RubyTest extends HTMLPurifier_HTMLModuleHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->config->set('HTML.Doctype', 'XHTML 1.1');
     }
 
-    function testBasicUse() {
+    public function testBasicUse()
+    {
         $this->assertResult(
             '<ruby><rb>WWW</rb><rt>World Wide Web</rt></ruby>'
         );
     }
 
-    function testRPUse() {
+    public function testRPUse()
+    {
         $this->assertResult(
             '<ruby><rb>WWW</rb><rp>(</rp><rt>World Wide Web</rt><rp>)</rp></ruby>'
         );
     }
 
-    function testComplexUse() {
+    public function testComplexUse()
+    {
         $this->assertResult(
 '<ruby>
   <rbc>
@@ -40,7 +44,8 @@ class HTMLPurifier_HTMLModule_RubyTest extends HTMLPurifier_HTMLModuleHarness
         );
 
         /* not implemented
-        function testBackwardsCompat() {
+        function testBackwardsCompat()
+        {
             $this->assertResult(
                 '<ruby>A<rp>(</rp><rt>aaa</rt><rp>)</rp></ruby>',
                 '<ruby><rb>A</rb><rp>(</rp><rt>aaa</rt><rp>)</rp></ruby>'

--- a/tests/HTMLPurifier/HTMLModule/SafeEmbedTest.php
+++ b/tests/HTMLPurifier/HTMLModule/SafeEmbedTest.php
@@ -3,34 +3,39 @@
 class HTMLPurifier_HTMLModule_SafeEmbedTest extends HTMLPurifier_HTMLModuleHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $def = $this->config->getHTMLDefinition(true);
         $def->manager->addModule('SafeEmbed');
     }
 
-    function testMinimal() {
+    public function testMinimal()
+    {
         $this->assertResult(
             '<embed src="http://www.youtube.com/v/RVtEQxH7PWA&amp;hl=en" />',
             '<embed src="http://www.youtube.com/v/RVtEQxH7PWA&amp;hl=en" allowscriptaccess="never" allownetworking="internal" type="application/x-shockwave-flash" />'
         );
     }
 
-    function testYouTube() {
+    public function testYouTube()
+    {
         $this->assertResult(
             '<embed src="http://www.youtube.com/v/RVtEQxH7PWA&amp;hl=en" type="application/x-shockwave-flash" width="425" height="344"></embed>',
             '<embed src="http://www.youtube.com/v/RVtEQxH7PWA&amp;hl=en" type="application/x-shockwave-flash" width="425" height="344" allowscriptaccess="never" allownetworking="internal" />'
         );
     }
 
-    function testMalicious() {
+    public function testMalicious()
+    {
         $this->assertResult(
             '<embed src="http://example.com/bad.swf" type="application/x-shockwave-flash" width="9999999" height="3499994" allowscriptaccess="always" allownetworking="always" />',
             '<embed src="http://example.com/bad.swf" type="application/x-shockwave-flash" width="1200" height="1200" allowscriptaccess="never" allownetworking="internal" />'
         );
     }
 
-    function testFull() {
+    public function testFull()
+    {
         $this->assertResult(
             '<b><embed src="http://www.youtube.com/v/RVtEQxH7PWA&amp;hl=en" type="application/x-shockwave-flash" width="24" height="23" allowscriptaccess="never" allownetworking="internal" wmode="window" /></b>'
         );

--- a/tests/HTMLPurifier/HTMLModule/SafeObjectTest.php
+++ b/tests/HTMLPurifier/HTMLModule/SafeObjectTest.php
@@ -3,20 +3,23 @@
 class HTMLPurifier_HTMLModule_SafeObjectTest extends HTMLPurifier_HTMLModuleHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->config->set('HTML.DefinitionID', 'HTMLPurifier_HTMLModule_SafeObjectTest');
         $this->config->set('HTML.SafeObject', true);
     }
 
-    function testMinimal() {
+    public function testMinimal()
+    {
         $this->assertResult(
             '<object></object>',
             '<object type="application/x-shockwave-flash"><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /></object>'
         );
     }
 
-    function testYouTube() {
+    public function testYouTube()
+    {
         // embed is purposely removed
         $this->assertResult(
             '<object width="425" height="344"><param name="movie" value="http://www.youtube.com/v/RVtEQxH7PWA&hl=en"></param><embed src="http://www.youtube.com/v/RVtEQxH7PWA&hl=en" type="application/x-shockwave-flash" width="425" height="344"></embed></object>',
@@ -24,20 +27,23 @@ class HTMLPurifier_HTMLModule_SafeObjectTest extends HTMLPurifier_HTMLModuleHarn
         );
     }
 
-    function testMalicious() {
+    public function testMalicious()
+    {
         $this->assertResult(
             '<object width="9999999" height="9999999"><param name="allowScriptAccess" value="always" /><param name="movie" value="http://example.com/attack.swf" /></object>',
             '<object width="1200" height="1200" data="http://example.com/attack.swf" type="application/x-shockwave-flash"><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /><param name="movie" value="http://example.com/attack.swf" /></object>'
         );
     }
 
-    function testFull() {
+    public function testFull()
+    {
         $this->assertResult(
             '<b><object width="425" height="344" type="application/x-shockwave-flash" data="Foobar"><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /><param name="flashvars" value="foobarbaz=bally" /><param name="movie" value="http://www.youtube.com/v/RVtEQxH7PWA&amp;hl=en" /><param name="wmode" value="window" /></object></b>'
         );
     }
 
-    function testFullScreen() {
+    public function testFullScreen()
+    {
         $this->config->set('HTML.FlashAllowFullScreen', true);
         $this->assertResult(
             '<b><object width="425" height="344" type="application/x-shockwave-flash" data="Foobar"><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /><param name="flashvars" value="foobarbaz=bally" /><param name="movie" value="http://www.youtube.com/v/RVtEQxH7PWA&amp;hl=en" /><param name="wmode" value="window" /><param name="allowFullScreen" value="true" /></object></b>'

--- a/tests/HTMLPurifier/HTMLModule/SafeScriptingTest.php
+++ b/tests/HTMLPurifier/HTMLModule/SafeScriptingTest.php
@@ -3,25 +3,29 @@
 class HTMLPurifier_HTMLModule_SafeScriptingTest extends HTMLPurifier_HTMLModuleHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->config->set('HTML.SafeScripting', array('http://localhost/foo.js'));
     }
 
-    function testMinimal() {
+    public function testMinimal()
+    {
         $this->assertResult(
             '<script></script>',
             ''
         );
     }
 
-    function testGood() {
+    public function testGood()
+    {
         $this->assertResult(
             '<script type="text/javascript" src="http://localhost/foo.js" />'
         );
     }
 
-    function testBad() {
+    public function testBad()
+    {
         $this->assertResult(
             '<script type="text/javascript" src="http://localhost/foobar.js" />',
             ''

--- a/tests/HTMLPurifier/HTMLModule/ScriptingTest.php
+++ b/tests/HTMLPurifier/HTMLModule/ScriptingTest.php
@@ -3,26 +3,30 @@
 class HTMLPurifier_HTMLModule_ScriptingTest extends HTMLPurifier_HTMLModuleHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->config->set('HTML.Trusted', true);
         $this->config->set('Output.CommentScriptContents', false);
     }
 
-    function testDefaultRemoval() {
+    public function testDefaultRemoval()
+    {
         $this->config->set('HTML.Trusted', false);
         $this->assertResult(
             '<script type="text/javascript">foo();</script>', ''
         );
     }
 
-    function testPreserve() {
+    public function testPreserve()
+    {
         $this->assertResult(
             '<script type="text/javascript">foo();</script>'
         );
     }
 
-    function testCDATAEnclosure() {
+    public function testCDATAEnclosure()
+    {
         $this->assertResult(
 '<script type="text/javascript">//<![CDATA[
 alert("<This is compatible with XHTML>");
@@ -30,7 +34,8 @@ alert("<This is compatible with XHTML>");
         );
     }
 
-    function testAllAttributes() {
+    public function testAllAttributes()
+    {
         $this->assertResult(
             '<script
                 defer="defer"
@@ -40,7 +45,8 @@ alert("<This is compatible with XHTML>");
         );
     }
 
-    function testUnsupportedAttributes() {
+    public function testUnsupportedAttributes()
+    {
         $this->assertResult(
             '<script
                 type="text/javascript"

--- a/tests/HTMLPurifier/HTMLModule/TargetBlankTest.php
+++ b/tests/HTMLPurifier/HTMLModule/TargetBlankTest.php
@@ -3,12 +3,14 @@
 class HTMLPurifier_HTMLModule_TargetBlankTest extends HTMLPurifier_HTMLModuleHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->config->set('HTML.TargetBlank', true);
     }
 
-    function testTargetBlank() {
+    public function testTargetBlank()
+    {
         $this->assertResult(
             '<a href="http://google.com">a</a><a href="/local">b</a><a href="mailto:foo@example.com">c</a>',
             '<a href="http://google.com" target="_blank">a</a><a href="/local">b</a><a href="mailto:foo@example.com">c</a>'

--- a/tests/HTMLPurifier/HTMLModule/TidyTest.php
+++ b/tests/HTMLPurifier/HTMLModule/TidyTest.php
@@ -9,8 +9,8 @@ Mock::generatePartial(
 class HTMLPurifier_HTMLModule_TidyTest extends HTMLPurifier_Harness
 {
 
-    function test_getFixesForLevel() {
-
+    public function test_getFixesForLevel()
+    {
         $module = new HTMLPurifier_HTMLModule_Tidy();
         $module->fixesForLevel['light'][]  = 'light-fix';
         $module->fixesForLevel['medium'][] = 'medium-fix';
@@ -38,8 +38,8 @@ class HTMLPurifier_HTMLModule_TidyTest extends HTMLPurifier_Harness
 
     }
 
-    function test_setup() {
-
+    public function test_setup()
+    {
         $i = 0; // counter, helps us isolate expectations
 
         // initialize partial mock
@@ -113,8 +113,8 @@ class HTMLPurifier_HTMLModule_TidyTest extends HTMLPurifier_Harness
 
     }
 
-    function test_makeFixesForLevel() {
-
+    public function test_makeFixesForLevel()
+    {
         $module = new HTMLPurifier_HTMLModule_Tidy();
         $module->defaultLevel = 'heavy';
 
@@ -129,8 +129,8 @@ class HTMLPurifier_HTMLModule_TidyTest extends HTMLPurifier_Harness
         $this->assertIdentical($module->fixesForLevel['light'], array());
 
     }
-    function test_makeFixesForLevel_undefinedLevel() {
-
+    public function test_makeFixesForLevel_undefinedLevel()
+    {
         $module = new HTMLPurifier_HTMLModule_Tidy();
         $module->defaultLevel = 'bananas';
 
@@ -142,8 +142,8 @@ class HTMLPurifier_HTMLModule_TidyTest extends HTMLPurifier_Harness
 
     }
 
-    function test_getFixType() {
-
+    public function test_getFixType()
+    {
         // syntax needs documenting
 
         $module = new HTMLPurifier_HTMLModule_Tidy();
@@ -190,8 +190,8 @@ class HTMLPurifier_HTMLModule_TidyTest extends HTMLPurifier_Harness
 
     }
 
-    function test_populate() {
-
+    public function test_populate()
+    {
         $i = 0;
 
         $module = new HTMLPurifier_HTMLModule_Tidy();

--- a/tests/HTMLPurifier/HTMLModuleHarness.php
+++ b/tests/HTMLPurifier/HTMLModuleHarness.php
@@ -2,7 +2,8 @@
 
 class HTMLPurifier_HTMLModuleHarness extends HTMLPurifier_StrategyHarness
 {
-    function setup() {
+    public function setup()
+    {
         parent::setup();
         $this->obj = new HTMLPurifier_Strategy_Core();
     }

--- a/tests/HTMLPurifier/HTMLModuleManagerTest.php
+++ b/tests/HTMLPurifier/HTMLModuleManagerTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_HTMLModuleManagerTest extends HTMLPurifier_Harness
 {
 
-    protected function createManager() {
+    protected function createManager()
+    {
         $manager = new HTMLPurifier_HTMLModuleManager();
 
         $this->config->set('HTML.CustomDoctype', 'Blank');
@@ -18,8 +19,8 @@ class HTMLPurifier_HTMLModuleManagerTest extends HTMLPurifier_Harness
         return $manager;
     }
 
-    function test_addModule() {
-
+    public function test_addModule()
+    {
         $manager = $this->createManager();
 
         // ...but we add user modules
@@ -85,8 +86,8 @@ class HTMLPurifier_HTMLModuleManagerTest extends HTMLPurifier_Harness
 
     }
 
-    function testAllowedModules() {
-
+    public function testAllowedModules()
+    {
         $manager = new HTMLPurifier_HTMLModuleManager();
         $manager->doctypes->register(
             'Fantasy Inventory 1.0', true,

--- a/tests/HTMLPurifier/HTMLModuleTest.php
+++ b/tests/HTMLPurifier/HTMLModuleTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_HTMLModuleTest extends HTMLPurifier_Harness
 {
 
-    function test_addElementToContentSet() {
-
+    public function test_addElementToContentSet()
+    {
         $module = new HTMLPurifier_HTMLModule();
 
         $module->addElementToContentSet('b', 'Inline');
@@ -15,8 +15,8 @@ class HTMLPurifier_HTMLModuleTest extends HTMLPurifier_Harness
 
     }
 
-    function test_addElement() {
-
+    public function test_addElement()
+    {
         $module = new HTMLPurifier_HTMLModule();
         $def = $module->addElement(
             'a', 'Inline', 'Optional: #PCDATA', array('Common'),
@@ -43,8 +43,8 @@ class HTMLPurifier_HTMLModuleTest extends HTMLPurifier_Harness
 
     }
 
-    function test_parseContents() {
-
+    public function test_parseContents()
+    {
         $module = new HTMLPurifier_HTMLModule();
 
         // pre-defined templates
@@ -90,8 +90,8 @@ class HTMLPurifier_HTMLModuleTest extends HTMLPurifier_Harness
 
     }
 
-    function test_mergeInAttrIncludes() {
-
+    public function test_mergeInAttrIncludes()
+    {
         $module = new HTMLPurifier_HTMLModule();
 
         $attr = array();
@@ -104,8 +104,8 @@ class HTMLPurifier_HTMLModuleTest extends HTMLPurifier_Harness
 
     }
 
-    function test_addBlankElement() {
-
+    public function test_addBlankElement()
+    {
         $module = new HTMLPurifier_HTMLModule();
         $def = $module->addBlankElement('a');
 
@@ -117,8 +117,8 @@ class HTMLPurifier_HTMLModuleTest extends HTMLPurifier_Harness
 
     }
 
-    function test_makeLookup() {
-
+    public function test_makeLookup()
+    {
         $module = new HTMLPurifier_HTMLModule();
 
         $this->assertIdentical(

--- a/tests/HTMLPurifier/HTMLT.php
+++ b/tests/HTMLPurifier/HTMLT.php
@@ -4,12 +4,14 @@ class HTMLPurifier_HTMLT extends HTMLPurifier_Harness
 {
     protected $path;
 
-    public function __construct($path) {
+    public function __construct($path)
+    {
         $this->path = $path;
         parent::__construct($path);
     }
 
-    public function testHtmlt() {
+    public function testHtmlt()
+    {
         $parser = new HTMLPurifier_StringHashParser();
         $hash = $parser->parseFile($this->path); // assume parser normalizes to "\n"
         if (isset($hash['SKIPIF'])) {

--- a/tests/HTMLPurifier/Harness.php
+++ b/tests/HTMLPurifier/Harness.php
@@ -6,17 +6,32 @@
 class HTMLPurifier_Harness extends UnitTestCase
 {
 
-    public function __construct($name = null) {
+    public function __construct($name = null)
+    {
         parent::__construct($name);
     }
 
-    protected $config, $context, $purifier;
+    /**
+     * @type HTMLPurifier_Config
+     */
+    protected $config;
+
+    /**
+     * @type HTMLPurifier_Context
+     */
+    protected $context;
+
+    /**
+     * @type HTMLPurifier
+     */
+    protected $purifier;
 
     /**
      * Generates easily accessible default config/context, as well as
      * a convenience purifier for integration testing.
      */
-    public function setUp() {
+    public function setUp()
+    {
         list($this->config, $this->context) = $this->createCommon();
         $this->config->set('Output.Newline', '
 ');
@@ -25,9 +40,14 @@ class HTMLPurifier_Harness extends UnitTestCase
 
     /**
      * Asserts a purification. Good for integration testing.
+     * @param string $input
+     * @param string $expect
      */
-    function assertPurification($input, $expect = null) {
-        if ($expect === null) $expect = $input;
+    public function assertPurification($input, $expect = null)
+    {
+        if ($expect === null) {
+            $expect = $input;
+        }
         $result = $this->purifier->purify($input, $this->config);
         $this->assertIdentical($expect, $result);
     }
@@ -38,23 +58,28 @@ class HTMLPurifier_Harness extends UnitTestCase
      * @param &$config Reference to config variable
      * @param &$context Reference to context variable
      */
-    protected function prepareCommon(&$config, &$context) {
+    protected function prepareCommon(&$config, &$context)
+    {
         $config = HTMLPurifier_Config::create($config);
-        if (!$context) $context = new HTMLPurifier_Context();
+        if (!$context) {
+            $context = new HTMLPurifier_Context();
+        }
     }
 
     /**
      * Generates default configuration and context objects
      * @return Defaults in form of array($config, $context)
      */
-    protected function createCommon() {
+    protected function createCommon()
+    {
         return array(HTMLPurifier_Config::createDefault(), new HTMLPurifier_Context);
     }
 
     /**
      * Normalizes a string to Unix (\n) endings
      */
-    protected function normalize(&$string) {
+    protected function normalize(&$string)
+    {
         $string = str_replace(array("\r\n", "\r"), "\n", $string);
     }
 
@@ -65,7 +90,8 @@ class HTMLPurifier_Harness extends UnitTestCase
      * @param $result Mixed result from processing
      * @param $expect Mixed expectation for result
      */
-    protected function assertEitherFailOrIdentical($status, $result, $expect) {
+    protected function assertEitherFailOrIdentical($status, $result, $expect)
+    {
         if ($expect === false) {
             $this->assertFalse($status, 'Expected false result, got true');
         } else {
@@ -74,7 +100,8 @@ class HTMLPurifier_Harness extends UnitTestCase
         }
     }
 
-    public function getTests() {
+    public function getTests()
+    {
         // __onlytest makes only one test get triggered
         foreach (get_class_methods(get_class($this)) as $method) {
             if (strtolower(substr($method, 0, 10)) == '__onlytest') {

--- a/tests/HTMLPurifier/IDAccumulatorTest.php
+++ b/tests/HTMLPurifier/IDAccumulatorTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_IDAccumulatorTest extends HTMLPurifier_Harness
 {
 
-    function test() {
-
+    public function test()
+    {
         // initialize the accumulator
         $accumulator = new HTMLPurifier_IDAccumulator();
 
@@ -17,8 +17,8 @@ class HTMLPurifier_IDAccumulatorTest extends HTMLPurifier_Harness
 
     }
 
-    function testLoad() {
-
+    public function testLoad()
+    {
         $accumulator = new HTMLPurifier_IDAccumulator();
 
         $accumulator->load(array('id1', 'id2', 'id3'));
@@ -28,7 +28,8 @@ class HTMLPurifier_IDAccumulatorTest extends HTMLPurifier_Harness
 
     }
 
-    function testBuild() {
+    public function testBuild()
+    {
         $this->config->set('Attr.IDBlacklist', array('foo'));
         $accumulator = HTMLPurifier_IDAccumulator::build($this->config, $this->context);
         $this->assertTrue( isset($accumulator->ids['foo']) );

--- a/tests/HTMLPurifier/Injector/AutoParagraphTest.php
+++ b/tests/HTMLPurifier/Injector/AutoParagraphTest.php
@@ -3,19 +3,22 @@
 class HTMLPurifier_Injector_AutoParagraphTest extends HTMLPurifier_InjectorHarness
 {
 
-    function setup() {
+    public function setup()
+    {
         parent::setup();
         $this->config->set('AutoFormat.AutoParagraph', true);
     }
 
-    function testSingleParagraph() {
+    public function testSingleParagraph()
+    {
         $this->assertResult(
             'Foobar',
             '<p>Foobar</p>'
         );
     }
 
-    function testSingleMultiLineParagraph() {
+    public function testSingleMultiLineParagraph()
+    {
         $this->assertResult(
 'Par 1
 Par 1 still',
@@ -24,7 +27,8 @@ Par 1 still</p>'
         );
     }
 
-    function testTwoParagraphs() {
+    public function testTwoParagraphs()
+    {
         $this->assertResult(
 'Par1
 
@@ -35,7 +39,8 @@ Par2',
         );
     }
 
-    function testTwoParagraphsWithLotsOfSpace() {
+    public function testTwoParagraphsWithLotsOfSpace()
+    {
         $this->assertResult(
 'Par1
 
@@ -48,7 +53,8 @@ Par2',
         );
     }
 
-    function testTwoParagraphsWithInlineElements() {
+    public function testTwoParagraphsWithInlineElements()
+    {
         $this->assertResult(
 '<b>Par1</b>
 
@@ -59,7 +65,8 @@ Par2',
         );
     }
 
-    function testSingleParagraphThatLooksLikeTwo() {
+    public function testSingleParagraphThatLooksLikeTwo()
+    {
         $this->assertResult(
 '<b>Par1
 
@@ -70,7 +77,8 @@ Par2</b></p>'
         );
     }
 
-    function testAddParagraphAdjacentToParagraph() {
+    public function testAddParagraphAdjacentToParagraph()
+    {
         $this->assertResult(
             'Par1<p>Par2</p>',
 '<p>Par1</p>
@@ -79,14 +87,16 @@ Par2</b></p>'
         );
     }
 
-    function testParagraphUnclosedInlineElement() {
+    public function testParagraphUnclosedInlineElement()
+    {
         $this->assertResult(
             '<b>Par1',
             '<p><b>Par1</b></p>'
         );
     }
 
-    function testPreservePreTags() {
+    public function testPreservePreTags()
+    {
         $this->assertResult(
 '<pre>Par1
 
@@ -94,7 +104,8 @@ Par1</pre>'
         );
     }
 
-    function testIgnoreTrailingWhitespace() {
+    public function testIgnoreTrailingWhitespace()
+    {
         $this->assertResult(
 'Par1
 
@@ -105,7 +116,8 @@ Par1</pre>'
         );
     }
 
-    function testDoNotParagraphBlockElements() {
+    public function testDoNotParagraphBlockElements()
+    {
         $this->assertResult(
 'Par1
 
@@ -120,14 +132,16 @@ Par3',
         );
     }
 
-    function testParagraphTextAndInlineNodes() {
+    public function testParagraphTextAndInlineNodes()
+    {
         $this->assertResult(
 'Par<b>1</b>',
             '<p>Par<b>1</b></p>'
         );
     }
 
-    function testPreserveLeadingWhitespace() {
+    public function testPreserveLeadingWhitespace()
+    {
         $this->assertResult(
 '
 
@@ -138,7 +152,8 @@ Par',
         );
     }
 
-    function testPreserveSurroundingWhitespace() {
+    public function testPreserveSurroundingWhitespace()
+    {
         $this->assertResult(
 '
 
@@ -153,7 +168,8 @@ Par
         );
     }
 
-    function testParagraphInsideBlockNode() {
+    public function testParagraphInsideBlockNode()
+    {
         $this->assertResult(
 '<div>Par1
 
@@ -164,7 +180,8 @@ Par2</div>',
         );
     }
 
-    function testParagraphInlineNodeInsideBlockNode() {
+    public function testParagraphInlineNodeInsideBlockNode()
+    {
         $this->assertResult(
 '<div><b>Par1</b>
 
@@ -175,11 +192,13 @@ Par2</div>',
         );
     }
 
-    function testNoParagraphWhenOnlyOneInsideBlockNode() {
+    public function testNoParagraphWhenOnlyOneInsideBlockNode()
+    {
         $this->assertResult('<div>Par1</div>');
     }
 
-    function testParagraphTwoInlineNodesInsideBlockNode() {
+    public function testParagraphTwoInlineNodesInsideBlockNode()
+    {
         $this->assertResult(
 '<div><b>Par1</b>
 
@@ -190,7 +209,8 @@ Par2</div>',
         );
     }
 
-    function testPreserveInlineNodesInPreTag() {
+    public function testPreserveInlineNodesInPreTag()
+    {
         $this->assertResult(
 '<pre><b>Par1</b>
 
@@ -198,7 +218,8 @@ Par2</div>',
         );
     }
 
-    function testSplitUpInternalsOfPTagInBlockNode() {
+    public function testSplitUpInternalsOfPTagInBlockNode()
+    {
         $this->assertResult(
 '<div><p>Foo
 
@@ -209,7 +230,8 @@ Bar</p></div>',
         );
     }
 
-    function testSplitUpInlineNodesInPTagInBlockNode() {
+    public function testSplitUpInlineNodesInPTagInBlockNode()
+    {
         $this->assertResult(
 '<div><p><b>Foo</b>
 
@@ -220,11 +242,13 @@ Bar</p></div>',
         );
     }
 
-    function testNoParagraphSingleInlineNodeInBlockNode() {
+    public function testNoParagraphSingleInlineNodeInBlockNode()
+    {
         $this->assertResult( '<div><b>Foo</b></div>' );
     }
 
-    function testParagraphInBlockquote() {
+    public function testParagraphInBlockquote()
+    {
         $this->assertResult(
 '<blockquote>Par1
 
@@ -235,7 +259,8 @@ Par2</blockquote>',
         );
     }
 
-    function testNoParagraphBetweenListItem() {
+    public function testNoParagraphBetweenListItem()
+    {
         $this->assertResult(
 '<ul><li>Foo</li>
 
@@ -243,7 +268,8 @@ Par2</blockquote>',
         );
     }
 
-    function testParagraphSingleElementWithSurroundingSpace() {
+    public function testParagraphSingleElementWithSurroundingSpace()
+    {
         $this->assertResult(
 '<div>
 
@@ -258,7 +284,8 @@ Bar
         );
     }
 
-    function testIgnoreExtraSpaceWithLeadingInlineNode() {
+    public function testIgnoreExtraSpaceWithLeadingInlineNode()
+    {
         $this->assertResult(
 '<b>Par1</b>a
 
@@ -271,7 +298,8 @@ Par2',
         );
     }
 
-    function testAbsorbExtraEndingPTag() {
+    public function testAbsorbExtraEndingPTag()
+    {
         $this->assertResult(
 'Par1
 
@@ -282,7 +310,8 @@ Par2</p>',
         );
     }
 
-    function testAbsorbExtraEndingDivTag() {
+    public function testAbsorbExtraEndingDivTag()
+    {
         $this->assertResult(
 'Par1
 
@@ -293,7 +322,8 @@ Par2</div>',
         );
     }
 
-    function testDoNotParagraphSingleSurroundingSpaceInBlockNode() {
+    public function testDoNotParagraphSingleSurroundingSpaceInBlockNode()
+    {
         $this->assertResult(
 '<div>
 Par1
@@ -301,7 +331,8 @@ Par1
         );
     }
 
-    function testBlockNodeTextDelimeterInBlockNode() {
+    public function testBlockNodeTextDelimeterInBlockNode()
+    {
         $this->assertResult(
 '<div>Par1
 
@@ -312,14 +343,16 @@ Par1
         );
     }
 
-    function testBlockNodeTextDelimeterWithoutDoublespaceInBlockNode() {
+    public function testBlockNodeTextDelimeterWithoutDoublespaceInBlockNode()
+    {
         $this->assertResult(
 '<div>Par1
 <div>Par2</div></div>'
         );
     }
 
-    function testBlockNodeTextDelimeterWithoutDoublespace() {
+    public function testBlockNodeTextDelimeterWithoutDoublespace()
+    {
         $this->assertResult(
 'Par1
 <div>Par2</div>',
@@ -330,7 +363,8 @@ Par1
         );
     }
 
-    function testTwoParagraphsOfTextAndInlineNode() {
+    public function testTwoParagraphsOfTextAndInlineNode()
+    {
         $this->assertResult(
 'Par1
 
@@ -341,32 +375,37 @@ Par1
         );
     }
 
-    function testLeadingInlineNodeParagraph() {
+    public function testLeadingInlineNodeParagraph()
+    {
         $this->assertResult(
 '<img /> Foo',
 '<p><img /> Foo</p>'
         );
     }
 
-    function testTrailingInlineNodeParagraph() {
+    public function testTrailingInlineNodeParagraph()
+    {
         $this->assertResult(
 '<li>Foo <a>bar</a></li>'
         );
     }
 
-    function testTwoInlineNodeParagraph() {
+    public function testTwoInlineNodeParagraph()
+    {
         $this->assertResult(
 '<li><b>baz</b><a>bar</a></li>'
         );
     }
 
-    function testNoParagraphTrailingBlockNodeInBlockNode() {
+    public function testNoParagraphTrailingBlockNodeInBlockNode()
+    {
         $this->assertResult(
 '<div><div>asdf</div><b>asdf</b></div>'
         );
     }
 
-    function testParagraphTrailingBlockNodeWithDoublespaceInBlockNode() {
+    public function testParagraphTrailingBlockNodeWithDoublespaceInBlockNode()
+    {
         $this->assertResult(
 '<div><div>asdf</div>
 
@@ -377,14 +416,16 @@ Par1
         );
     }
 
-    function testParagraphTwoInlineNodesAndWhitespaceNode() {
+    public function testParagraphTwoInlineNodesAndWhitespaceNode()
+    {
         $this->assertResult(
 '<b>One</b> <i>Two</i>',
 '<p><b>One</b> <i>Two</i></p>'
         );
     }
 
-    function testNoParagraphWithInlineRootNode() {
+    public function testNoParagraphWithInlineRootNode()
+    {
         $this->config->set('HTML.Parent', 'span');
         $this->assertResult(
 'Par
@@ -393,13 +434,15 @@ Par2'
         );
     }
 
-    function testInlineAndBlockTagInDivNoParagraph() {
+    public function testInlineAndBlockTagInDivNoParagraph()
+    {
         $this->assertResult(
             '<div><code>bar</code> mmm <pre>asdf</pre></div>'
         );
     }
 
-    function testInlineAndBlockTagInDivNeedingParagraph() {
+    public function testInlineAndBlockTagInDivNeedingParagraph()
+    {
         $this->assertResult(
 '<div><code>bar</code> mmm
 
@@ -410,7 +453,8 @@ Par2'
         );
     }
 
-    function testTextInlineNodeTextThenDoubleNewlineNeedsParagraph() {
+    public function testTextInlineNodeTextThenDoubleNewlineNeedsParagraph()
+    {
         $this->assertResult(
 '<div>asdf <code>bar</code> mmm
 
@@ -421,7 +465,8 @@ Par2'
         );
     }
 
-    function testUpcomingTokenHasNewline() {
+    public function testUpcomingTokenHasNewline()
+    {
         $this->assertResult(
 '<div>Test<b>foo</b>bar<b>bing</b>bang
 
@@ -432,7 +477,8 @@ boo</div>',
 );
     }
 
-    function testEmptyTokenAtEndOfDiv() {
+    public function testEmptyTokenAtEndOfDiv()
+    {
         $this->assertResult(
 '<div><p>foo</p>
 </div>',
@@ -441,7 +487,8 @@ boo</div>',
 );
     }
 
-    function testEmptyDoubleLineTokenAtEndOfDiv() {
+    public function testEmptyDoubleLineTokenAtEndOfDiv()
+    {
         $this->assertResult(
 '<div><p>foo</p>
 
@@ -452,26 +499,31 @@ boo</div>',
 );
     }
 
-    function testTextState11Root() {
+    public function testTextState11Root()
+    {
         $this->assertResult('<div></div>   ');
     }
 
-    function testTextState11Element() {
+    public function testTextState11Element()
+    {
         $this->assertResult(
 "<div><div></div>
 
 </div>");
     }
 
-    function testTextStateLikeElementState111NoWhitespace() {
+    public function testTextStateLikeElementState111NoWhitespace()
+    {
         $this->assertResult('<div><p>P</p>Boo</div>', '<div><p>P</p>Boo</div>');
     }
 
-    function testElementState111NoWhitespace() {
+    public function testElementState111NoWhitespace()
+    {
         $this->assertResult('<div><p>P</p><b>Boo</b></div>', '<div><p>P</p><b>Boo</b></div>');
     }
 
-    function testElementState133() {
+    public function testElementState133()
+    {
         $this->assertResult(
 "<div><b>B</b><pre>Ba</pre>
 
@@ -482,13 +534,15 @@ Bar</div>",
 );
     }
 
-    function testElementState22() {
+    public function testElementState22()
+    {
         $this->assertResult(
             '<ul><li>foo</li></ul>'
         );
     }
 
-    function testElementState311() {
+    public function testElementState311()
+    {
         $this->assertResult(
             '<p>Foo</p><b>Bar</b>',
 '<p>Foo</p>
@@ -497,20 +551,23 @@ Bar</div>",
         );
     }
 
-    function testAutoClose() {
+    public function testAutoClose()
+    {
         $this->assertResult(
             '<p></p>
 <hr />'
         );
     }
 
-    function testErrorNeeded() {
+    public function testErrorNeeded()
+    {
         $this->config->set('HTML.Allowed', 'b');
         $this->expectError('Cannot enable AutoParagraph injector because p is not allowed');
         $this->assertResult('<b>foobar</b>');
     }
 
-    function testParentElement() {
+    public function testParentElement()
+    {
         $this->config->set('HTML.Allowed', 'p,ul,li');
         $this->assertResult('Foo<ul><li>Bar</li></ul>', "<p>Foo</p>\n\n<ul><li>Bar</li></ul>");
     }

--- a/tests/HTMLPurifier/Injector/DisplayLinkURITest.php
+++ b/tests/HTMLPurifier/Injector/DisplayLinkURITest.php
@@ -3,25 +3,29 @@
 class HTMLPurifier_Injector_DisplayLinkURITest extends HTMLPurifier_InjectorHarness
 {
 
-    function setup() {
+    public function setup()
+    {
         parent::setup();
         $this->config->set('AutoFormat.DisplayLinkURI', true);
     }
 
-    function testBasicLink() {
+    public function testBasicLink()
+    {
         $this->assertResult(
             '<a href="http://malware.example.com">Don\'t go here!</a>',
             '<a>Don\'t go here!</a> (http://malware.example.com)'
         );
     }
 
-    function testEmptyLink() {
+    public function testEmptyLink()
+    {
         $this->assertResult(
             '<a>Don\'t go here!</a>',
             '<a>Don\'t go here!</a>'
         );
     }
-    function testEmptyText() {
+    public function testEmptyText()
+    {
         $this->assertResult(
             '<a href="http://malware.example.com"></a>',
             '<a></a> (http://malware.example.com)'

--- a/tests/HTMLPurifier/Injector/LinkifyTest.php
+++ b/tests/HTMLPurifier/Injector/LinkifyTest.php
@@ -3,45 +3,52 @@
 class HTMLPurifier_Injector_LinkifyTest extends HTMLPurifier_InjectorHarness
 {
 
-    function setup() {
+    public function setup()
+    {
         parent::setup();
         $this->config->set('AutoFormat.Linkify', true);
     }
 
-    function testLinkifyURLInRootNode() {
+    public function testLinkifyURLInRootNode()
+    {
         $this->assertResult(
             'http://example.com',
             '<a href="http://example.com">http://example.com</a>'
         );
     }
 
-    function testLinkifyURLInInlineNode() {
+    public function testLinkifyURLInInlineNode()
+    {
         $this->assertResult(
             '<b>http://example.com</b>',
             '<b><a href="http://example.com">http://example.com</a></b>'
         );
     }
 
-    function testBasicUsageCase() {
+    public function testBasicUsageCase()
+    {
         $this->assertResult(
             'This URL http://example.com is what you need',
             'This URL <a href="http://example.com">http://example.com</a> is what you need'
         );
     }
 
-    function testIgnoreURLInATag() {
+    public function testIgnoreURLInATag()
+    {
         $this->assertResult(
             '<a>http://example.com/</a>'
         );
     }
 
-    function testNeeded() {
+    public function testNeeded()
+    {
         $this->config->set('HTML.Allowed', 'b');
         $this->expectError('Cannot enable Linkify injector because a is not allowed');
         $this->assertResult('http://example.com/');
     }
 
-    function testExcludes() {
+    public function testExcludes()
+    {
         $this->assertResult('<a><span>http://example.com</span></a>');
     }
 

--- a/tests/HTMLPurifier/Injector/PurifierLinkifyTest.php
+++ b/tests/HTMLPurifier/Injector/PurifierLinkifyTest.php
@@ -3,52 +3,61 @@
 class HTMLPurifier_Injector_PurifierLinkifyTest extends HTMLPurifier_InjectorHarness
 {
 
-    function setup() {
+    public function setup()
+    {
         parent::setup();
         $this->config->set('AutoFormat.PurifierLinkify', true);
         $this->config->set('AutoFormat.PurifierLinkify.DocURL', '#%s');
     }
 
-    function testNoTriggerCharacer() {
+    public function testNoTriggerCharacer()
+    {
         $this->assertResult('Foobar');
     }
 
-    function testTriggerCharacterInIrrelevantContext() {
+    public function testTriggerCharacterInIrrelevantContext()
+    {
         $this->assertResult('20% off!');
     }
 
-    function testPreserveNamespace() {
+    public function testPreserveNamespace()
+    {
         $this->assertResult('%Core namespace (not recognized)');
     }
 
-    function testLinkifyBasic() {
+    public function testLinkifyBasic()
+    {
         $this->assertResult(
           '%Namespace.Directive',
           '<a href="#Namespace.Directive">%Namespace.Directive</a>'
         );
     }
 
-    function testLinkifyWithAdjacentTextNodes() {
+    public function testLinkifyWithAdjacentTextNodes()
+    {
         $this->assertResult(
           'This %Namespace.Directive thing',
           'This <a href="#Namespace.Directive">%Namespace.Directive</a> thing'
         );
     }
 
-    function testLinkifyInBlock() {
+    public function testLinkifyInBlock()
+    {
         $this->assertResult(
           '<div>This %Namespace.Directive thing</div>',
           '<div>This <a href="#Namespace.Directive">%Namespace.Directive</a> thing</div>'
         );
     }
 
-    function testPreserveInATag() {
+    public function testPreserveInATag()
+    {
         $this->assertResult(
           '<a>%Namespace.Directive</a>'
         );
     }
 
-    function testNeeded() {
+    public function testNeeded()
+    {
         $this->config->set('HTML.Allowed', 'b');
         $this->expectError('Cannot enable PurifierLinkify injector because a is not allowed');
         $this->assertResult('%Namespace.Directive');

--- a/tests/HTMLPurifier/Injector/RemoveEmptyTest.php
+++ b/tests/HTMLPurifier/Injector/RemoveEmptyTest.php
@@ -3,73 +3,89 @@
 class HTMLPurifier_Injector_RemoveEmptyTest extends HTMLPurifier_InjectorHarness
 {
 
-    public function setup() {
+    public function setup()
+    {
         parent::setup();
         $this->config->set('AutoFormat.RemoveEmpty', true);
     }
 
-    function testPreserve() {
+    public function testPreserve()
+    {
         $this->assertResult('<b>asdf</b>');
     }
 
-    function testRemove() {
+    public function testRemove()
+    {
         $this->assertResult('<b></b>', '');
     }
 
-    function testRemoveWithSpace() {
+    public function testRemoveWithSpace()
+    {
         $this->assertResult('<b>   </b>', '');
     }
 
-    function testRemoveWithAttr() {
+    public function testRemoveWithAttr()
+    {
         $this->assertResult('<b class="asdf"></b>', '');
     }
 
-    function testRemoveIdAndName() {
+    public function testRemoveIdAndName()
+    {
         $this->assertResult('<a id="asdf" name="asdf"></a>', '');
     }
 
-    function testPreserveColgroup() {
+    public function testPreserveColgroup()
+    {
         $this->assertResult('<colgroup></colgroup>');
     }
 
-    function testPreserveId() {
+    public function testPreserveId()
+    {
         $this->config->set('Attr.EnableID', true);
         $this->assertResult('<a id="asdf"></a>');
     }
 
-    function testPreserveName() {
+    public function testPreserveName()
+    {
         $this->config->set('Attr.EnableID', true);
         $this->assertResult('<a name="asdf"></a>');
     }
 
-    function testRemoveNested() {
+    public function testRemoveNested()
+    {
         $this->assertResult('<b><i></i></b>', '');
     }
 
-    function testRemoveNested2() {
+    public function testRemoveNested2()
+    {
         $this->assertResult('<b><i><u></u></i></b>', '');
     }
 
-    function testRemoveNested3() {
+    public function testRemoveNested3()
+    {
         $this->assertResult('<b> <i> <u> </u> </i> </b>', '');
     }
 
-    function testRemoveNbsp() {
+    public function testRemoveNbsp()
+    {
         $this->config->set('AutoFormat.RemoveEmpty.RemoveNbsp', true);
         $this->assertResult('<b>&nbsp;</b>', '');
     }
 
-    function testRemoveNbspMix() {
+    public function testRemoveNbspMix()
+    {
         $this->config->set('AutoFormat.RemoveEmpty.RemoveNbsp', true);
         $this->assertResult('<b>&nbsp;   &nbsp;</b>', '');
     }
 
-    function testDontRemoveNbsp() {
+    public function testDontRemoveNbsp()
+    {
         $this->config->set('AutoFormat.RemoveEmpty.RemoveNbsp', true);
         $this->assertResult('<td>&nbsp;</b>', "<td>\xC2\xA0</td>");
     }
 
-    function testRemoveNbspExceptionsSpecial() {
+    public function testRemoveNbspExceptionsSpecial()
+    {
         $this->config->set('AutoFormat.RemoveEmpty.RemoveNbsp', true);
         $this->config->set('AutoFormat.RemoveEmpty.RemoveNbsp.Exceptions', 'b');
         $this->assertResult('<b>&nbsp;</b>', "<b>\xC2\xA0</b>");

--- a/tests/HTMLPurifier/Injector/RemoveSpansWithoutAttributesTest.php
+++ b/tests/HTMLPurifier/Injector/RemoveSpansWithoutAttributesTest.php
@@ -2,34 +2,39 @@
 
 class HTMLPurifier_Injector_RemoveSpansWithoutAttributesTest extends HTMLPurifier_InjectorHarness
 {
-    function setup() {
+    public function setup()
+    {
         parent::setup();
         $this->config->set('HTML.Allowed', 'span[class],div,p,strong,em');
         $this->config->set('AutoFormat.RemoveSpansWithoutAttributes', true);
     }
 
-    function testSingleSpan() {
+    public function testSingleSpan()
+    {
         $this->assertResult(
             '<span>foo</span>',
             'foo'
         );
     }
 
-    function testSingleSpanWithAttributes() {
+    public function testSingleSpanWithAttributes()
+    {
         $this->assertResult(
             '<span class="bar">foo</span>',
             '<span class="bar">foo</span>'
         );
     }
 
-    function testSingleNestedSpan() {
+    public function testSingleNestedSpan()
+    {
         $this->assertResult(
             '<p><span>foo</span></p>',
             '<p>foo</p>'
         );
     }
 
-    function testSingleNestedSpanWithAttributes() {
+    public function testSingleNestedSpanWithAttributes()
+    {
         $this->assertResult(
             '<p><span class="bar">foo</span></p>',
             '<p><span class="bar">foo</span></p>'
@@ -37,49 +42,56 @@ class HTMLPurifier_Injector_RemoveSpansWithoutAttributesTest extends HTMLPurifie
     }
 
 
-    function testSpanWithChildren() {
+    public function testSpanWithChildren()
+    {
         $this->assertResult(
             '<span>foo <strong>bar</strong> <em>baz</em></span>',
             'foo <strong>bar</strong> <em>baz</em>'
         );
     }
 
-    function testSpanWithSiblings() {
+    public function testSpanWithSiblings()
+    {
         $this->assertResult(
             '<p>before <span>inside</span> <strong>after</strong></p>',
             '<p>before inside <strong>after</strong></p>'
         );
     }
 
-    function testNestedSpanWithSiblingsAndChildren() {
+    public function testNestedSpanWithSiblingsAndChildren()
+    {
         $this->assertResult(
             '<p>a <span>b <em>c</em> d</span> e</p>',
             '<p>a b <em>c</em> d e</p>'
         );
     }
 
-    function testNestedSpansWithoutAttributes() {
+    public function testNestedSpansWithoutAttributes()
+    {
         $this->assertResult(
             '<span>one<span>two<span>three</span></span></span>',
             'onetwothree'
         );
     }
 
-    function testDeeplyNestedSpan() {
+    public function testDeeplyNestedSpan()
+    {
         $this->assertResult(
             '<div><div><div><span class="a">a <span>b</span> c</span></div></div></div>',
             '<div><div><div><span class="a">a b c</span></div></div></div>'
         );
     }
 
-    function testSpanWithInvalidAttributes() {
+    public function testSpanWithInvalidAttributes()
+    {
         $this->assertResult(
             '<p><span snorkel buzzer="emu">foo</span></p>',
             '<p>foo</p>'
         );
     }
 
-    function testNestedAlternateSpans() {
+    public function testNestedAlternateSpans()
+    {
         $this->assertResult(
 '<span>a <span class="x">b <span>c <span class="y">d <span>e <span class="z">f
 </span></span></span></span></span></span>',
@@ -88,7 +100,8 @@ class HTMLPurifier_Injector_RemoveSpansWithoutAttributesTest extends HTMLPurifie
         );
     }
 
-    function testSpanWithSomeInvalidAttributes() {
+    public function testSpanWithSomeInvalidAttributes()
+    {
         $this->assertResult(
             '<p><span buzzer="emu" class="bar">foo</span></p>',
             '<p><span class="bar">foo</span></p>'

--- a/tests/HTMLPurifier/Injector/SafeObjectTest.php
+++ b/tests/HTMLPurifier/Injector/SafeObjectTest.php
@@ -8,75 +8,86 @@
 class HTMLPurifier_Injector_SafeObjectTest extends HTMLPurifier_InjectorHarness
 {
 
-    function setup() {
+    public function setup()
+    {
         parent::setup();
         // there is no AutoFormat.SafeObject directive
         $this->config->set('AutoFormat.Custom', array(new HTMLPurifier_Injector_SafeObject()));
         $this->config->set('HTML.Trusted', true);
     }
 
-    function testPreserve() {
+    public function testPreserve()
+    {
         $this->assertResult(
             '<b>asdf</b>'
         );
     }
 
-    function testRemoveStrayParam() {
+    public function testRemoveStrayParam()
+    {
         $this->assertResult(
             '<param />',
             ''
         );
     }
 
-    function testEditObjectParam() {
+    public function testEditObjectParam()
+    {
         $this->assertResult(
             '<object></object>',
             '<object><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /></object>'
         );
     }
 
-    function testIgnoreStrayParam() {
+    public function testIgnoreStrayParam()
+    {
         $this->assertResult(
             '<object><param /></object>',
             '<object><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /></object>'
         );
     }
 
-    function testIgnoreDuplicates() {
+    public function testIgnoreDuplicates()
+    {
         $this->assertResult(
             '<object><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /></object>'
         );
     }
 
-    function testIgnoreBogusData() {
+    public function testIgnoreBogusData()
+    {
         $this->assertResult(
             '<object><param name="allowScriptAccess" value="always" /><param name="allowNetworking" value="always" /></object>',
             '<object><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /></object>'
         );
     }
 
-    function testIgnoreInvalidData() {
+    public function testIgnoreInvalidData()
+    {
         $this->assertResult(
             '<object><param name="foo" value="bar" /></object>',
             '<object><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /></object>'
         );
     }
 
-    function testKeepValidData() {
+    public function testKeepValidData()
+    {
         $this->assertResult(
             '<object><param name="movie" value="bar" /></object>',
             '<object data="bar"><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /><param name="movie" value="bar" /></object>'
         );
     }
 
-    function testNested() {
+    public function testNested()
+    {
         $this->assertResult(
             '<object><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /><object></object></object>',
             '<object><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /><object><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /></object></object>'
         );
     }
 
-    function testNotActuallyNested() {
+    public function testNotActuallyNested()
+    {
         $this->assertResult(
             '<object><p><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /></p></object>',
             '<object><param name="allowScriptAccess" value="never" /><param name="allowNetworking" value="internal" /><p></p></object>'

--- a/tests/HTMLPurifier/InjectorHarness.php
+++ b/tests/HTMLPurifier/InjectorHarness.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_InjectorHarness extends HTMLPurifier_StrategyHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_MakeWellFormed();
     }

--- a/tests/HTMLPurifier/LanguageFactoryTest.php
+++ b/tests/HTMLPurifier/LanguageFactoryTest.php
@@ -8,13 +8,14 @@ class HTMLPurifier_LanguageFactoryTest extends HTMLPurifier_Harness
      */
     protected $factory;
 
-    public function setUp() {
+    public function setUp()
+    {
         $this->factory = HTMLPurifier_LanguageFactory::instance();
         parent::setUp();
     }
 
-    function test() {
-
+    public function test()
+    {
         $this->config->set('Core.Language', 'en');
         $language = $this->factory->create($this->config, $this->context);
 
@@ -28,8 +29,8 @@ class HTMLPurifier_LanguageFactoryTest extends HTMLPurifier_Harness
 
     }
 
-    function testFallback() {
-
+    public function testFallback()
+    {
         $this->config->set('Core.Language', 'en-x-test');
         $language = $this->factory->create($this->config, $this->context);
 
@@ -46,7 +47,8 @@ class HTMLPurifier_LanguageFactoryTest extends HTMLPurifier_Harness
 
     }
 
-    function testFallbackWithNoClass() {
+    public function testFallbackWithNoClass()
+    {
         $this->config->set('Core.Language', 'en-x-testmini');
         $language = $this->factory->create($this->config, $this->context);
         $this->assertIsA($language, 'HTMLPurifier_Language');
@@ -57,7 +59,8 @@ class HTMLPurifier_LanguageFactoryTest extends HTMLPurifier_Harness
         $this->assertIdentical($language->error, false);
     }
 
-    function testNoSuchLanguage() {
+    public function testNoSuchLanguage()
+    {
         $this->config->set('Core.Language', 'en-x-testnone');
         $language = $this->factory->create($this->config, $this->context);
         $this->assertIsA($language, 'HTMLPurifier_Language');

--- a/tests/HTMLPurifier/LanguageTest.php
+++ b/tests/HTMLPurifier/LanguageTest.php
@@ -8,14 +8,16 @@ class HTMLPurifier_LanguageTest extends HTMLPurifier_Harness
 
     protected $lang;
 
-    protected function generateEnLanguage() {
+    protected function generateEnLanguage()
+    {
         $factory = HTMLPurifier_LanguageFactory::instance();
         $config = HTMLPurifier_Config::create(array('Core.Language' => 'en'));
         $context = new HTMLPurifier_Context();
         return $factory->create($config, $context);
     }
 
-    function test_getMessage() {
+    public function test_getMessage()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $context = new HTMLPurifier_Context();
         $lang = new HTMLPurifier_Language($config, $context);
@@ -25,7 +27,8 @@ class HTMLPurifier_LanguageTest extends HTMLPurifier_Harness
         $this->assertIdentical($lang->getMessage('LanguageTest: Totally non-existent key'), '[LanguageTest: Totally non-existent key]');
     }
 
-    function test_formatMessage() {
+    public function test_formatMessage()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $context = new HTMLPurifier_Context();
         $lang = new HTMLPurifier_Language($config, $context);
@@ -34,7 +37,8 @@ class HTMLPurifier_LanguageTest extends HTMLPurifier_Harness
         $this->assertIdentical($lang->formatMessage('LanguageTest: Error', array(1=>'fatal', 32)), 'Error is fatal on line 32');
     }
 
-    function test_formatMessage_tokenParameter() {
+    public function test_formatMessage_tokenParameter()
+    {
         $config = HTMLPurifier_Config::createDefault();
         $context = new HTMLPurifier_Context();
         $generator = new HTMLPurifier_Generator($config, $context); // replace with mock if this gets icky
@@ -51,14 +55,16 @@ class HTMLPurifier_LanguageTest extends HTMLPurifier_Harness
             'Data Token: data>, data&gt;, data&gt;, 23');
     }
 
-    function test_listify() {
+    public function test_listify()
+    {
         $lang = $this->generateEnLanguage();
         $this->assertEqual($lang->listify(array('Item')), 'Item');
         $this->assertEqual($lang->listify(array('Item', 'Item2')), 'Item and Item2');
         $this->assertEqual($lang->listify(array('Item', 'Item2', 'Item3')), 'Item, Item2 and Item3');
     }
 
-    function test_formatMessage_arrayParameter() {
+    public function test_formatMessage_arrayParameter()
+    {
         $lang = $this->generateEnLanguage();
 
         $array = array('Item1', 'Item2', 'Item3');

--- a/tests/HTMLPurifier/LengthTest.php
+++ b/tests/HTMLPurifier/LengthTest.php
@@ -3,24 +3,28 @@
 class HTMLPurifier_LengthTest extends HTMLPurifier_Harness
 {
 
-    function testConstruct() {
+    public function testConstruct()
+    {
         $l = new HTMLPurifier_Length('23', 'in');
         $this->assertIdentical($l->getN(), '23');
         $this->assertIdentical($l->getUnit(), 'in');
     }
 
-    function testMake() {
+    public function testMake()
+    {
         $l = HTMLPurifier_Length::make('+23.4in');
         $this->assertIdentical($l->getN(), '+23.4');
         $this->assertIdentical($l->getUnit(), 'in');
     }
 
-    function testToString() {
+    public function testToString()
+    {
         $l = new HTMLPurifier_Length('23', 'in');
         $this->assertIdentical($l->toString(), '23in');
     }
 
-    protected function assertValidate($string, $expect = true) {
+    protected function assertValidate($string, $expect = true)
+    {
         if ($expect === true) $expect = $string;
         $l = HTMLPurifier_Length::make($string);
         $result = $l->isValid();
@@ -28,7 +32,8 @@ class HTMLPurifier_LengthTest extends HTMLPurifier_Harness
         else $this->assertIdentical($l->toString(), $expect);
     }
 
-    function testValidate() {
+    public function testValidate()
+    {
         $this->assertValidate('0');
         $this->assertValidate('+0', '0');
         $this->assertValidate('-0', '0');
@@ -52,7 +57,8 @@ class HTMLPurifier_LengthTest extends HTMLPurifier_Harness
      * @param $s2 Second string to compare
      * @param $expect 0 for $s1 == $s2, 1 for $s1 > $s2 and -1 for $s1 < $s2
      */
-    protected function assertComparison($s1, $s2, $expect = 0) {
+    protected function assertComparison($s1, $s2, $expect = 0)
+    {
         $l1 = HTMLPurifier_Length::make($s1);
         $l2 = HTMLPurifier_Length::make($s2);
         $r1 = $l1->compareTo($l2);
@@ -61,7 +67,8 @@ class HTMLPurifier_LengthTest extends HTMLPurifier_Harness
         $this->assertIdentical($r2 == 0 ? 0 : ($r2 > 0 ? 1 : -1), - $expect);
     }
 
-    function testCompareTo() {
+    public function testCompareTo()
+    {
         $this->assertComparison('12in', '12in');
         $this->assertComparison('12in', '12mm', 1);
         $this->assertComparison('1px', '1mm', -1);

--- a/tests/HTMLPurifier/Lexer/DirectLexTest.php
+++ b/tests/HTMLPurifier/Lexer/DirectLexTest.php
@@ -5,13 +5,14 @@ class HTMLPurifier_Lexer_DirectLexTest extends HTMLPurifier_Harness
 
     protected $DirectLex;
 
-    function setUp() {
+    public function setUp()
+    {
         $this->DirectLex = new HTMLPurifier_Lexer_DirectLex();
     }
 
     // internals testing
-    function test_parseAttributeString() {
-
+    public function test_parseAttributeString()
+    {
         $input[0] = 'href="about:blank" rel="nofollow"';
         $expect[0] = array('href'=>'about:blank', 'rel'=>'nofollow');
 
@@ -73,8 +74,8 @@ class HTMLPurifier_Lexer_DirectLexTest extends HTMLPurifier_Harness
 
     }
 
-    function testLineNumbers() {
-
+    public function testLineNumbers()
+    {
         //       .  .     .     .  .     .     .           .      .             .
         //       01234567890123 01234567890123 0123456789012345 0123456789012   012345
         $html = "<b>Line 1</b>\n<i>Line 2</i>\nStill Line 2<br\n/>Now Line 4\n\n<br />";

--- a/tests/HTMLPurifier/Lexer/DirectLex_ErrorsTest.php
+++ b/tests/HTMLPurifier/Lexer/DirectLex_ErrorsTest.php
@@ -3,34 +3,40 @@
 class HTMLPurifier_Lexer_DirectLex_ErrorsTest extends HTMLPurifier_ErrorsHarness
 {
 
-    function invoke($input) {
+    public function invoke($input)
+    {
         $lexer = new HTMLPurifier_Lexer_DirectLex();
         $lexer->tokenizeHTML($input, $this->config, $this->context);
     }
 
-    function invokeAttr($input) {
+    public function invokeAttr($input)
+    {
         $lexer = new HTMLPurifier_Lexer_DirectLex();
         $lexer->parseAttributeString($input, $this->config, $this->context);
     }
 
-    function testExtractBody() {
+    public function testExtractBody()
+    {
         $this->expectErrorCollection(E_WARNING, 'Lexer: Extracted body');
         $this->invoke('<body>foo</body>');
     }
 
-    function testUnclosedComment() {
+    public function testUnclosedComment()
+    {
         $this->expectErrorCollection(E_WARNING, 'Lexer: Unclosed comment');
         $this->expectContext('CurrentLine', 1);
         $this->invoke('<!-- >');
     }
 
-    function testUnescapedLt() {
+    public function testUnescapedLt()
+    {
         $this->expectErrorCollection(E_NOTICE, 'Lexer: Unescaped lt');
         $this->expectContext('CurrentLine', 1);
         $this->invoke('< foo>');
     }
 
-    function testMissingGt() {
+    public function testMissingGt()
+    {
         $this->expectErrorCollection(E_WARNING, 'Lexer: Missing gt');
         $this->expectContext('CurrentLine', 1);
         $this->invoke('<a href=""');
@@ -38,17 +44,20 @@ class HTMLPurifier_Lexer_DirectLex_ErrorsTest extends HTMLPurifier_ErrorsHarness
 
     // these are sub-errors, will only be thrown in context of collector
 
-    function testMissingAttributeKey1() {
+    public function testMissingAttributeKey1()
+    {
         $this->expectErrorCollection(E_ERROR, 'Lexer: Missing attribute key');
         $this->invokeAttr('=""');
     }
 
-    function testMissingAttributeKey2() {
+    public function testMissingAttributeKey2()
+    {
         $this->expectErrorCollection(E_ERROR, 'Lexer: Missing attribute key');
         $this->invokeAttr('foo="bar" =""');
     }
 
-    function testMissingEndQuote() {
+    public function testMissingEndQuote()
+    {
         $this->expectErrorCollection(E_ERROR, 'Lexer: Missing end quote');
         $this->invokeAttr('src="foo');
     }

--- a/tests/HTMLPurifier/LexerTest.php
+++ b/tests/HTMLPurifier/LexerTest.php
@@ -5,7 +5,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
 
     protected $_has_pear = false;
 
-    public function __construct() {
+    public function __construct()
+    {
         parent::__construct();
         if ($GLOBALS['HTMLPurifierTest']['PH5P']) {
             require_once 'HTMLPurifier/Lexer/PH5P.php';
@@ -14,25 +15,29 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
 
     // HTMLPurifier_Lexer::create() --------------------------------------------
 
-    function test_create() {
+    public function test_create()
+    {
         $this->config->set('Core.MaintainLineNumbers', true);
         $lexer = HTMLPurifier_Lexer::create($this->config);
         $this->assertIsA($lexer, 'HTMLPurifier_Lexer_DirectLex');
     }
 
-    function test_create_objectLexerImpl() {
+    public function test_create_objectLexerImpl()
+    {
         $this->config->set('Core.LexerImpl', new HTMLPurifier_Lexer_DirectLex());
         $lexer = HTMLPurifier_Lexer::create($this->config);
         $this->assertIsA($lexer, 'HTMLPurifier_Lexer_DirectLex');
     }
 
-    function test_create_unknownLexer() {
+    public function test_create_unknownLexer()
+    {
         $this->config->set('Core.LexerImpl', 'AsdfAsdf');
         $this->expectException(new HTMLPurifier_Exception('Cannot instantiate unrecognized Lexer type AsdfAsdf'));
         HTMLPurifier_Lexer::create($this->config);
     }
 
-    function test_create_incompatibleLexer() {
+    public function test_create_incompatibleLexer()
+    {
         $this->config->set('Core.LexerImpl', 'DOMLex');
         $this->config->set('Core.MaintainLineNumbers', true);
         $this->expectException(new HTMLPurifier_Exception('Cannot use lexer that does not support line numbers with Core.MaintainLineNumbers or Core.CollectErrors (use DirectLex instead)'));
@@ -41,70 +46,85 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
 
     // HTMLPurifier_Lexer->parseData() -----------------------------------------
 
-    function assertParseData($input, $expect = true) {
+    public function assertParseData($input, $expect = true)
+    {
         if ($expect === true) $expect = $input;
         $lexer = new HTMLPurifier_Lexer();
         $this->assertIdentical($expect, $lexer->parseData($input));
     }
 
-    function test_parseData_plainText() {
+    public function test_parseData_plainText()
+    {
         $this->assertParseData('asdf');
     }
 
-    function test_parseData_ampersandEntity() {
+    public function test_parseData_ampersandEntity()
+    {
         $this->assertParseData('&amp;', '&');
     }
 
-    function test_parseData_quotEntity() {
+    public function test_parseData_quotEntity()
+    {
         $this->assertParseData('&quot;', '"');
     }
 
-    function test_parseData_aposNumericEntity() {
+    public function test_parseData_aposNumericEntity()
+    {
         $this->assertParseData('&#039;', "'");
     }
 
-    function test_parseData_aposCompactNumericEntity() {
+    public function test_parseData_aposCompactNumericEntity()
+    {
         $this->assertParseData('&#39;', "'");
     }
 
-    function test_parseData_adjacentAmpersandEntities() {
+    public function test_parseData_adjacentAmpersandEntities()
+    {
         $this->assertParseData('&amp;&amp;&amp;', '&&&');
     }
 
-    function test_parseData_trailingUnescapedAmpersand() {
+    public function test_parseData_trailingUnescapedAmpersand()
+    {
         $this->assertParseData('&amp;&', '&&');
     }
 
-    function test_parseData_internalUnescapedAmpersand() {
+    public function test_parseData_internalUnescapedAmpersand()
+    {
         $this->assertParseData('Procter & Gamble');
     }
 
-    function test_parseData_improperEntityFaultToleranceTest() {
+    public function test_parseData_improperEntityFaultToleranceTest()
+    {
         $this->assertParseData('&#x2D;');
     }
 
     // HTMLPurifier_Lexer->extractBody() ---------------------------------------
 
-    function assertExtractBody($text, $extract = true) {
+    public function assertExtractBody($text, $extract = true)
+    {
         $lexer = new HTMLPurifier_Lexer();
         $result = $lexer->extractBody($text);
         if ($extract === true) $extract = $text;
         $this->assertIdentical($extract, $result);
     }
 
-    function test_extractBody_noBodyTags() {
+    public function test_extractBody_noBodyTags()
+    {
         $this->assertExtractBody('<b>Bold</b>');
     }
 
-    function test_extractBody_lowercaseBodyTags() {
+    public function test_extractBody_lowercaseBodyTags()
+    {
         $this->assertExtractBody('<html><body><b>Bold</b></body></html>', '<b>Bold</b>');
     }
 
-    function test_extractBody_uppercaseBodyTags() {
+    public function test_extractBody_uppercaseBodyTags()
+    {
         $this->assertExtractBody('<HTML><BODY><B>Bold</B></BODY></HTML>', '<B>Bold</B>');
     }
 
-    function test_extractBody_realisticUseCase() {
+    public function test_extractBody_realisticUseCase()
+    {
         $this->assertExtractBody(
 '<?xml version="1.0"
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
@@ -134,21 +154,25 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
    ');
     }
 
-    function test_extractBody_bodyWithAttributes() {
+    public function test_extractBody_bodyWithAttributes()
+    {
         $this->assertExtractBody('<html><body bgcolor="#F00"><b>Bold</b></body></html>', '<b>Bold</b>');
     }
 
-    function test_extractBody_preserveUnclosedBody() {
+    public function test_extractBody_preserveUnclosedBody()
+    {
         $this->assertExtractBody('<body>asdf'); // not closed, don't accept
     }
 
-    function test_extractBody_useLastBody() {
+    public function test_extractBody_useLastBody()
+    {
         $this->assertExtractBody('<body>foo</body>bar</body>', 'foo</body>bar');
     }
 
     // HTMLPurifier_Lexer->tokenizeHTML() --------------------------------------
 
-    function assertTokenization($input, $expect, $alt_expect = array()) {
+    public function assertTokenization($input, $expect, $alt_expect = array())
+    {
         $lexers = array();
         $lexers['DirectLex']  = new HTMLPurifier_Lexer_DirectLex();
         if (class_exists('DOMDocument')) {
@@ -171,11 +195,13 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         }
     }
 
-    function test_tokenizeHTML_emptyInput() {
+    public function test_tokenizeHTML_emptyInput()
+    {
         $this->assertTokenization('', array());
     }
 
-    function test_tokenizeHTML_plainText() {
+    public function test_tokenizeHTML_plainText()
+    {
         $this->assertTokenization(
             'This is regular text.',
             array(
@@ -184,7 +210,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_textAndTags() {
+    public function test_tokenizeHTML_textAndTags()
+    {
         $this->assertTokenization(
             'This is <b>bold</b> text',
             array(
@@ -197,7 +224,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_normalizeCase() {
+    public function test_tokenizeHTML_normalizeCase()
+    {
         $this->assertTokenization(
             '<DIV>Totally rad dude. <b>asdf</b></div>',
             array(
@@ -211,7 +239,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_notWellFormed() {
+    public function test_tokenizeHTML_notWellFormed()
+    {
         $this->assertTokenization(
             '<asdf></asdf><d></d><poOloka><poolasdf><ds></asdf></ASDF>',
             array(
@@ -240,7 +269,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_whitespaceInTag() {
+    public function test_tokenizeHTML_whitespaceInTag()
+    {
         $this->assertTokenization(
             '<a'."\t".'href="foobar.php"'."\n".'title="foo!">Link to <b id="asdf">foobar</b></a>',
             array(
@@ -254,7 +284,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_singleAttribute() {
+    public function test_tokenizeHTML_singleAttribute()
+    {
         $this->assertTokenization(
             '<br style="&amp;" />',
             array(
@@ -263,28 +294,32 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_emptyTag() {
+    public function test_tokenizeHTML_emptyTag()
+    {
         $this->assertTokenization(
             '<br />',
             array( new HTMLPurifier_Token_Empty('br') )
         );
     }
 
-    function test_tokenizeHTML_comment() {
+    public function test_tokenizeHTML_comment()
+    {
         $this->assertTokenization(
             '<!-- Comment -->',
             array( new HTMLPurifier_Token_Comment(' Comment ') )
         );
     }
 
-    function test_tokenizeHTML_malformedComment() {
+    public function test_tokenizeHTML_malformedComment()
+    {
         $this->assertTokenization(
             '<!-- not so well formed --->',
             array( new HTMLPurifier_Token_Comment(' not so well formed -') )
         );
     }
 
-    function test_tokenizeHTML_unterminatedTag() {
+    public function test_tokenizeHTML_unterminatedTag()
+    {
         $this->assertTokenization(
             '<a href=""',
             array( new HTMLPurifier_Token_Text('<a href=""') ),
@@ -296,7 +331,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_specialEntities() {
+    public function test_tokenizeHTML_specialEntities()
+    {
         $this->assertTokenization(
             '&lt;b&gt;',
             array(
@@ -313,7 +349,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_earlyQuote() {
+    public function test_tokenizeHTML_earlyQuote()
+    {
         $this->assertTokenization(
             '<a "=>',
             array( new HTMLPurifier_Token_Empty('a') ),
@@ -327,7 +364,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_earlyQuote_PH5P() {
+    public function test_tokenizeHTML_earlyQuote_PH5P()
+    {
         if (!class_exists('DOMDocument')) return;
         $lexer = new HTMLPurifier_Lexer_PH5P();
         $result = $lexer->tokenizeHTML('<a "=>', $this->config, $this->context);
@@ -342,21 +380,24 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         }
     }
 
-    function test_tokenizeHTML_unescapedQuote() {
+    public function test_tokenizeHTML_unescapedQuote()
+    {
         $this->assertTokenization(
             '"',
             array( new HTMLPurifier_Token_Text('"') )
         );
     }
 
-    function test_tokenizeHTML_escapedQuote() {
+    public function test_tokenizeHTML_escapedQuote()
+    {
         $this->assertTokenization(
             '&quot;',
             array( new HTMLPurifier_Token_Text('"') )
         );
     }
 
-    function test_tokenizeHTML_cdata() {
+    public function test_tokenizeHTML_cdata()
+    {
         $this->assertTokenization(
             '<![CDATA[You <b>can&#39;t</b> get me!]]>',
             array( new HTMLPurifier_Token_Text('You <b>can&#39;t</b> get me!') ),
@@ -378,14 +419,16 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_characterEntity() {
+    public function test_tokenizeHTML_characterEntity()
+    {
         $this->assertTokenization(
             '&theta;',
             array( new HTMLPurifier_Token_Text("\xCE\xB8") )
         );
     }
 
-    function test_tokenizeHTML_characterEntityInCDATA() {
+    public function test_tokenizeHTML_characterEntityInCDATA()
+    {
         $this->assertTokenization(
             '<![CDATA[&rarr;]]>',
             array( new HTMLPurifier_Token_Text("&rarr;") ),
@@ -398,7 +441,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_entityInAttribute() {
+    public function test_tokenizeHTML_entityInAttribute()
+    {
         $this->assertTokenization(
             '<a href="index.php?title=foo&amp;id=bar">Link</a>',
             array(
@@ -409,21 +453,24 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_preserveUTF8() {
+    public function test_tokenizeHTML_preserveUTF8()
+    {
         $this->assertTokenization(
             "\xCE\xB8",
             array( new HTMLPurifier_Token_Text("\xCE\xB8") )
         );
     }
 
-    function test_tokenizeHTML_specialEntityInAttribute() {
+    public function test_tokenizeHTML_specialEntityInAttribute()
+    {
         $this->assertTokenization(
             '<br test="x &lt; 6" />',
             array( new HTMLPurifier_Token_Empty('br', array('test' => 'x < 6')) )
         );
     }
 
-    function test_tokenizeHTML_emoticonProtection() {
+    public function test_tokenizeHTML_emoticonProtection()
+    {
         $this->assertTokenization(
             '<b>Whoa! <3 That\'s not good >.></b>',
             array(
@@ -451,7 +498,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_commentWithFunkyChars() {
+    public function test_tokenizeHTML_commentWithFunkyChars()
+    {
         $this->assertTokenization(
             '<!-- This >< comment --><br />',
             array(
@@ -461,7 +509,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_unterminatedComment() {
+    public function test_tokenizeHTML_unterminatedComment()
+    {
         $this->assertTokenization(
             '<!-- This >< comment',
             array( new HTMLPurifier_Token_Comment(' This >< comment') ),
@@ -472,7 +521,8 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_scriptCDATAContents() {
+    public function test_tokenizeHTML_scriptCDATAContents()
+    {
         $this->config->set('HTML.Trusted', true);
         $this->assertTokenization(
             'Foo: <script>alert("<foo>");</script>',
@@ -489,14 +539,16 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_entitiesInComment() {
+    public function test_tokenizeHTML_entitiesInComment()
+    {
         $this->assertTokenization(
             '<!-- This comment < &lt; & -->',
             array( new HTMLPurifier_Token_Comment(' This comment < &lt; & ') )
         );
     }
 
-    function test_tokenizeHTML_attributeWithSpecialCharacters() {
+    public function test_tokenizeHTML_attributeWithSpecialCharacters()
+    {
         $this->assertTokenization(
             '<a href="><>">',
             array( new HTMLPurifier_Token_Empty('a', array('href' => '><>')) ),
@@ -510,14 +562,16 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
         );
     }
 
-    function test_tokenizeHTML_emptyTagWithSlashInAttribute() {
+    public function test_tokenizeHTML_emptyTagWithSlashInAttribute()
+    {
         $this->assertTokenization(
             '<param name="src" value="http://example.com/video.wmv" />',
             array( new HTMLPurifier_Token_Empty('param', array('name' => 'src', 'value' => 'http://example.com/video.wmv')) )
         );
     }
 
-    function test_tokenizeHTML_style() {
+    public function test_tokenizeHTML_style()
+    {
         $extra = array(
                 // PH5P doesn't seem to like style tags
                 'PH5P' => false,
@@ -551,7 +605,8 @@ div {}
         );
     }
 
-    function test_tokenizeHTML_tagWithAtSignAndExtraGt() {
+    public function test_tokenizeHTML_tagWithAtSignAndExtraGt()
+    {
         $alt_expect = array(
             // Technically this is invalid, but it won't be a
             // problem with invalid element removal; also, this
@@ -572,7 +627,8 @@ div {}
         );
     }
 
-    function test_tokenizeHTML_emoticonHeart() {
+    public function test_tokenizeHTML_emoticonHeart()
+    {
         $this->assertTokenization(
             '<br /><3<br />',
             array(
@@ -591,7 +647,8 @@ div {}
         );
     }
 
-    function test_tokenizeHTML_emoticonShiftyEyes() {
+    public function test_tokenizeHTML_emoticonShiftyEyes()
+    {
         $this->assertTokenization(
             '<b><<</b>',
             array(
@@ -610,7 +667,8 @@ div {}
         );
     }
 
-    function test_tokenizeHTML_eon1996() {
+    public function test_tokenizeHTML_eon1996()
+    {
         $this->assertTokenization(
             '< <b>test</b>',
             array(
@@ -631,7 +689,8 @@ div {}
         );
     }
 
-    function test_tokenizeHTML_bodyInCDATA() {
+    public function test_tokenizeHTML_bodyInCDATA()
+    {
         $alt_tokens = array(
             new HTMLPurifier_Token_Text('<'),
             new HTMLPurifier_Token_Text('body'),
@@ -652,7 +711,8 @@ div {}
         );
     }
 
-    function test_tokenizeHTML_() {
+    public function test_tokenizeHTML_()
+    {
         $this->assertTokenization(
             '<a><img /></a>',
             array(
@@ -663,14 +723,16 @@ div {}
         );
     }
 
-    function test_tokenizeHTML_ignoreIECondComment() {
+    public function test_tokenizeHTML_ignoreIECondComment()
+    {
         $this->assertTokenization(
             '<!--[if IE]>foo<a>bar<!-- baz --><![endif]-->',
             array()
         );
     }
 
-    function test_tokenizeHTML_removeProcessingInstruction() {
+    public function test_tokenizeHTML_removeProcessingInstruction()
+    {
         $this->config->set('Core.RemoveProcessingInstructions', true);
         $this->assertTokenization(
             '<?xml blah blah ?>',
@@ -678,7 +740,8 @@ div {}
         );
     }
 
-   function test_tokenizeHTML_removeNewline() {
+   public function test_tokenizeHTML_removeNewline()
+   {
         $this->config->set('Core.NormalizeNewlines', true);
         $this->assertTokenization(
             "plain\rtext\r\n",
@@ -688,7 +751,8 @@ div {}
         );
    }
 
-   function test_tokenizeHTML_noRemoveNewline() {
+   public function test_tokenizeHTML_noRemoveNewline()
+   {
         $this->config->set('Core.NormalizeNewlines', false);
         $this->assertTokenization(
             "plain\rtext\r\n",
@@ -698,7 +762,8 @@ div {}
         );
      }
 
-    function test_tokenizeHTML_conditionalCommentUngreedy() {
+    public function test_tokenizeHTML_conditionalCommentUngreedy()
+    {
         $this->assertTokenization(
             '<!--[if gte mso 9]>a<![endif]-->b<!--[if gte mso 9]>c<![endif]-->',
             array(
@@ -707,7 +772,8 @@ div {}
         );
     }
 
-    function test_tokenizeHTML_imgTag() {
+    public function test_tokenizeHTML_imgTag()
+    {
         $start = array(
                         new HTMLPurifier_Token_Start('img',
                             array(
@@ -737,7 +803,8 @@ div {}
 
     /*
 
-    function test_tokenizeHTML_() {
+    public function test_tokenizeHTML_()
+    {
         $this->assertTokenization(
             ,
             array(

--- a/tests/HTMLPurifier/PercentEncoderTest.php
+++ b/tests/HTMLPurifier/PercentEncoderTest.php
@@ -6,17 +6,20 @@ class HTMLPurifier_PercentEncoderTest extends HTMLPurifier_Harness
     protected $PercentEncoder;
     protected $func;
 
-    function setUp() {
+    public function setUp()
+    {
         $this->PercentEncoder = new HTMLPurifier_PercentEncoder();
         $this->func = '';
     }
 
-    function assertDecode($string, $expect = true) {
+    public function assertDecode($string, $expect = true)
+    {
         if ($expect === true) $expect = $string;
         $this->assertIdentical($this->PercentEncoder->{$this->func}($string), $expect);
     }
 
-    function test_normalize() {
+    public function test_normalize()
+    {
         $this->func = 'normalize';
 
         $this->assertDecode('Aw.../-$^8'); // no change
@@ -35,26 +38,31 @@ class HTMLPurifier_PercentEncoderTest extends HTMLPurifier_Harness
 
     }
 
-    function assertEncode($string, $expect = true, $preserve = false) {
+    public function assertEncode($string, $expect = true, $preserve = false)
+    {
         if ($expect === true) $expect = $string;
         $encoder = new HTMLPurifier_PercentEncoder($preserve);
         $result = $encoder->encode($string);
         $this->assertIdentical($result, $expect);
     }
 
-    function test_encode_noChange() {
+    public function test_encode_noChange()
+    {
         $this->assertEncode('abc012-_~.');
     }
 
-    function test_encode_encode() {
+    public function test_encode_encode()
+    {
         $this->assertEncode('>', '%3E');
     }
 
-    function test_encode_preserve() {
+    public function test_encode_preserve()
+    {
         $this->assertEncode('<>', '<%3E', '<');
     }
 
-    function test_encode_low() {
+    public function test_encode_low()
+    {
         $this->assertEncode("\1", '%01');
     }
 

--- a/tests/HTMLPurifier/PropertyListTest.php
+++ b/tests/HTMLPurifier/PropertyListTest.php
@@ -3,19 +3,22 @@
 class HTMLPurifier_PropertyListTest extends UnitTestCase
 {
 
-    function testBasic() {
+    public function testBasic()
+    {
         $plist = new HTMLPurifier_PropertyList();
         $plist->set('key', 'value');
         $this->assertIdentical($plist->get('key'), 'value');
     }
 
-    function testNotFound() {
+    public function testNotFound()
+    {
         $this->expectException(new HTMLPurifier_Exception("Key 'key' not found"));
         $plist = new HTMLPurifier_PropertyList();
         $plist->get('key');
     }
 
-    function testRecursion() {
+    public function testRecursion()
+    {
         $parent_plist = new HTMLPurifier_PropertyList();
         $parent_plist->set('key', 'value');
         $plist = new HTMLPurifier_PropertyList();
@@ -23,7 +26,8 @@ class HTMLPurifier_PropertyListTest extends UnitTestCase
         $this->assertIdentical($plist->get('key'), 'value');
     }
 
-    function testOverride() {
+    public function testOverride()
+    {
         $parent_plist = new HTMLPurifier_PropertyList();
         $parent_plist->set('key', 'value');
         $plist = new HTMLPurifier_PropertyList();
@@ -32,7 +36,8 @@ class HTMLPurifier_PropertyListTest extends UnitTestCase
         $this->assertIdentical($plist->get('key'), 'value2');
     }
 
-    function testRecursionNotFound() {
+    public function testRecursionNotFound()
+    {
         $this->expectException(new HTMLPurifier_Exception("Key 'key' not found"));
         $parent_plist = new HTMLPurifier_PropertyList();
         $plist = new HTMLPurifier_PropertyList();
@@ -40,14 +45,16 @@ class HTMLPurifier_PropertyListTest extends UnitTestCase
         $this->assertIdentical($plist->get('key'), 'value');
     }
 
-    function testHas() {
+    public function testHas()
+    {
         $plist = new HTMLPurifier_PropertyList();
         $this->assertIdentical($plist->has('key'), false);
         $plist->set('key', 'value');
         $this->assertIdentical($plist->has('key'), true);
     }
 
-    function testReset() {
+    public function testReset()
+    {
         $plist = new HTMLPurifier_PropertyList();
         $plist->set('key1', 'value');
         $plist->set('key2', 'value');
@@ -65,7 +72,8 @@ class HTMLPurifier_PropertyListTest extends UnitTestCase
         $this->assertIdentical($plist->has('key3'), false);
     }
 
-    function testSquash() {
+    public function testSquash()
+    {
         $parent = new HTMLPurifier_PropertyList();
         $parent->set('key1', 'hidden');
         $parent->set('key2', 2);

--- a/tests/HTMLPurifier/SimpleTest/Reporter.php
+++ b/tests/HTMLPurifier/SimpleTest/Reporter.php
@@ -5,12 +5,14 @@ class HTMLPurifier_SimpleTest_Reporter extends HTMLReporter
 
     protected $ac;
 
-    public function __construct($encoding, $ac) {
+    public function __construct($encoding, $ac)
+    {
         $this->ac = $ac;
         parent::__construct($encoding);
     }
 
-    public function paintHeader($test_name) {
+    public function paintHeader($test_name)
+    {
         parent::paintHeader($test_name);
 ?>
 <form action="" method="get" id="select">
@@ -29,7 +31,8 @@ class HTMLPurifier_SimpleTest_Reporter extends HTMLReporter
         flush();
     }
 
-    public function paintFooter($test_name) {
+    public function paintFooter($test_name)
+    {
         if (function_exists('xdebug_peak_memory_usage')) {
             $max_mem = number_format(xdebug_peak_memory_usage());
             echo "<div>Max memory usage: $max_mem bytes</div>";
@@ -37,7 +40,8 @@ class HTMLPurifier_SimpleTest_Reporter extends HTMLReporter
         parent::paintFooter($test_name);
     }
 
-    protected function getCss() {
+    protected function getCss()
+    {
         $css = parent::getCss();
         $css .= '
         #select {position:absolute;top:0.2em;right:0.2em;}
@@ -45,7 +49,8 @@ class HTMLPurifier_SimpleTest_Reporter extends HTMLReporter
         return $css;
     }
 
-    function getTestList() {
+    public function getTestList()
+    {
         // hacky; depends on a specific implementation of paintPass, etc.
         $list = parent::getTestList();
         $testcase = $list[1];

--- a/tests/HTMLPurifier/SimpleTest/TextReporter.php
+++ b/tests/HTMLPurifier/SimpleTest/TextReporter.php
@@ -1,12 +1,15 @@
 <?php
 
-class HTMLPurifier_SimpleTest_TextReporter extends TextReporter {
+class HTMLPurifier_SimpleTest_TextReporter extends TextReporter
+{
     protected $verbose = false;
-    function __construct($AC) {
+    public function __construct($AC)
+    {
         parent::__construct();
         $this->verbose = $AC['verbose'];
     }
-    function paintPass($message) {
+    public function paintPass($message)
+    {
         parent::paintPass($message);
         if ($this->verbose) {
             print 'Pass ' . $this->getPassCount() . ") $message\n";

--- a/tests/HTMLPurifier/Strategy/CompositeTest.php
+++ b/tests/HTMLPurifier/Strategy/CompositeTest.php
@@ -4,7 +4,8 @@ class HTMLPurifier_Strategy_Composite_Test
     extends HTMLPurifier_Strategy_Composite
 {
 
-    public function __construct(&$strategies) {
+    public function __construct(&$strategies)
+    {
         $this->strategies =& $strategies;
     }
 
@@ -14,8 +15,8 @@ class HTMLPurifier_Strategy_Composite_Test
 class HTMLPurifier_Strategy_CompositeTest extends HTMLPurifier_Harness
 {
 
-    function test() {
-
+    public function test()
+    {
         generate_mock_once('HTMLPurifier_Strategy');
         generate_mock_once('HTMLPurifier_Config');
         generate_mock_once('HTMLPurifier_Context');

--- a/tests/HTMLPurifier/Strategy/CoreTest.php
+++ b/tests/HTMLPurifier/Strategy/CoreTest.php
@@ -3,37 +3,43 @@
 class HTMLPurifier_Strategy_CoreTest extends HTMLPurifier_StrategyHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_Core();
     }
 
-    function testBlankInput() {
+    public function testBlankInput()
+    {
         $this->assertResult('');
     }
 
-    function testMakeWellFormed() {
+    public function testMakeWellFormed()
+    {
         $this->assertResult(
             '<b>Make well formed.',
             '<b>Make well formed.</b>'
         );
     }
 
-    function testFixNesting() {
+    public function testFixNesting()
+    {
         $this->assertResult(
             '<b><div>Fix nesting.</div></b>',
             '<b></b><div><b>Fix nesting.</b></div><b></b>'
         );
     }
 
-    function testRemoveForeignElements() {
+    public function testRemoveForeignElements()
+    {
         $this->assertResult(
             '<asdf>Foreign element removal.</asdf>',
             'Foreign element removal.'
         );
     }
 
-    function testFirstThree() {
+    public function testFirstThree()
+    {
         $this->assertResult(
             '<foo><b><div>All three.</div></b>',
             '<b></b><div><b>All three.</b></div><b></b>'

--- a/tests/HTMLPurifier/Strategy/ErrorsHarness.php
+++ b/tests/HTMLPurifier/Strategy/ErrorsHarness.php
@@ -6,7 +6,8 @@ class HTMLPurifier_Strategy_ErrorsHarness extends HTMLPurifier_ErrorsHarness
     // needs to be defined
     protected function getStrategy() {}
 
-    protected function invoke($input) {
+    protected function invoke($input)
+    {
         $strategy = $this->getStrategy();
         $lexer = new HTMLPurifier_Lexer_DirectLex();
         $tokens = $lexer->tokenizeHTML($input, $this->config, $this->context);

--- a/tests/HTMLPurifier/Strategy/FixNestingTest.php
+++ b/tests/HTMLPurifier/Strategy/FixNestingTest.php
@@ -3,27 +3,32 @@
 class HTMLPurifier_Strategy_FixNestingTest extends HTMLPurifier_StrategyHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_FixNesting();
     }
 
-    function testPreserveInlineInRoot() {
+    public function testPreserveInlineInRoot()
+    {
         $this->assertResult('<b>Bold text</b>');
     }
 
-    function testPreserveInlineAndBlockInRoot() {
+    public function testPreserveInlineAndBlockInRoot()
+    {
         $this->assertResult('<a href="about:blank">Blank</a><div>Block</div>');
     }
 
-    function testRemoveBlockInInline() {
+    public function testRemoveBlockInInline()
+    {
         $this->assertResult(
             '<b><div>Illegal div.</div></b>',
             '<b>Illegal div.</b>'
         );
     }
 
-    function testEscapeBlockInInline() {
+    public function testEscapeBlockInInline()
+    {
         $this->config->set('Core.EscapeInvalidChildren', true);
         $this->assertResult(
             '<b><div>Illegal div.</div></b>',
@@ -31,60 +36,70 @@ class HTMLPurifier_Strategy_FixNestingTest extends HTMLPurifier_StrategyHarness
         );
     }
 
-    function testRemoveNodeWithMissingRequiredElements() {
+    public function testRemoveNodeWithMissingRequiredElements()
+    {
         $this->assertResult('<ul></ul>', '');
     }
 
-    function testListHandleIllegalPCDATA() {
+    public function testListHandleIllegalPCDATA()
+    {
         $this->assertResult(
             '<ul>Illegal text<li>Legal item</li></ul>',
             '<ul><li>Illegal text</li><li>Legal item</li></ul>'
         );
     }
 
-    function testRemoveIllegalPCDATA() {
+    public function testRemoveIllegalPCDATA()
+    {
         $this->assertResult(
             '<table><tr>Illegal text<td></td></tr></table>',
             '<table><tr><td></td></tr></table>'
         );
     }
 
-    function testCustomTableDefinition() {
+    public function testCustomTableDefinition()
+    {
         $this->assertResult('<table><tr><td>Cell 1</td></tr></table>');
     }
 
-    function testRemoveEmptyTable() {
+    public function testRemoveEmptyTable()
+    {
         $this->assertResult('<table></table>', '');
     }
 
-    function testChameleonRemoveBlockInNodeInInline() {
+    public function testChameleonRemoveBlockInNodeInInline()
+    {
         $this->assertResult(
           '<span><ins><div>Not allowed!</div></ins></span>',
           '<span><ins>Not allowed!</ins></span>'
         );
     }
 
-    function testChameleonRemoveBlockInBlockNodeWithInlineContent() {
+    public function testChameleonRemoveBlockInBlockNodeWithInlineContent()
+    {
         $this->assertResult(
           '<h1><ins><div>Not allowed!</div></ins></h1>',
           '<h1><ins>Not allowed!</ins></h1>'
         );
     }
 
-    function testNestedChameleonRemoveBlockInNodeWithInlineContent() {
+    public function testNestedChameleonRemoveBlockInNodeWithInlineContent()
+    {
         $this->assertResult(
           '<h1><ins><del><div>Not allowed!</div></del></ins></h1>',
           '<h1><ins><del>Not allowed!</del></ins></h1>'
         );
     }
 
-    function testNestedChameleonPreserveBlockInBlock() {
+    public function testNestedChameleonPreserveBlockInBlock()
+    {
         $this->assertResult(
           '<div><ins><del><div>Allowed!</div></del></ins></div>'
         );
     }
 
-    function testChameleonEscapeInvalidBlockInInline() {
+    public function testChameleonEscapeInvalidBlockInInline()
+    {
         $this->config->set('Core.EscapeInvalidChildren', true);
         $this->assertResult( // alt config
           '<span><ins><div>Not allowed!</div></ins></span>',
@@ -92,7 +107,8 @@ class HTMLPurifier_Strategy_FixNestingTest extends HTMLPurifier_StrategyHarness
         );
     }
 
-    function testExclusionsIntegration() {
+    public function testExclusionsIntegration()
+    {
         // test exclusions
         $this->assertResult(
           '<a><span><a>Not allowed</a></span></a>',
@@ -100,17 +116,20 @@ class HTMLPurifier_Strategy_FixNestingTest extends HTMLPurifier_StrategyHarness
         );
     }
 
-    function testPreserveInlineNodeInInlineRootNode() {
+    public function testPreserveInlineNodeInInlineRootNode()
+    {
         $this->config->set('HTML.Parent', 'span');
         $this->assertResult('<b>Bold</b>');
     }
 
-    function testRemoveBlockNodeInInlineRootNode() {
+    public function testRemoveBlockNodeInInlineRootNode()
+    {
         $this->config->set('HTML.Parent', 'span');
         $this->assertResult('<div>Reject</div>', 'Reject');
    }
 
-   function testInvalidParentError() {
+   public function testInvalidParentError()
+   {
         // test fallback to div
         $this->config->set('HTML.Parent', 'obviously-impossible');
         $this->config->set('Cache.DefinitionImpl', null);
@@ -118,28 +137,34 @@ class HTMLPurifier_Strategy_FixNestingTest extends HTMLPurifier_StrategyHarness
         $this->assertResult('<div>Accept</div>');
     }
 
-    function testCascadingRemovalOfNodesMissingRequiredChildren() {
+    public function testCascadingRemovalOfNodesMissingRequiredChildren()
+    {
         $this->assertResult('<table><tr></tr></table>', '');
     }
 
-    function testCascadingRemovalSpecialCaseCannotScrollOneBack() {
+    public function testCascadingRemovalSpecialCaseCannotScrollOneBack()
+    {
         $this->assertResult('<table><tr></tr><tr></tr></table>', '');
     }
 
-    function testLotsOfCascadingRemovalOfNodes() {
+    public function testLotsOfCascadingRemovalOfNodes()
+    {
         $this->assertResult('<table><tbody><tr></tr><tr></tr></tbody><tr></tr><tr></tr></table>', '');
     }
 
-    function testAdjacentRemovalOfNodeMissingRequiredChildren() {
+    public function testAdjacentRemovalOfNodeMissingRequiredChildren()
+    {
         $this->assertResult('<table></table><table></table>', '');
     }
 
-    function testStrictBlockquoteInHTML401() {
+    public function testStrictBlockquoteInHTML401()
+    {
         $this->config->set('HTML.Doctype', 'HTML 4.01 Strict');
         $this->assertResult('<blockquote>text</blockquote>', '<blockquote><p>text</p></blockquote>');
     }
 
-    function testDisabledExcludes() {
+    public function testDisabledExcludes()
+    {
         $this->config->set('Core.DisableExcludes', true);
         $this->assertResult('<pre><font><font></font></font></pre>');
     }

--- a/tests/HTMLPurifier/Strategy/FixNesting_ErrorsTest.php
+++ b/tests/HTMLPurifier/Strategy/FixNesting_ErrorsTest.php
@@ -3,34 +3,40 @@
 class HTMLPurifier_Strategy_FixNesting_ErrorsTest extends HTMLPurifier_Strategy_ErrorsHarness
 {
 
-    protected function getStrategy() {
+    protected function getStrategy()
+    {
         return new HTMLPurifier_Strategy_FixNesting();
     }
 
-    function testNodeRemoved() {
+    public function testNodeRemoved()
+    {
         $this->expectErrorCollection(E_ERROR, 'Strategy_FixNesting: Node removed');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Start('ul', array(), 1));
         $this->invoke('<ul></ul>');
     }
 
-    function testNodeExcluded() {
+    public function testNodeExcluded()
+    {
         $this->expectErrorCollection(E_ERROR, 'Strategy_FixNesting: Node excluded');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Start('a', array(), 2));
         $this->invoke("<a>\n<a></a></a>");
     }
 
-    function testNodeReorganized() {
+    public function testNodeReorganized()
+    {
         $this->expectErrorCollection(E_WARNING, 'Strategy_FixNesting: Node reorganized');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Start('span', array(), 1));
         $this->invoke("<span>Valid<div>Invalid</div></span>");
     }
 
-    function testNoNodeReorganizedForEmptyNode() {
+    public function testNoNodeReorganizedForEmptyNode()
+    {
         $this->expectNoErrorCollection();
         $this->invoke("<span></span>");
     }
 
-    function testNodeContentsRemoved() {
+    public function testNodeContentsRemoved()
+    {
         $this->expectErrorCollection(E_ERROR, 'Strategy_FixNesting: Node contents removed');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Start('span', array(), 1));
         $this->invoke("<span><div></div></span>");

--- a/tests/HTMLPurifier/Strategy/MakeWellFormed/EndInsertInjector.php
+++ b/tests/HTMLPurifier/Strategy/MakeWellFormed/EndInsertInjector.php
@@ -4,7 +4,8 @@ class HTMLPurifier_Strategy_MakeWellFormed_EndInsertInjector extends HTMLPurifie
 {
     public $name = 'EndInsertInjector';
     public $needed = array('span');
-    public function handleEnd(&$token) {
+    public function handleEnd(&$token)
+    {
         if ($token->name == 'div') return;
         $token = array(
             new HTMLPurifier_Token_Start('b'),

--- a/tests/HTMLPurifier/Strategy/MakeWellFormed/EndInsertInjectorTest.php
+++ b/tests/HTMLPurifier/Strategy/MakeWellFormed/EndInsertInjectorTest.php
@@ -2,35 +2,44 @@
 
 class HTMLPurifier_Strategy_MakeWellFormed_EndInsertInjectorTest extends HTMLPurifier_StrategyHarness
 {
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_MakeWellFormed();
         $this->config->set('AutoFormat.Custom', array(
             new HTMLPurifier_Strategy_MakeWellFormed_EndInsertInjector()
         ));
     }
-    function testEmpty() {
+    public function testEmpty()
+    {
         $this->assertResult('');
     }
-    function testNormal() {
+    public function testNormal()
+    {
         $this->assertResult('<i>Foo</i>', '<i>Foo<b>Comment</b></i>');
     }
-    function testEndOfDocumentProcessing() {
+    public function testEndOfDocumentProcessing()
+    {
         $this->assertResult('<i>Foo', '<i>Foo<b>Comment</b></i>');
     }
-    function testDoubleEndOfDocumentProcessing() {
+    public function testDoubleEndOfDocumentProcessing()
+    {
         $this->assertResult('<i><i>Foo', '<i><i>Foo<b>Comment</b></i><b>Comment</b></i>');
     }
-    function testEndOfNodeProcessing() {
+    public function testEndOfNodeProcessing()
+    {
         $this->assertResult('<div><i>Foo</div>asdf', '<div><i>Foo<b>Comment</b></i></div><i>asdf<b>Comment</b></i>');
     }
-    function testEmptyToStartEndProcessing() {
+    public function testEmptyToStartEndProcessing()
+    {
         $this->assertResult('<i />', '<i><b>Comment</b></i>');
     }
-    function testSpuriousEndTag() {
+    public function testSpuriousEndTag()
+    {
         $this->assertResult('</i>', '');
     }
-    function testLessButStillSpuriousEndTag() {
+    public function testLessButStillSpuriousEndTag()
+    {
         $this->assertResult('<div></i></div>', '<div></div>');
     }
 }

--- a/tests/HTMLPurifier/Strategy/MakeWellFormed/EndRewindInjector.php
+++ b/tests/HTMLPurifier/Strategy/MakeWellFormed/EndRewindInjector.php
@@ -4,15 +4,18 @@ class HTMLPurifier_Strategy_MakeWellFormed_EndRewindInjector extends HTMLPurifie
 {
     public $name = 'EndRewindInjector';
     public $needed = array('span');
-    public function handleElement(&$token) {
+    public function handleElement(&$token)
+    {
         if (isset($token->_InjectorTest_EndRewindInjector_delete)) {
             $token = false;
         }
     }
-    public function handleText(&$token) {
+    public function handleText(&$token)
+    {
         $token = false;
     }
-    public function handleEnd(&$token) {
+    public function handleEnd(&$token)
+    {
         $i = null;
         if (
             $this->backward($i, $prev) &&

--- a/tests/HTMLPurifier/Strategy/MakeWellFormed/EndRewindInjectorTest.php
+++ b/tests/HTMLPurifier/Strategy/MakeWellFormed/EndRewindInjectorTest.php
@@ -2,26 +2,32 @@
 
 class HTMLPurifier_Strategy_MakeWellFormed_EndRewindInjectorTest extends HTMLPurifier_StrategyHarness
 {
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_MakeWellFormed();
         $this->config->set('AutoFormat.Custom', array(
             new HTMLPurifier_Strategy_MakeWellFormed_EndRewindInjector()
         ));
     }
-    function testBasic() {
+    public function testBasic()
+    {
         $this->assertResult('');
     }
-    function testFunction() {
+    public function testFunction()
+    {
         $this->assertResult('<span>asdf</span>','');
     }
-    function testFailedFunction() {
+    public function testFailedFunction()
+    {
         $this->assertResult('<span>asd<b>asdf</b>asdf</span>','<span><b></b></span>');
     }
-    function testPadded() {
+    public function testPadded()
+    {
         $this->assertResult('<b></b><span>asdf</span><b></b>','<b></b><b></b>');
     }
-    function testDoubled() {
+    public function testDoubled()
+    {
         $this->config->set('AutoFormat.Custom', array(
             new HTMLPurifier_Strategy_MakeWellFormed_EndRewindInjector(),
             new HTMLPurifier_Strategy_MakeWellFormed_EndRewindInjector(),

--- a/tests/HTMLPurifier/Strategy/MakeWellFormed/SkipInjector.php
+++ b/tests/HTMLPurifier/Strategy/MakeWellFormed/SkipInjector.php
@@ -4,7 +4,8 @@ class HTMLPurifier_Strategy_MakeWellFormed_SkipInjector extends HTMLPurifier_Inj
 {
     public $name = 'EndRewindInjector';
     public $needed = array('span');
-    public function handleElement(&$token) {
+    public function handleElement(&$token)
+    {
         $token = array(clone $token, clone $token);
     }
 }

--- a/tests/HTMLPurifier/Strategy/MakeWellFormed/SkipInjectorTest.php
+++ b/tests/HTMLPurifier/Strategy/MakeWellFormed/SkipInjectorTest.php
@@ -2,20 +2,24 @@
 
 class HTMLPurifier_Strategy_MakeWellFormed_SkipInjectorTest extends HTMLPurifier_StrategyHarness
 {
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_MakeWellFormed();
         $this->config->set('AutoFormat.Custom', array(
             new HTMLPurifier_Strategy_MakeWellFormed_SkipInjector()
         ));
     }
-    function testEmpty() {
+    public function testEmpty()
+    {
         $this->assertResult('');
     }
-    function testMultiply() {
+    public function testMultiply()
+    {
         $this->assertResult('<br />', '<br /><br />');
     }
-    function testMultiplyMultiply() {
+    public function testMultiplyMultiply()
+    {
         $this->config->set('AutoFormat.Custom', array(
             new HTMLPurifier_Strategy_MakeWellFormed_SkipInjector(),
             new HTMLPurifier_Strategy_MakeWellFormed_SkipInjector()

--- a/tests/HTMLPurifier/Strategy/MakeWellFormedTest.php
+++ b/tests/HTMLPurifier/Strategy/MakeWellFormedTest.php
@@ -3,97 +3,112 @@
 class HTMLPurifier_Strategy_MakeWellFormedTest extends HTMLPurifier_StrategyHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_MakeWellFormed();
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult('');
     }
 
-    function testWellFormedInput() {
+    public function testWellFormedInput()
+    {
         $this->assertResult('This is <b>bold text</b>.');
     }
 
-    function testUnclosedTagTerminatedByDocumentEnd() {
+    public function testUnclosedTagTerminatedByDocumentEnd()
+    {
         $this->assertResult(
             '<b>Unclosed tag, gasp!',
             '<b>Unclosed tag, gasp!</b>'
         );
     }
 
-    function testUnclosedTagTerminatedByParentNodeEnd() {
+    public function testUnclosedTagTerminatedByParentNodeEnd()
+    {
         $this->assertResult(
             '<b><i>Bold and italic?</b>',
             '<b><i>Bold and italic?</i></b><i></i>'
         );
     }
 
-    function testRemoveStrayClosingTag() {
+    public function testRemoveStrayClosingTag()
+    {
         $this->assertResult(
             'Unused end tags... recycle!</b>',
             'Unused end tags... recycle!'
         );
     }
 
-    function testConvertStartToEmpty() {
+    public function testConvertStartToEmpty()
+    {
         $this->assertResult(
             '<br style="clear:both;">',
             '<br style="clear:both;" />'
         );
     }
 
-    function testConvertEmptyToStart() {
+    public function testConvertEmptyToStart()
+    {
         $this->assertResult(
             '<div style="clear:both;" />',
             '<div style="clear:both;"></div>'
         );
     }
 
-    function testAutoCloseParagraph() {
+    public function testAutoCloseParagraph()
+    {
         $this->assertResult(
             '<p>Paragraph 1<p>Paragraph 2',
             '<p>Paragraph 1</p><p>Paragraph 2</p>'
         );
     }
 
-    function testAutoCloseParagraphInsideDiv() {
+    public function testAutoCloseParagraphInsideDiv()
+    {
         $this->assertResult(
             '<div><p>Paragraphs<p>In<p>A<p>Div</div>',
             '<div><p>Paragraphs</p><p>In</p><p>A</p><p>Div</p></div>'
         );
     }
 
-    function testAutoCloseListItem() {
+    public function testAutoCloseListItem()
+    {
         $this->assertResult(
             '<ol><li>Item 1<li>Item 2</ol>',
             '<ol><li>Item 1</li><li>Item 2</li></ol>'
         );
     }
 
-    function testAutoCloseColgroup() {
+    public function testAutoCloseColgroup()
+    {
         $this->assertResult(
             '<table><colgroup><col /><tr></tr></table>',
             '<table><colgroup><col /></colgroup><tr></tr></table>'
         );
     }
 
-    function testAutoCloseMultiple() {
+    public function testAutoCloseMultiple()
+    {
         $this->assertResult(
             '<b><span><div></div>asdf',
             '<b><span></span></b><div><b></b></div><b>asdf</b>'
         );
     }
 
-    function testUnrecognized() {
+    public function testUnrecognized()
+    {
         $this->assertResult(
             '<asdf><foobar /><biddles>foo</asdf>',
             '<asdf><foobar /><biddles>foo</biddles></asdf>'
         );
     }
 
-    function testBlockquoteWithInline() {
+    public function testBlockquoteWithInline()
+    {
         $this->config->set('HTML.Doctype', 'XHTML 1.0 Strict');
         $this->assertResult(
             // This is actually invalid, but will be fixed by
@@ -102,42 +117,48 @@ class HTMLPurifier_Strategy_MakeWellFormedTest extends HTMLPurifier_StrategyHarn
         );
     }
 
-    function testLongCarryOver() {
+    public function testLongCarryOver()
+    {
         $this->assertResult(
             '<b>asdf<div>asdf<i>df</i></div>asdf</b>',
             '<b>asdf</b><div><b>asdf<i>df</i></b></div><b>asdf</b>'
         );
     }
 
-    function testInterleaved() {
+    public function testInterleaved()
+    {
         $this->assertResult(
             '<u>foo<i>bar</u>baz</i>',
             '<u>foo<i>bar</i></u><i>baz</i>'
         );
     }
 
-    function testNestedOl() {
+    public function testNestedOl()
+    {
         $this->assertResult(
             '<ol><ol><li>foo</li></ol></ol>',
             '<ol><ol><li>foo</li></ol></ol>'
         );
     }
 
-    function testNestedUl() {
+    public function testNestedUl()
+    {
         $this->assertResult(
             '<ul><ul><li>foo</li></ul></ul>',
             '<ul><ul><li>foo</li></ul></ul>'
         );
     }
 
-    function testNestedOlWithStrangeEnding() {
+    public function testNestedOlWithStrangeEnding()
+    {
         $this->assertResult(
             '<ol><li><ol><ol><li>foo</li></ol></li><li>foo</li></ol>',
             '<ol><li><ol><ol><li>foo</li></ol></ol></li><li>foo</li></ol>'
         );
     }
 
-    function testNoAutocloseIfNoParentsCanAccomodateTag() {
+    public function testNoAutocloseIfNoParentsCanAccomodateTag()
+    {
         $this->assertResult(
             '<table><tr><td><li>foo</li></td></tr></table>',
             '<table><tr><td>foo</td></tr></table>'

--- a/tests/HTMLPurifier/Strategy/MakeWellFormed_ErrorsTest.php
+++ b/tests/HTMLPurifier/Strategy/MakeWellFormed_ErrorsTest.php
@@ -3,56 +3,65 @@
 class HTMLPurifier_Strategy_MakeWellFormed_ErrorsTest extends HTMLPurifier_Strategy_ErrorsHarness
 {
 
-    protected function getStrategy() {
+    protected function getStrategy()
+    {
         return new HTMLPurifier_Strategy_MakeWellFormed();
     }
 
-    function testUnnecessaryEndTagRemoved() {
+    public function testUnnecessaryEndTagRemoved()
+    {
         $this->expectErrorCollection(E_WARNING, 'Strategy_MakeWellFormed: Unnecessary end tag removed');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_End('b', array(), 1, 0));
         $this->invoke('</b>');
     }
 
-    function testUnnecessaryEndTagToText() {
+    public function testUnnecessaryEndTagToText()
+    {
         $this->config->set('Core.EscapeInvalidTags', true);
         $this->expectErrorCollection(E_WARNING, 'Strategy_MakeWellFormed: Unnecessary end tag to text');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_End('b', array(), 1, 0));
         $this->invoke('</b>');
     }
 
-    function testTagAutoclose() {
+    public function testTagAutoclose()
+    {
         $this->expectErrorCollection(E_NOTICE, 'Strategy_MakeWellFormed: Tag auto closed', new HTMLPurifier_Token_Start('p', array(), 1, 0));
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Start('div', array(), 1, 6));
         $this->invoke('<p>Foo<div>Bar</div>');
     }
 
-    function testTagCarryOver() {
+    public function testTagCarryOver()
+    {
         $b = new HTMLPurifier_Token_Start('b', array(), 1, 0);
         $this->expectErrorCollection(E_NOTICE, 'Strategy_MakeWellFormed: Tag carryover', $b);
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Start('div', array(), 1, 6));
         $this->invoke('<b>Foo<div>Bar</div>');
     }
 
-    function testStrayEndTagRemoved() {
+    public function testStrayEndTagRemoved()
+    {
         $this->expectErrorCollection(E_WARNING, 'Strategy_MakeWellFormed: Stray end tag removed');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_End('b', array(), 1, 3));
         $this->invoke('<i></b></i>');
     }
 
-    function testStrayEndTagToText() {
+    public function testStrayEndTagToText()
+    {
         $this->config->set('Core.EscapeInvalidTags', true);
         $this->expectErrorCollection(E_WARNING, 'Strategy_MakeWellFormed: Stray end tag to text');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_End('b', array(), 1, 3));
         $this->invoke('<i></b></i>');
     }
 
-    function testTagClosedByElementEnd() {
+    public function testTagClosedByElementEnd()
+    {
         $this->expectErrorCollection(E_NOTICE, 'Strategy_MakeWellFormed: Tag closed by element end', new HTMLPurifier_Token_Start('b', array(), 1, 3));
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_End('i', array(), 1, 12));
         $this->invoke('<i><b>Foobar</i>');
     }
 
-    function testTagClosedByDocumentEnd() {
+    public function testTagClosedByDocumentEnd()
+    {
         $this->expectErrorCollection(E_NOTICE, 'Strategy_MakeWellFormed: Tag closed by document end', new HTMLPurifier_Token_Start('b', array(), 1, 0));
         $this->invoke('<b>Foobar');
     }

--- a/tests/HTMLPurifier/Strategy/MakeWellFormed_InjectorTest.php
+++ b/tests/HTMLPurifier/Strategy/MakeWellFormed_InjectorTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_Strategy_MakeWellFormed_InjectorTest extends HTMLPurifier_StrategyHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_MakeWellFormed();
         $this->config->set('AutoFormat.AutoParagraph', true);
@@ -12,7 +13,8 @@ class HTMLPurifier_Strategy_MakeWellFormed_InjectorTest extends HTMLPurifier_Str
         generate_mock_once('HTMLPurifier_Injector');
     }
 
-    function testEndHandler() {
+    public function testEndHandler()
+    {
         $mock = new HTMLPurifier_InjectorMock();
         $b = new HTMLPurifier_Token_End('b');
         $b->skip = array(0 => true);
@@ -32,48 +34,55 @@ class HTMLPurifier_Strategy_MakeWellFormed_InjectorTest extends HTMLPurifier_Str
         $this->assertResult('<i><b>asdf</b>', '<i><b>asdf</b></i>');
     }
 
-    function testErrorRequiredElementNotAllowed() {
+    public function testErrorRequiredElementNotAllowed()
+    {
         $this->config->set('HTML.Allowed', '');
         $this->expectError('Cannot enable AutoParagraph injector because p is not allowed');
         $this->expectError('Cannot enable Linkify injector because a is not allowed');
         $this->assertResult('Foobar');
     }
 
-    function testErrorRequiredAttributeNotAllowed() {
+    public function testErrorRequiredAttributeNotAllowed()
+    {
         $this->config->set('HTML.Allowed', 'a,p');
         $this->expectError('Cannot enable Linkify injector because a.href is not allowed');
         $this->assertResult('<p>http://example.com</p>');
     }
 
-    function testOnlyAutoParagraph() {
+    public function testOnlyAutoParagraph()
+    {
         $this->assertResult(
             'Foobar',
             '<p>Foobar</p>'
         );
     }
 
-    function testParagraphWrappingOnlyLink() {
+    public function testParagraphWrappingOnlyLink()
+    {
         $this->assertResult(
             'http://example.com',
             '<p><a href="http://example.com">http://example.com</a></p>'
         );
     }
 
-    function testParagraphWrappingNodeContainingLink() {
+    public function testParagraphWrappingNodeContainingLink()
+    {
         $this->assertResult(
             '<b>http://example.com</b>',
             '<p><b><a href="http://example.com">http://example.com</a></b></p>'
         );
     }
 
-    function testParagraphWrappingPoorlyFormedNodeContainingLink() {
+    public function testParagraphWrappingPoorlyFormedNodeContainingLink()
+    {
         $this->assertResult(
             '<b>http://example.com',
             '<p><b><a href="http://example.com">http://example.com</a></b></p>'
         );
     }
 
-    function testTwoParagraphsContainingOnlyOneLink() {
+    public function testTwoParagraphsContainingOnlyOneLink()
+    {
         $this->assertResult(
             "http://example.com\n\nhttp://dev.example.com",
 '<p><a href="http://example.com">http://example.com</a></p>
@@ -82,7 +91,8 @@ class HTMLPurifier_Strategy_MakeWellFormed_InjectorTest extends HTMLPurifier_Str
         );
     }
 
-    function testParagraphNextToDivWithLinks() {
+    public function testParagraphNextToDivWithLinks()
+    {
         $this->assertResult(
             'http://example.com <div>http://example.com</div>',
 '<p><a href="http://example.com">http://example.com</a> </p>
@@ -91,14 +101,16 @@ class HTMLPurifier_Strategy_MakeWellFormed_InjectorTest extends HTMLPurifier_Str
         );
     }
 
-    function testRealisticLinkInSentence() {
+    public function testRealisticLinkInSentence()
+    {
         $this->assertResult(
             'This URL http://example.com is what you need',
             '<p>This URL <a href="http://example.com">http://example.com</a> is what you need</p>'
         );
     }
 
-    function testParagraphAfterLinkifiedURL() {
+    public function testParagraphAfterLinkifiedURL()
+    {
         $this->assertResult(
 "http://google.com
 
@@ -109,7 +121,8 @@ class HTMLPurifier_Strategy_MakeWellFormed_InjectorTest extends HTMLPurifier_Str
         );
     }
 
-    function testEmptyAndParagraph() {
+    public function testEmptyAndParagraph()
+    {
         // This is a fairly degenerate case, but it demonstrates that
         // the two don't error out together, at least.
         // Change this behavior!
@@ -127,7 +140,8 @@ asdf<b></b></p>
         );
     }
 
-    function testRewindAndParagraph() {
+    public function testRewindAndParagraph()
+    {
         $this->assertResult(
 "bar
 

--- a/tests/HTMLPurifier/Strategy/RemoveForeignElementsTest.php
+++ b/tests/HTMLPurifier/Strategy/RemoveForeignElementsTest.php
@@ -3,41 +3,48 @@
 class HTMLPurifier_Strategy_RemoveForeignElementsTest extends HTMLPurifier_StrategyHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_RemoveForeignElements();
     }
 
-    function testBlankInput() {
+    public function testBlankInput()
+    {
         $this->assertResult('');
     }
 
-    function testPreserveRecognizedElements() {
+    public function testPreserveRecognizedElements()
+    {
         $this->assertResult('This is <b>bold text</b>.');
     }
 
-    function testRemoveForeignElements() {
+    public function testRemoveForeignElements()
+    {
         $this->assertResult(
             '<asdf>Bling</asdf><d href="bang">Bong</d><foobar />',
             'BlingBong'
         );
     }
 
-    function testRemoveScriptAndContents() {
+    public function testRemoveScriptAndContents()
+    {
         $this->assertResult(
             '<script>alert();</script>',
             ''
         );
     }
 
-    function testRemoveStyleAndContents() {
+    public function testRemoveStyleAndContents()
+    {
         $this->assertResult(
             '<style>.foo {blink;}</style>',
             ''
         );
     }
 
-    function testRemoveOnlyScriptTagsLegacy() {
+    public function testRemoveOnlyScriptTagsLegacy()
+    {
         $this->config->set('Core.RemoveScriptContents', false);
         $this->assertResult(
             '<script>alert();</script>',
@@ -45,7 +52,8 @@ class HTMLPurifier_Strategy_RemoveForeignElementsTest extends HTMLPurifier_Strat
         );
     }
 
-    function testRemoveOnlyScriptTags() {
+    public function testRemoveOnlyScriptTags()
+    {
         $this->config->set('Core.HiddenElements', array());
         $this->assertResult(
             '<script>alert();</script>',
@@ -53,20 +61,24 @@ class HTMLPurifier_Strategy_RemoveForeignElementsTest extends HTMLPurifier_Strat
         );
     }
 
-    function testRemoveInvalidImg() {
+    public function testRemoveInvalidImg()
+    {
         $this->assertResult('<img />', '');
     }
 
-    function testPreserveValidImg() {
+    public function testPreserveValidImg()
+    {
         $this->assertResult('<img src="foobar.gif" alt="foobar.gif" />');
     }
 
-    function testPreserveInvalidImgWhenRemovalIsDisabled() {
+    public function testPreserveInvalidImgWhenRemovalIsDisabled()
+    {
         $this->config->set('Core.RemoveInvalidImg', false);
         $this->assertResult('<img />');
     }
 
-    function testTextifyCommentedScriptContents() {
+    public function testTextifyCommentedScriptContents()
+    {
         $this->config->set('HTML.Trusted', true);
         $this->config->set('Output.CommentScriptContents', false); // simplify output
         $this->assertResult(
@@ -79,33 +91,39 @@ alert(&lt;b&gt;bold&lt;/b&gt;);
         );
     }
 
-    function testRequiredAttributesTestNotPerformedOnEndTag() {
+    public function testRequiredAttributesTestNotPerformedOnEndTag()
+    {
         $def = $this->config->getHTMLDefinition(true);
         $def->addElement('f', 'Block', 'Optional: #PCDATA', false, array('req*' => 'Text'));
         $this->assertResult('<f req="text">Foo</f> Bar');
     }
 
-    function testPreserveCommentsWithHTMLTrusted() {
+    public function testPreserveCommentsWithHTMLTrusted()
+    {
         $this->config->set('HTML.Trusted', true);
         $this->assertResult('<!-- foo -->');
     }
 
-    function testRemoveTrailingHyphensInComment() {
+    public function testRemoveTrailingHyphensInComment()
+    {
         $this->config->set('HTML.Trusted', true);
         $this->assertResult('<!-- foo ----->', '<!-- foo -->');
     }
 
-    function testCollapseDoubleHyphensInComment() {
+    public function testCollapseDoubleHyphensInComment()
+    {
         $this->config->set('HTML.Trusted', true);
         $this->assertResult('<!-- bo --- asdf--as -->', '<!-- bo - asdf-as -->');
     }
 
-    function testPreserveCommentsWithLookup() {
+    public function testPreserveCommentsWithLookup()
+    {
         $this->config->set('HTML.AllowedComments', array('allowed'));
         $this->assertResult('<!-- allowed --><!-- not allowed -->', '<!-- allowed -->');
     }
 
-    function testPreserveCommentsWithRegexp() {
+    public function testPreserveCommentsWithRegexp()
+    {
         $this->config->set('HTML.AllowedCommentsRegexp', '/^allowed[1-9]$/');
         $this->assertResult('<!-- allowed1 --><!-- not allowed -->', '<!-- allowed1 -->');
     }

--- a/tests/HTMLPurifier/Strategy/RemoveForeignElements_ErrorsTest.php
+++ b/tests/HTMLPurifier/Strategy/RemoveForeignElements_ErrorsTest.php
@@ -3,63 +3,73 @@
 class HTMLPurifier_Strategy_RemoveForeignElements_ErrorsTest extends HTMLPurifier_Strategy_ErrorsHarness
 {
 
-    public function setup() {
+    public function setup()
+    {
         parent::setup();
         $this->config->set('HTML.TidyLevel', 'heavy');
     }
 
-    protected function getStrategy() {
+    protected function getStrategy()
+    {
         return new HTMLPurifier_Strategy_RemoveForeignElements();
     }
 
-    function testTagTransform() {
+    public function testTagTransform()
+    {
         $this->expectErrorCollection(E_NOTICE, 'Strategy_RemoveForeignElements: Tag transform', 'center');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Start('div', array('style' => 'text-align:center;'), 1));
         $this->invoke('<center>');
     }
 
-    function testMissingRequiredAttr() {
+    public function testMissingRequiredAttr()
+    {
         // a little fragile, since img has two required attributes
         $this->expectErrorCollection(E_ERROR, 'Strategy_RemoveForeignElements: Missing required attribute', 'alt');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Empty('img', array(), 1));
         $this->invoke('<img />');
     }
 
-    function testForeignElementToText() {
+    public function testForeignElementToText()
+    {
         $this->config->set('Core.EscapeInvalidTags', true);
         $this->expectErrorCollection(E_WARNING, 'Strategy_RemoveForeignElements: Foreign element to text');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Start('invalid', array(), 1));
         $this->invoke('<invalid>');
     }
 
-    function testForeignElementRemoved() {
+    public function testForeignElementRemoved()
+    {
         // uses $CurrentToken.Serialized
         $this->expectErrorCollection(E_ERROR, 'Strategy_RemoveForeignElements: Foreign element removed');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Start('invalid', array(), 1));
         $this->invoke('<invalid>');
     }
 
-    function testCommentRemoved() {
+    public function testCommentRemoved()
+    {
         $this->expectErrorCollection(E_NOTICE, 'Strategy_RemoveForeignElements: Comment removed');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Comment(' test ', 1));
         $this->invoke('<!-- test -->');
     }
 
-    function testTrailingHyphenInCommentRemoved() {
+    public function testTrailingHyphenInCommentRemoved()
+    {
         $this->config->set('HTML.Trusted', true);
         $this->expectErrorCollection(E_NOTICE, 'Strategy_RemoveForeignElements: Trailing hyphen in comment removed');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Comment(' test ', 1));
         $this->invoke('<!-- test ---->');
     }
 
-    function testDoubleHyphenInCommentRemoved() {
+    public function testDoubleHyphenInCommentRemoved()
+    {
         $this->config->set('HTML.Trusted', true);
         $this->expectErrorCollection(E_NOTICE, 'Strategy_RemoveForeignElements: Hyphens in comment collapsed');
         $this->expectContext('CurrentToken', new HTMLPurifier_Token_Comment(' test - test - test ', 1));
         $this->invoke('<!-- test --- test -- test -->');
     }
 
-    function testForeignMetaElementRemoved() {
+    public function testForeignMetaElementRemoved()
+    {
         $this->collector->expectAt(0, 'send', array(E_ERROR, 'Strategy_RemoveForeignElements: Foreign meta element removed'));
         $this->collector->expectContextAt(0, 'CurrentToken', new HTMLPurifier_Token_Start('script', array(), 1));
         $this->collector->expectAt(1, 'send', array(E_ERROR, 'Strategy_RemoveForeignElements: Token removed to end', 'script'));

--- a/tests/HTMLPurifier/Strategy/RemoveForeignElements_TidyTest.php
+++ b/tests/HTMLPurifier/Strategy/RemoveForeignElements_TidyTest.php
@@ -4,20 +4,23 @@ class HTMLPurifier_Strategy_RemoveForeignElements_TidyTest
   extends HTMLPurifier_StrategyHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_RemoveForeignElements();
         $this->config->set('HTML.TidyLevel', 'heavy');
     }
 
-    function testCenterTransform() {
+    public function testCenterTransform()
+    {
         $this->assertResult(
             '<center>Look I am Centered!</center>',
             '<div style="text-align:center;">Look I am Centered!</div>'
         );
     }
 
-    function testFontTransform() {
+    public function testFontTransform()
+    {
         $this->assertResult(
             '<font color="red" face="Arial" size="6">Big Warning!</font>',
             '<span style="color:red;font-family:Arial;font-size:xx-large;">Big'.
@@ -25,7 +28,8 @@ class HTMLPurifier_Strategy_RemoveForeignElements_TidyTest
         );
     }
 
-    function testTransformToForbiddenElement() {
+    public function testTransformToForbiddenElement()
+    {
         $this->config->set('HTML.Allowed', 'div');
         $this->assertResult(
             '<font color="red" face="Arial" size="6">Big Warning!</font>',
@@ -33,7 +37,8 @@ class HTMLPurifier_Strategy_RemoveForeignElements_TidyTest
         );
     }
 
-    function testMenuTransform() {
+    public function testMenuTransform()
+    {
         $this->assertResult(
             '<menu><li>Item 1</li></menu>',
             '<ul><li>Item 1</li></ul>'

--- a/tests/HTMLPurifier/Strategy/ValidateAttributesTest.php
+++ b/tests/HTMLPurifier/Strategy/ValidateAttributesTest.php
@@ -4,34 +4,40 @@ class HTMLPurifier_Strategy_ValidateAttributesTest extends
       HTMLPurifier_StrategyHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_ValidateAttributes();
     }
 
-    function testEmptyInput() {
+    public function testEmptyInput()
+    {
         $this->assertResult('');
     }
 
-    function testRemoveIDByDefault() {
+    public function testRemoveIDByDefault()
+    {
         $this->assertResult(
             '<div id="valid">Kill the ID.</div>',
             '<div>Kill the ID.</div>'
         );
     }
 
-    function testRemoveInvalidDir() {
+    public function testRemoveInvalidDir()
+    {
         $this->assertResult(
             '<span dir="up-to-down">Bad dir.</span>',
             '<span>Bad dir.</span>'
         );
     }
 
-    function testPreserveValidClass() {
+    public function testPreserveValidClass()
+    {
         $this->assertResult('<div class="valid">Valid</div>');
     }
 
-    function testSelectivelyRemoveInvalidClasses() {
+    public function testSelectivelyRemoveInvalidClasses()
+    {
         $this->config->set('HTML.Doctype', 'XHTML 1.1');
         $this->assertResult(
             '<div class="valid 0invalid">Keep valid.</div>',
@@ -39,20 +45,23 @@ class HTMLPurifier_Strategy_ValidateAttributesTest extends
         );
     }
 
-    function testPreserveTitle() {
+    public function testPreserveTitle()
+    {
         $this->assertResult(
             '<acronym title="PHP: Hypertext Preprocessor">PHP</acronym>'
         );
     }
 
-    function testAddXMLLang() {
+    public function testAddXMLLang()
+    {
         $this->assertResult(
             '<span lang="fr">La soupe.</span>',
             '<span lang="fr" xml:lang="fr">La soupe.</span>'
         );
     }
 
-    function testOnlyXMLLangInXHTML11() {
+    public function testOnlyXMLLangInXHTML11()
+    {
         $this->config->set('HTML.Doctype', 'XHTML 1.1');
         $this->assertResult(
             '<b lang="en">asdf</b>',
@@ -60,32 +69,37 @@ class HTMLPurifier_Strategy_ValidateAttributesTest extends
         );
     }
 
-    function testBasicURI() {
+    public function testBasicURI()
+    {
         $this->assertResult('<a href="http://www.google.com/">Google</a>');
     }
 
-    function testInvalidURI() {
+    public function testInvalidURI()
+    {
         $this->assertResult(
             '<a href="javascript:badstuff();">Google</a>',
             '<a>Google</a>'
         );
     }
 
-    function testBdoAddMissingDir() {
+    public function testBdoAddMissingDir()
+    {
         $this->assertResult(
             '<bdo>Go left.</bdo>',
             '<bdo dir="ltr">Go left.</bdo>'
         );
     }
 
-    function testBdoReplaceInvalidDirWithDefault() {
+    public function testBdoReplaceInvalidDirWithDefault()
+    {
         $this->assertResult(
             '<bdo dir="blahblah">Invalid value!</bdo>',
             '<bdo dir="ltr">Invalid value!</bdo>'
         );
     }
 
-    function testBdoAlternateDefaultDir() {
+    public function testBdoAlternateDefaultDir()
+    {
         $this->config->set('Attr.DefaultTextDir', 'rtl');
         $this->assertResult(
             '<bdo>Go right.</bdo>',
@@ -93,14 +107,16 @@ class HTMLPurifier_Strategy_ValidateAttributesTest extends
         );
     }
 
-    function testRemoveDirWhenNotRequired() {
+    public function testRemoveDirWhenNotRequired()
+    {
         $this->assertResult(
             '<span dir="blahblah">Invalid value!</span>',
             '<span>Invalid value!</span>'
         );
     }
 
-    function testTableAttributes() {
+    public function testTableAttributes()
+    {
         $this->assertResult(
 '<table frame="above" rules="rows" summary="A test table" border="2" cellpadding="5%" cellspacing="3" width="100%">
     <col align="right" width="4*" />
@@ -120,14 +136,16 @@ class HTMLPurifier_Strategy_ValidateAttributesTest extends
         );
     }
 
-    function testColSpanIsNonZero() {
+    public function testColSpanIsNonZero()
+    {
         $this->assertResult(
             '<col span="0" />',
             '<col />'
         );
     }
 
-    function testImgAddDefaults() {
+    public function testImgAddDefaults()
+    {
         $this->config->set('Core.RemoveInvalidImg', false);
         $this->assertResult(
             '<img />',
@@ -135,14 +153,16 @@ class HTMLPurifier_Strategy_ValidateAttributesTest extends
         );
     }
 
-    function testImgGenerateAlt() {
+    public function testImgGenerateAlt()
+    {
         $this->assertResult(
             '<img src="foobar.jpg" />',
             '<img src="foobar.jpg" alt="foobar.jpg" />'
         );
     }
 
-    function testImgAddDefaultSrc() {
+    public function testImgAddDefaultSrc()
+    {
         $this->config->set('Core.RemoveInvalidImg', false);
         $this->assertResult(
             '<img alt="pretty picture" />',
@@ -150,7 +170,8 @@ class HTMLPurifier_Strategy_ValidateAttributesTest extends
         );
     }
 
-    function testImgRemoveNonRetrievableProtocol() {
+    public function testImgRemoveNonRetrievableProtocol()
+    {
         $this->config->set('Core.RemoveInvalidImg', false);
         $this->assertResult(
             '<img src="mailto:foo@example.com" />',
@@ -158,18 +179,21 @@ class HTMLPurifier_Strategy_ValidateAttributesTest extends
         );
     }
 
-    function testPreserveRel() {
+    public function testPreserveRel()
+    {
         $this->config->set('Attr.AllowedRel', 'nofollow');
         $this->assertResult('<a href="foo" rel="nofollow" />');
     }
 
-    function testPreserveTarget() {
+    public function testPreserveTarget()
+    {
         $this->config->set('Attr.AllowedFrameTargets', '_top');
         $this->config->set('HTML.Doctype', 'XHTML 1.0 Transitional');
         $this->assertResult('<a href="foo" target="_top" />');
     }
 
-    function testRemoveTargetWhenNotSupported() {
+    public function testRemoveTargetWhenNotSupported()
+    {
         $this->config->set('HTML.Doctype', 'XHTML 1.0 Strict');
         $this->config->set('Attr.AllowedFrameTargets', '_top');
         $this->assertResult(
@@ -178,20 +202,23 @@ class HTMLPurifier_Strategy_ValidateAttributesTest extends
         );
     }
 
-    function testKeepAbsoluteCSSWidthAndHeightOnImg() {
+    public function testKeepAbsoluteCSSWidthAndHeightOnImg()
+    {
         $this->assertResult(
             '<img src="" alt="" style="width:10px;height:10px;border:1px solid #000;" />'
         );
     }
 
-    function testRemoveLargeCSSWidthAndHeightOnImg() {
+    public function testRemoveLargeCSSWidthAndHeightOnImg()
+    {
         $this->assertResult(
             '<img src="" alt="" style="width:10000000px;height:10000000px;border:1px solid #000;" />',
             '<img src="" alt="" style="border:1px solid #000;" />'
         );
     }
 
-    function testRemoveLargeCSSWidthAndHeightOnImgWithUserConf() {
+    public function testRemoveLargeCSSWidthAndHeightOnImgWithUserConf()
+    {
         $this->config->set('CSS.MaxImgLength', '1px');
         $this->assertResult(
             '<img src="" alt="" style="width:1mm;height:1mm;border:1px solid #000;" />',
@@ -199,28 +226,32 @@ class HTMLPurifier_Strategy_ValidateAttributesTest extends
         );
     }
 
-    function testKeepLargeCSSWidthAndHeightOnImgWhenToldTo() {
+    public function testKeepLargeCSSWidthAndHeightOnImgWhenToldTo()
+    {
         $this->config->set('CSS.MaxImgLength', null);
         $this->assertResult(
             '<img src="" alt="" style="width:10000000px;height:10000000px;border:1px solid #000;" />'
         );
     }
 
-    function testKeepPercentCSSWidthAndHeightOnImgWhenToldTo() {
+    public function testKeepPercentCSSWidthAndHeightOnImgWhenToldTo()
+    {
         $this->config->set('CSS.MaxImgLength', null);
         $this->assertResult(
             '<img src="" alt="" style="width:100%;height:100%;border:1px solid #000;" />'
         );
     }
 
-    function testRemoveRelativeCSSWidthAndHeightOnImg() {
+    public function testRemoveRelativeCSSWidthAndHeightOnImg()
+    {
         $this->assertResult(
             '<img src="" alt="" style="width:10em;height:10em;border:1px solid #000;" />',
             '<img src="" alt="" style="border:1px solid #000;" />'
         );
     }
 
-    function testRemovePercentCSSWidthAndHeightOnImg() {
+    public function testRemovePercentCSSWidthAndHeightOnImg()
+    {
         $this->assertResult(
             '<img src="" alt="" style="width:100%;height:100%;border:1px solid #000;" />',
             '<img src="" alt="" style="border:1px solid #000;" />'

--- a/tests/HTMLPurifier/Strategy/ValidateAttributes_IDTest.php
+++ b/tests/HTMLPurifier/Strategy/ValidateAttributes_IDTest.php
@@ -3,46 +3,53 @@
 class HTMLPurifier_Strategy_ValidateAttributes_IDTest extends HTMLPurifier_StrategyHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_ValidateAttributes();
         $this->config->set('Attr.EnableID', true);
     }
 
 
-    function testPreserveIDWhenEnabled() {
+    public function testPreserveIDWhenEnabled()
+    {
         $this->assertResult('<div id="valid">Preserve the ID.</div>');
     }
 
-    function testRemoveInvalidID() {
+    public function testRemoveInvalidID()
+    {
         $this->assertResult(
             '<div id="0invalid">Kill the ID.</div>',
             '<div>Kill the ID.</div>'
         );
     }
 
-    function testRemoveDuplicateID() {
+    public function testRemoveDuplicateID()
+    {
         $this->assertResult(
             '<div id="valid">Valid</div><div id="valid">Invalid</div>',
             '<div id="valid">Valid</div><div>Invalid</div>'
         );
     }
 
-    function testAttributeKeyCaseInsensitivity() {
+    public function testAttributeKeyCaseInsensitivity()
+    {
         $this->assertResult(
             '<div ID="valid">Convert ID to lowercase.</div>',
             '<div id="valid">Convert ID to lowercase.</div>'
         );
     }
 
-    function testTrimWhitespace() {
+    public function testTrimWhitespace()
+    {
         $this->assertResult(
             '<div id=" valid ">Trim whitespace.</div>',
             '<div id="valid">Trim whitespace.</div>'
         );
     }
 
-    function testIDBlacklist() {
+    public function testIDBlacklist()
+    {
         $this->config->set('Attr.IDBlacklist', array('invalid'));
         $this->assertResult(
             '<div id="invalid">Invalid</div>',
@@ -50,7 +57,8 @@ class HTMLPurifier_Strategy_ValidateAttributes_IDTest extends HTMLPurifier_Strat
         );
     }
 
-    function testNameConvertedToID() {
+    public function testNameConvertedToID()
+    {
         $this->config->set('HTML.TidyLevel', 'heavy');
         $this->assertResult(
             '<a name="foobar" />',

--- a/tests/HTMLPurifier/Strategy/ValidateAttributes_TidyTest.php
+++ b/tests/HTMLPurifier/Strategy/ValidateAttributes_TidyTest.php
@@ -3,342 +3,391 @@
 class HTMLPurifier_Strategy_ValidateAttributes_TidyTest extends HTMLPurifier_StrategyHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->obj = new HTMLPurifier_Strategy_ValidateAttributes();
         $this->config->set('HTML.TidyLevel', 'heavy');
     }
 
-    function testConvertCenterAlign() {
+    public function testConvertCenterAlign()
+    {
         $this->assertResult(
             '<h1 align="center">Centered Headline</h1>',
             '<h1 style="text-align:center;">Centered Headline</h1>'
         );
     }
 
-    function testConvertRightAlign() {
+    public function testConvertRightAlign()
+    {
         $this->assertResult(
             '<h1 align="right">Right-aligned Headline</h1>',
             '<h1 style="text-align:right;">Right-aligned Headline</h1>'
         );
     }
 
-    function testConvertLeftAlign() {
+    public function testConvertLeftAlign()
+    {
         $this->assertResult(
             '<h1 align="left">Left-aligned Headline</h1>',
             '<h1 style="text-align:left;">Left-aligned Headline</h1>'
         );
     }
 
-    function testConvertJustifyAlign() {
+    public function testConvertJustifyAlign()
+    {
         $this->assertResult(
             '<p align="justify">Justified Paragraph</p>',
             '<p style="text-align:justify;">Justified Paragraph</p>'
         );
     }
 
-    function testRemoveInvalidAlign() {
+    public function testRemoveInvalidAlign()
+    {
         $this->assertResult(
             '<h1 align="invalid">Invalid Headline</h1>',
             '<h1>Invalid Headline</h1>'
         );
     }
 
-    function testConvertTableLengths() {
+    public function testConvertTableLengths()
+    {
         $this->assertResult(
             '<td width="5%" height="10" /><th width="10" height="5%" /><hr width="10" height="10" />',
             '<td style="width:5%;height:10px;" /><th style="width:10px;height:5%;" /><hr style="width:10px;" />'
         );
     }
 
-    function testTdConvertNowrap() {
+    public function testTdConvertNowrap()
+    {
         $this->assertResult(
             '<td nowrap />',
             '<td style="white-space:nowrap;" />'
         );
     }
 
-    function testCaptionConvertAlignLeft() {
+    public function testCaptionConvertAlignLeft()
+    {
         $this->assertResult(
             '<caption align="left" />',
             '<caption style="text-align:left;" />'
         );
     }
 
-    function testCaptionConvertAlignRight() {
+    public function testCaptionConvertAlignRight()
+    {
         $this->assertResult(
             '<caption align="right" />',
             '<caption style="text-align:right;" />'
         );
     }
 
-    function testCaptionConvertAlignTop() {
+    public function testCaptionConvertAlignTop()
+    {
         $this->assertResult(
             '<caption align="top" />',
             '<caption style="caption-side:top;" />'
         );
     }
 
-    function testCaptionConvertAlignBottom() {
+    public function testCaptionConvertAlignBottom()
+    {
         $this->assertResult(
             '<caption align="bottom" />',
             '<caption style="caption-side:bottom;" />'
         );
     }
 
-    function testCaptionRemoveInvalidAlign() {
+    public function testCaptionRemoveInvalidAlign()
+    {
         $this->assertResult(
             '<caption align="nonsense" />',
             '<caption />'
         );
     }
 
-    function testTableConvertAlignLeft() {
+    public function testTableConvertAlignLeft()
+    {
         $this->assertResult(
             '<table align="left" />',
             '<table style="float:left;" />'
         );
     }
 
-    function testTableConvertAlignCenter() {
+    public function testTableConvertAlignCenter()
+    {
         $this->assertResult(
             '<table align="center" />',
             '<table style="margin-left:auto;margin-right:auto;" />'
         );
     }
 
-    function testTableConvertAlignRight() {
+    public function testTableConvertAlignRight()
+    {
         $this->assertResult(
             '<table align="right" />',
             '<table style="float:right;" />'
         );
     }
 
-    function testTableRemoveInvalidAlign() {
+    public function testTableRemoveInvalidAlign()
+    {
         $this->assertResult(
             '<table align="top" />',
             '<table />'
         );
     }
 
-    function testImgConvertAlignLeft() {
+    public function testImgConvertAlignLeft()
+    {
         $this->assertResult(
             '<img src="foobar.jpg" alt="foobar" align="left" />',
             '<img src="foobar.jpg" alt="foobar" style="float:left;" />'
         );
     }
 
-    function testImgConvertAlignRight() {
+    public function testImgConvertAlignRight()
+    {
         $this->assertResult(
             '<img src="foobar.jpg" alt="foobar" align="right" />',
             '<img src="foobar.jpg" alt="foobar" style="float:right;" />'
         );
     }
 
-    function testImgConvertAlignBottom() {
+    public function testImgConvertAlignBottom()
+    {
         $this->assertResult(
             '<img src="foobar.jpg" alt="foobar" align="bottom" />',
             '<img src="foobar.jpg" alt="foobar" style="vertical-align:baseline;" />'
         );
     }
 
-    function testImgConvertAlignMiddle() {
+    public function testImgConvertAlignMiddle()
+    {
         $this->assertResult(
             '<img src="foobar.jpg" alt="foobar" align="middle" />',
             '<img src="foobar.jpg" alt="foobar" style="vertical-align:middle;" />'
         );
     }
 
-    function testImgConvertAlignTop() {
+    public function testImgConvertAlignTop()
+    {
         $this->assertResult(
             '<img src="foobar.jpg" alt="foobar" align="top" />',
             '<img src="foobar.jpg" alt="foobar" style="vertical-align:top;" />'
         );
     }
 
-    function testImgRemoveInvalidAlign() {
+    public function testImgRemoveInvalidAlign()
+    {
         $this->assertResult(
             '<img src="foobar.jpg" alt="foobar" align="outerspace" />',
             '<img src="foobar.jpg" alt="foobar" />'
         );
     }
 
-    function testBorderConvertHVSpace() {
+    public function testBorderConvertHVSpace()
+    {
         $this->assertResult(
             '<img src="foo" alt="foo" hspace="1" vspace="3" />',
             '<img src="foo" alt="foo" style="margin-top:3px;margin-bottom:3px;margin-left:1px;margin-right:1px;" />'
         );
     }
 
-    function testHrConvertSize() {
+    public function testHrConvertSize()
+    {
         $this->assertResult(
             '<hr size="3" />',
             '<hr style="height:3px;" />'
         );
     }
 
-    function testHrConvertNoshade() {
+    public function testHrConvertNoshade()
+    {
         $this->assertResult(
             '<hr noshade />',
             '<hr style="color:#808080;background-color:#808080;border:0;" />'
         );
     }
 
-    function testHrConvertAlignLeft() {
+    public function testHrConvertAlignLeft()
+    {
         $this->assertResult(
             '<hr align="left" />',
             '<hr style="margin-left:0;margin-right:auto;text-align:left;" />'
         );
     }
 
-    function testHrConvertAlignCenter() {
+    public function testHrConvertAlignCenter()
+    {
         $this->assertResult(
             '<hr align="center" />',
             '<hr style="margin-left:auto;margin-right:auto;text-align:center;" />'
         );
     }
 
-    function testHrConvertAlignRight() {
+    public function testHrConvertAlignRight()
+    {
         $this->assertResult(
             '<hr align="right" />',
             '<hr style="margin-left:auto;margin-right:0;text-align:right;" />'
         );
     }
 
-    function testHrRemoveInvalidAlign() {
+    public function testHrRemoveInvalidAlign()
+    {
         $this->assertResult(
             '<hr align="bottom" />',
             '<hr />'
         );
     }
 
-    function testBrConvertClearLeft() {
+    public function testBrConvertClearLeft()
+    {
         $this->assertResult(
             '<br clear="left" />',
             '<br style="clear:left;" />'
         );
     }
 
-    function testBrConvertClearRight() {
+    public function testBrConvertClearRight()
+    {
         $this->assertResult(
             '<br clear="right" />',
             '<br style="clear:right;" />'
         );
     }
 
-    function testBrConvertClearAll() {
+    public function testBrConvertClearAll()
+    {
         $this->assertResult(
             '<br clear="all" />',
             '<br style="clear:both;" />'
         );
     }
 
-    function testBrConvertClearNone() {
+    public function testBrConvertClearNone()
+    {
         $this->assertResult(
             '<br clear="none" />',
             '<br style="clear:none;" />'
         );
     }
 
-    function testBrRemoveInvalidClear() {
+    public function testBrRemoveInvalidClear()
+    {
         $this->assertResult(
             '<br clear="foo" />',
             '<br />'
         );
     }
 
-    function testUlConvertTypeDisc() {
+    public function testUlConvertTypeDisc()
+    {
         $this->assertResult(
             '<ul type="disc" />',
             '<ul style="list-style-type:disc;" />'
         );
     }
 
-    function testUlConvertTypeSquare() {
+    public function testUlConvertTypeSquare()
+    {
         $this->assertResult(
             '<ul type="square" />',
             '<ul style="list-style-type:square;" />'
         );
     }
 
-    function testUlConvertTypeCircle() {
+    public function testUlConvertTypeCircle()
+    {
         $this->assertResult(
             '<ul type="circle" />',
             '<ul style="list-style-type:circle;" />'
         );
     }
 
-    function testUlConvertTypeCaseInsensitive() {
+    public function testUlConvertTypeCaseInsensitive()
+    {
         $this->assertResult(
             '<ul type="CIRCLE" />',
             '<ul style="list-style-type:circle;" />'
         );
     }
 
-    function testUlRemoveInvalidType() {
+    public function testUlRemoveInvalidType()
+    {
         $this->assertResult(
             '<ul type="a" />',
             '<ul />'
         );
     }
 
-    function testOlConvertType1() {
+    public function testOlConvertType1()
+    {
         $this->assertResult(
             '<ol type="1" />',
             '<ol style="list-style-type:decimal;" />'
         );
     }
 
-    function testOlConvertTypeLowerI() {
+    public function testOlConvertTypeLowerI()
+    {
         $this->assertResult(
             '<ol type="i" />',
             '<ol style="list-style-type:lower-roman;" />'
         );
     }
 
-    function testOlConvertTypeUpperI() {
+    public function testOlConvertTypeUpperI()
+    {
         $this->assertResult(
             '<ol type="I" />',
             '<ol style="list-style-type:upper-roman;" />'
         );
     }
 
-    function testOlConvertTypeLowerA() {
+    public function testOlConvertTypeLowerA()
+    {
         $this->assertResult(
             '<ol type="a" />',
             '<ol style="list-style-type:lower-alpha;" />'
         );
     }
 
-    function testOlConvertTypeUpperA() {
+    public function testOlConvertTypeUpperA()
+    {
         $this->assertResult(
             '<ol type="A" />',
             '<ol style="list-style-type:upper-alpha;" />'
         );
     }
 
-    function testOlRemoveInvalidType() {
+    public function testOlRemoveInvalidType()
+    {
         $this->assertResult(
             '<ol type="disc" />',
             '<ol />'
         );
     }
 
-    function testLiConvertTypeCircle() {
+    public function testLiConvertTypeCircle()
+    {
         $this->assertResult(
             '<li type="circle" />',
             '<li style="list-style-type:circle;" />'
         );
     }
 
-    function testLiConvertTypeA() {
+    public function testLiConvertTypeA()
+    {
         $this->assertResult(
             '<li type="A" />',
             '<li style="list-style-type:upper-alpha;" />'
         );
     }
 
-    function testLiConvertTypeCaseSensitive() {
+    public function testLiConvertTypeCaseSensitive()
+    {
         $this->assertResult(
             '<li type="CIRCLE" />',
             '<li />'

--- a/tests/HTMLPurifier/StrategyHarness.php
+++ b/tests/HTMLPurifier/StrategyHarness.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_StrategyHarness extends HTMLPurifier_ComplexHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->func      = 'execute';
         $this->to_tokens = true;

--- a/tests/HTMLPurifier/StringHashParserTest.php
+++ b/tests/HTMLPurifier/StringHashParserTest.php
@@ -11,19 +11,22 @@ class HTMLPurifier_StringHashParserTest extends UnitTestCase
      */
     protected $parser;
 
-    public function setup() {
+    public function setup()
+    {
         $this->parser = new HTMLPurifier_StringHashParser();
     }
 
     /**
      * Assert that $file gets parsed into the form of $expect
      */
-    protected function assertParse($file, $expect) {
+    protected function assertParse($file, $expect)
+    {
         $result = $this->parser->parseFile(dirname(__FILE__) . '/StringHashParser/' . $file);
         $this->assertIdentical($result, $expect);
     }
 
-    function testSimple() {
+    public function testSimple()
+    {
         $this->assertParse('Simple.txt', array(
             'ID' => 'Namespace.Directive',
             'TYPE' => 'string',
@@ -34,26 +37,30 @@ class HTMLPurifier_StringHashParserTest extends UnitTestCase
         ));
     }
 
-    function testOverrideSingle() {
+    public function testOverrideSingle()
+    {
         $this->assertParse('OverrideSingle.txt', array(
             'KEY' => 'New',
         ));
     }
 
-    function testAppendMultiline() {
+    public function testAppendMultiline()
+    {
         $this->assertParse('AppendMultiline.txt', array(
             'KEY' => "Line1\nLine2\n",
         ));
     }
 
-    function testDefault() {
+    public function testDefault()
+    {
         $this->parser->default = 'NEW-ID';
         $this->assertParse('Default.txt', array(
             'NEW-ID' => 'DefaultValue',
         ));
     }
 
-    function testError() {
+    public function testError()
+    {
         try {
             $this->parser->parseFile('NoExist.txt');
         } catch (HTMLPurifier_ConfigSchema_Exception $e) {
@@ -61,7 +68,8 @@ class HTMLPurifier_StringHashParserTest extends UnitTestCase
         }
     }
 
-    function testParseMultiple() {
+    public function testParseMultiple()
+    {
         $result = $this->parser->parseMultiFile(dirname(__FILE__) . '/StringHashParser/Multi.txt');
         $this->assertIdentical(
             $result,

--- a/tests/HTMLPurifier/StringHashTest.php
+++ b/tests/HTMLPurifier/StringHashTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_StringHashTest extends UnitTestCase
 {
 
-    function testUsed() {
+    public function testUsed()
+    {
         $hash = new HTMLPurifier_StringHash(array(
             'key' => 'value',
             'key2' => 'value2'

--- a/tests/HTMLPurifier/TagTransformTest.php
+++ b/tests/HTMLPurifier/TagTransformTest.php
@@ -86,8 +86,8 @@ class HTMLPurifier_TagTransformTest extends HTMLPurifier_Harness
 
     }
 
-    function testSimple() {
-
+    public function testSimple()
+    {
         $transformer = new HTMLPurifier_TagTransform_Simple('ul');
 
         $this->assertTransformation(
@@ -98,8 +98,8 @@ class HTMLPurifier_TagTransformTest extends HTMLPurifier_Harness
 
     }
 
-    function testSimpleWithCSS() {
-
+    public function testSimpleWithCSS()
+    {
         $transformer = new HTMLPurifier_TagTransform_Simple('div', 'text-align:center;');
 
         $this->assertTransformation(
@@ -119,7 +119,8 @@ class HTMLPurifier_TagTransformTest extends HTMLPurifier_Harness
 
     }
 
-    protected function assertSizeToStyle($transformer, $size, $style) {
+    protected function assertSizeToStyle($transformer, $size, $style)
+    {
         $this->assertTransformation(
             $transformer,
             'font', array('size' => $size),
@@ -127,8 +128,8 @@ class HTMLPurifier_TagTransformTest extends HTMLPurifier_Harness
         );
     }
 
-    function testFont() {
-
+    public function testFont()
+    {
         $transformer = new HTMLPurifier_TagTransform_Font();
 
         // test a font-face transformation

--- a/tests/HTMLPurifier/TokenFactoryTest.php
+++ b/tests/HTMLPurifier/TokenFactoryTest.php
@@ -2,8 +2,8 @@
 
 class HTMLPurifier_TokenFactoryTest extends HTMLPurifier_Harness
 {
-    public function test() {
-
+    public function test()
+    {
         $factory = new HTMLPurifier_TokenFactory();
 
         $regular = new HTMLPurifier_Token_Start('a', array('href' => 'about:blank'));

--- a/tests/HTMLPurifier/TokenTest.php
+++ b/tests/HTMLPurifier/TokenTest.php
@@ -14,8 +14,8 @@ class HTMLPurifier_TokenTest extends HTMLPurifier_Harness
         $this->assertIdentical($expect_attr, $token->attr);
     }
 
-    function testConstruct() {
-
+    public function testConstruct()
+    {
         // standard case
         $this->assertTokenConstruction('a', array('href' => 'about:blank'));
 

--- a/tests/HTMLPurifier/URIDefinitionTest.php
+++ b/tests/HTMLPurifier/URIDefinitionTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_URIDefinitionTest extends HTMLPurifier_URIHarness
 {
 
-    protected function createFilterMock($expect = true, $result = true, $post = false, $setup = true) {
+    protected function createFilterMock($expect = true, $result = true, $post = false, $setup = true)
+    {
         static $i = 0;
         generate_mock_once('HTMLPurifier_URIFilter');
         $mock = new HTMLPurifier_URIFilterMock();
@@ -16,7 +17,8 @@ class HTMLPurifier_URIDefinitionTest extends HTMLPurifier_URIHarness
         return $mock;
     }
 
-    function test_filter() {
+    public function test_filter()
+    {
         $def = new HTMLPurifier_URIDefinition();
         $def->addFilter($this->createFilterMock(), $this->config);
         $def->addFilter($this->createFilterMock(), $this->config);
@@ -24,7 +26,8 @@ class HTMLPurifier_URIDefinitionTest extends HTMLPurifier_URIHarness
         $this->assertTrue($def->filter($uri, $this->config, $this->context));
     }
 
-    function test_filter_earlyAbortIfFail() {
+    public function test_filter_earlyAbortIfFail()
+    {
         $def = new HTMLPurifier_URIDefinition();
         $def->addFilter($this->createFilterMock(true, false), $this->config);
         $def->addFilter($this->createFilterMock(false), $this->config); // never called
@@ -32,7 +35,8 @@ class HTMLPurifier_URIDefinitionTest extends HTMLPurifier_URIHarness
         $this->assertFalse($def->filter($uri, $this->config, $this->context));
     }
 
-    function test_setupMemberVariables_collisionPrecedenceIsHostBaseScheme() {
+    public function test_setupMemberVariables_collisionPrecedenceIsHostBaseScheme()
+    {
         $this->config->set('URI.Host', $host = 'example.com');
         $this->config->set('URI.Base', $base = 'http://sub.example.com/foo/bar.html');
         $this->config->set('URI.DefaultScheme', 'ftp');
@@ -43,14 +47,16 @@ class HTMLPurifier_URIDefinitionTest extends HTMLPurifier_URIHarness
         $this->assertIdentical($def->defaultScheme, 'http'); // not ftp!
     }
 
-    function test_setupMemberVariables_onlyScheme() {
+    public function test_setupMemberVariables_onlyScheme()
+    {
         $this->config->set('URI.DefaultScheme', 'ftp');
         $def = new HTMLPurifier_URIDefinition();
         $def->setup($this->config);
         $this->assertIdentical($def->defaultScheme, 'ftp');
     }
 
-    function test_setupMemberVariables_onlyBase() {
+    public function test_setupMemberVariables_onlyBase()
+    {
         $this->config->set('URI.Base', 'http://sub.example.com/foo/bar.html');
         $def = new HTMLPurifier_URIDefinition();
         $def->setup($this->config);

--- a/tests/HTMLPurifier/URIFilter/DisableExternalResourcesTest.php
+++ b/tests/HTMLPurifier/URIFilter/DisableExternalResourcesTest.php
@@ -4,14 +4,16 @@ class HTMLPurifier_URIFilter_DisableExternalResourcesTest extends
       HTMLPurifier_URIFilter_DisableExternalTest
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->filter = new HTMLPurifier_URIFilter_DisableExternalResources();
         $var = true;
         $this->context->register('EmbeddedURI', $var);
     }
 
-    function testPreserveWhenNotEmbedded() {
+    public function testPreserveWhenNotEmbedded()
+    {
         $this->context->destroy('EmbeddedURI'); // undo setUp
         $this->assertFiltering(
             'http://example.com'

--- a/tests/HTMLPurifier/URIFilter/DisableExternalTest.php
+++ b/tests/HTMLPurifier/URIFilter/DisableExternalTest.php
@@ -3,45 +3,52 @@
 class HTMLPurifier_URIFilter_DisableExternalTest extends HTMLPurifier_URIFilterHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->filter = new HTMLPurifier_URIFilter_DisableExternal();
     }
 
-    function testRemoveExternal() {
+    public function testRemoveExternal()
+    {
         $this->assertFiltering(
             'http://example.com', false
         );
     }
 
-    function testPreserveInternal() {
+    public function testPreserveInternal()
+    {
         $this->assertFiltering(
             '/foo/bar'
         );
     }
 
-    function testPreserveOurHost() {
+    public function testPreserveOurHost()
+    {
         $this->config->set('URI.Host', 'example.com');
         $this->assertFiltering(
             'http://example.com'
         );
     }
 
-    function testPreserveOurSubdomain() {
+    public function testPreserveOurSubdomain()
+    {
         $this->config->set('URI.Host', 'example.com');
         $this->assertFiltering(
             'http://www.example.com'
         );
     }
 
-    function testRemoveSuperdomain() {
+    public function testRemoveSuperdomain()
+    {
         $this->config->set('URI.Host', 'www.example.com');
         $this->assertFiltering(
             'http://example.com', false
         );
     }
 
-    function testBaseAsHost() {
+    public function testBaseAsHost()
+    {
         $this->config->set('URI.Base', 'http://www.example.com/foo/bar');
         $this->assertFiltering(
             'http://www.example.com/baz'

--- a/tests/HTMLPurifier/URIFilter/DisableResourcesTest.php
+++ b/tests/HTMLPurifier/URIFilter/DisableResourcesTest.php
@@ -3,18 +3,21 @@
 class HTMLPurifier_URIFilter_DisableResourcesTest extends HTMLPurifier_URIFilterHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->filter = new HTMLPurifier_URIFilter_DisableResources();
         $var = true;
         $this->context->register('EmbeddedURI', $var);
     }
 
-    function testRemoveResource() {
+    public function testRemoveResource()
+    {
         $this->assertFiltering('/foo/bar', false);
     }
 
-    function testPreserveRegular() {
+    public function testPreserveRegular()
+    {
         $this->context->destroy('EmbeddedURI'); // undo setUp
         $this->assertFiltering('/foo/bar');
     }

--- a/tests/HTMLPurifier/URIFilter/HostBlacklistTest.php
+++ b/tests/HTMLPurifier/URIFilter/HostBlacklistTest.php
@@ -3,23 +3,27 @@
 class HTMLPurifier_URIFilter_HostBlacklistTest extends HTMLPurifier_URIFilterHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->filter = new HTMLPurifier_URIFilter_HostBlacklist();
     }
 
-    function testRejectBlacklistedHost() {
+    public function testRejectBlacklistedHost()
+    {
         $this->config->set('URI.HostBlacklist', 'example.com');
         $this->assertFiltering('http://example.com', false);
     }
 
-    function testRejectBlacklistedHostThoughNotTrue() {
+    public function testRejectBlacklistedHostThoughNotTrue()
+    {
         // maybe this behavior should change
         $this->config->set('URI.HostBlacklist', 'example.com');
         $this->assertFiltering('http://example.comcast.com', false);
     }
 
-    function testPreserveNonBlacklistedHost() {
+    public function testPreserveNonBlacklistedHost()
+    {
         $this->config->set('URI.HostBlacklist', 'example.com');
         $this->assertFiltering('http://google.com');
     }

--- a/tests/HTMLPurifier/URIFilter/MakeAbsoluteTest.php
+++ b/tests/HTMLPurifier/URIFilter/MakeAbsoluteTest.php
@@ -3,124 +3,151 @@
 class HTMLPurifier_URIFilter_MakeAbsoluteTest extends HTMLPurifier_URIFilterHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->filter = new HTMLPurifier_URIFilter_MakeAbsolute();
         $this->setBase();
     }
 
-    function setBase($base = 'http://example.com/foo/bar.html?q=s#frag') {
+    public function setBase($base = 'http://example.com/foo/bar.html?q=s#frag')
+    {
         $this->config->set('URI.Base', $base);
     }
 
     // corresponding to RFC 2396
 
-    function testPreserveAbsolute() {
+    public function testPreserveAbsolute()
+    {
         $this->assertFiltering('http://example.com/foo.html');
     }
 
-    function testFilterBlank() {
+    public function testFilterBlank()
+    {
         $this->assertFiltering('', 'http://example.com/foo/bar.html?q=s');
     }
 
-    function testFilterEmptyPath() {
+    public function testFilterEmptyPath()
+    {
         $this->assertFiltering('?q=s#frag', 'http://example.com/foo/bar.html?q=s#frag');
     }
 
-    function testPreserveAltScheme() {
+    public function testPreserveAltScheme()
+    {
         $this->assertFiltering('mailto:bob@example.com');
     }
 
-    function testFilterIgnoreHTTPSpecialCase() {
+    public function testFilterIgnoreHTTPSpecialCase()
+    {
         $this->assertFiltering('http:/', 'http://example.com/');
     }
 
-    function testFilterAbsolutePath() {
+    public function testFilterAbsolutePath()
+    {
         $this->assertFiltering('/foo.txt', 'http://example.com/foo.txt');
     }
 
-    function testFilterRelativePath() {
+    public function testFilterRelativePath()
+    {
         $this->assertFiltering('baz.txt', 'http://example.com/foo/baz.txt');
     }
 
-    function testFilterRelativePathWithInternalDot() {
+    public function testFilterRelativePathWithInternalDot()
+    {
         $this->assertFiltering('./baz.txt', 'http://example.com/foo/baz.txt');
     }
 
-    function testFilterRelativePathWithEndingDot() {
+    public function testFilterRelativePathWithEndingDot()
+    {
         $this->assertFiltering('baz/.', 'http://example.com/foo/baz/');
     }
 
-    function testFilterRelativePathDot() {
+    public function testFilterRelativePathDot()
+    {
         $this->assertFiltering('.', 'http://example.com/foo/');
     }
 
-    function testFilterRelativePathMultiDot() {
+    public function testFilterRelativePathMultiDot()
+    {
         $this->assertFiltering('././foo/./bar/.././baz', 'http://example.com/foo/foo/baz');
     }
 
-    function testFilterAbsolutePathWithDot() {
+    public function testFilterAbsolutePathWithDot()
+    {
         $this->assertFiltering('/./foo', 'http://example.com/foo');
     }
 
-    function testFilterAbsolutePathWithMultiDot() {
+    public function testFilterAbsolutePathWithMultiDot()
+    {
         $this->assertFiltering('/./foo/../bar/.', 'http://example.com/bar/');
     }
 
-    function testFilterRelativePathWithInternalDotDot() {
+    public function testFilterRelativePathWithInternalDotDot()
+    {
         $this->assertFiltering('../baz.txt', 'http://example.com/baz.txt');
     }
 
-    function testFilterRelativePathWithEndingDotDot() {
+    public function testFilterRelativePathWithEndingDotDot()
+    {
         $this->assertFiltering('..', 'http://example.com/');
     }
 
-    function testFilterRelativePathTooManyDotDots() {
+    public function testFilterRelativePathTooManyDotDots()
+    {
         $this->assertFiltering('../../', 'http://example.com/');
     }
 
-    function testFilterAppendingQueryAndFragment() {
+    public function testFilterAppendingQueryAndFragment()
+    {
         $this->assertFiltering('/foo.php?q=s#frag', 'http://example.com/foo.php?q=s#frag');
     }
 
     // edge cases below
 
-    function testFilterAbsolutePathBase() {
+    public function testFilterAbsolutePathBase()
+    {
         $this->setBase('/foo/baz.txt');
         $this->assertFiltering('test.php', '/foo/test.php');
     }
 
-    function testFilterAbsolutePathBaseDirectory() {
+    public function testFilterAbsolutePathBaseDirectory()
+    {
         $this->setBase('/foo/');
         $this->assertFiltering('test.php', '/foo/test.php');
     }
 
-    function testFilterAbsolutePathBaseBelow() {
+    public function testFilterAbsolutePathBaseBelow()
+    {
         $this->setBase('/foo/baz.txt');
         $this->assertFiltering('../../test.php', '/test.php');
     }
 
-    function testFilterRelativePathBase() {
+    public function testFilterRelativePathBase()
+    {
         $this->setBase('foo/baz.html');
         $this->assertFiltering('foo.php', 'foo/foo.php');
     }
 
-    function testFilterRelativePathBaseBelow() {
+    public function testFilterRelativePathBaseBelow()
+    {
         $this->setBase('../baz.html');
         $this->assertFiltering('test/strike.html', '../test/strike.html');
     }
 
-    function testFilterRelativePathBaseWithAbsoluteURI() {
+    public function testFilterRelativePathBaseWithAbsoluteURI()
+    {
         $this->setBase('../baz.html');
         $this->assertFiltering('/test/strike.html');
     }
 
-    function testFilterRelativePathBaseWithDot() {
+    public function testFilterRelativePathBaseWithDot()
+    {
         $this->setBase('../baz.html');
         $this->assertFiltering('.', '../');
     }
 
-    function testRemoveJavaScriptWithEmbeddedLink() {
+    public function testRemoveJavaScriptWithEmbeddedLink()
+    {
         // credits: NykO18
         $this->setBase('http://www.example.com/');
         $this->assertFiltering('javascript: window.location = \'http://www.example.com\';', false);
@@ -128,14 +155,16 @@ class HTMLPurifier_URIFilter_MakeAbsoluteTest extends HTMLPurifier_URIFilterHarn
 
     // miscellaneous
 
-    function testFilterDomainWithNoSlash() {
+    public function testFilterDomainWithNoSlash()
+    {
         $this->setBase('http://example.com');
         $this->assertFiltering('foo', 'http://example.com/foo');
     }
 
     // error case
 
-    function testErrorNoBase() {
+    public function testErrorNoBase()
+    {
         $this->setBase(null);
         $this->expectError('URI.MakeAbsolute is being ignored due to lack of value for URI.Base configuration');
         $this->assertFiltering('foo/bar.txt');

--- a/tests/HTMLPurifier/URIFilter/MungeTest.php
+++ b/tests/HTMLPurifier/URIFilter/MungeTest.php
@@ -3,21 +3,25 @@
 class HTMLPurifier_URIFilter_MungeTest extends HTMLPurifier_URIFilterHarness
 {
 
-    function setUp() {
+    public function setUp()
+    {
         parent::setUp();
         $this->filter = new HTMLPurifier_URIFilter_Munge();
     }
 
-    protected function setMunge($uri = 'http://www.google.com/url?q=%s') {
+    protected function setMunge($uri = 'http://www.google.com/url?q=%s')
+    {
         $this->config->set('URI.Munge', $uri);
     }
 
-    protected function setSecureMunge($key = 'secret') {
+    protected function setSecureMunge($key = 'secret')
+    {
         $this->setMunge('/redirect.php?url=%s&checksum=%t');
         $this->config->set('URI.MungeSecretKey', $key);
     }
 
-    function testMunge() {
+    public function testMunge()
+    {
         $this->setMunge();
         $this->assertFiltering(
             'http://www.example.com/',
@@ -25,42 +29,48 @@ class HTMLPurifier_URIFilter_MungeTest extends HTMLPurifier_URIFilterHarness
         );
     }
 
-    function testMungeReplaceTagName() {
+    public function testMungeReplaceTagName()
+    {
         $this->setMunge('/r?tagname=%n&url=%s');
         $token = new HTMLPurifier_Token_Start('a');
         $this->context->register('CurrentToken', $token);
         $this->assertFiltering('http://google.com', '/r?tagname=a&url=http%3A%2F%2Fgoogle.com');
     }
 
-    function testMungeReplaceAttribute() {
+    public function testMungeReplaceAttribute()
+    {
         $this->setMunge('/r?attr=%m&url=%s');
         $attr = 'href';
         $this->context->register('CurrentAttr', $attr);
         $this->assertFiltering('http://google.com', '/r?attr=href&url=http%3A%2F%2Fgoogle.com');
     }
 
-    function testMungeReplaceResource() {
+    public function testMungeReplaceResource()
+    {
         $this->setMunge('/r?embeds=%r&url=%s');
         $embeds = false;
         $this->context->register('EmbeddedURI', $embeds);
         $this->assertFiltering('http://google.com', '/r?embeds=&url=http%3A%2F%2Fgoogle.com');
     }
 
-    function testMungeReplaceCSSProperty() {
+    public function testMungeReplaceCSSProperty()
+    {
         $this->setMunge('/r?property=%p&url=%s');
         $property = 'background';
         $this->context->register('CurrentCSSProperty', $property);
         $this->assertFiltering('http://google.com', '/r?property=background&url=http%3A%2F%2Fgoogle.com');
     }
 
-    function testIgnoreEmbedded() {
+    public function testIgnoreEmbedded()
+    {
         $this->setMunge();
         $embeds = true;
         $this->context->register('EmbeddedURI', $embeds);
         $this->assertFiltering('http://example.com');
     }
 
-    function testProcessEmbedded() {
+    public function testProcessEmbedded()
+    {
         $this->setMunge();
         $this->config->set('URI.MungeResources', true);
         $embeds = true;
@@ -68,73 +78,86 @@ class HTMLPurifier_URIFilter_MungeTest extends HTMLPurifier_URIFilterHarness
         $this->assertFiltering('http://www.example.com/', 'http://www.google.com/url?q=http%3A%2F%2Fwww.example.com%2F');
     }
 
-    function testPreserveRelative() {
+    public function testPreserveRelative()
+    {
         $this->setMunge();
         $this->assertFiltering('index.html');
     }
 
-    function testMungeIgnoreUnknownSchemes() {
+    public function testMungeIgnoreUnknownSchemes()
+    {
         $this->setMunge();
         $this->assertFiltering('javascript:foobar();', true);
     }
 
-    function testSecureMungePreserve() {
+    public function testSecureMungePreserve()
+    {
         $this->setSecureMunge();
         $this->assertFiltering('/local');
     }
 
-    function testSecureMungePreserveEmbedded() {
+    public function testSecureMungePreserveEmbedded()
+    {
         $this->setSecureMunge();
         $embedded = true;
         $this->context->register('EmbeddedURI', $embedded);
         $this->assertFiltering('http://google.com');
     }
 
-    function testSecureMungeStandard() {
+    public function testSecureMungeStandard()
+    {
         $this->setSecureMunge();
         $this->assertFiltering('http://google.com', '/redirect.php?url=http%3A%2F%2Fgoogle.com&checksum=0072e2f817fd2844825def74e54443debecf0892');
     }
 
-    function testSecureMungeIgnoreUnknownSchemes() {
+    public function testSecureMungeIgnoreUnknownSchemes()
+    {
         // This should be integration tested as well to be false
         $this->setSecureMunge();
         $this->assertFiltering('javascript:', true);
     }
 
-    function testSecureMungeIgnoreUnbrowsableSchemes() {
+    public function testSecureMungeIgnoreUnbrowsableSchemes()
+    {
         $this->setSecureMunge();
         $this->assertFiltering('news:', true);
     }
 
-    function testSecureMungeToDirectory() {
+    public function testSecureMungeToDirectory()
+    {
         $this->setSecureMunge();
         $this->setMunge('/links/%s/%t');
         $this->assertFiltering('http://google.com', '/links/http%3A%2F%2Fgoogle.com/0072e2f817fd2844825def74e54443debecf0892');
     }
 
-    function testMungeIgnoreSameDomain() {
+    public function testMungeIgnoreSameDomain()
+    {
         $this->setMunge('http://example.com/%s');
         $this->assertFiltering('http://example.com/foobar');
     }
 
-    function testMungeIgnoreSameDomainInsecureToSecure() {
+    public function testMungeIgnoreSameDomainInsecureToSecure()
+    {
         $this->setMunge('http://example.com/%s');
         $this->assertFiltering('https://example.com/foobar');
     }
 
-    function testMungeIgnoreSameDomainSecureToSecure() {
+    public function testMungeIgnoreSameDomainSecureToSecure()
+    {
         $this->config->set('URI.Base', 'https://example.com');
         $this->setMunge('http://example.com/%s');
         $this->assertFiltering('https://example.com/foobar');
     }
 
-    function testMungeSameDomainSecureToInsecure() {
+    public function testMungeSameDomainSecureToInsecure()
+    {
         $this->config->set('URI.Base', 'https://example.com');
         $this->setMunge('/%s');
         $this->assertFiltering('http://example.com/foobar', '/http%3A%2F%2Fexample.com%2Ffoobar');
     }
 
-    function testMungeIgnoresSourceHost() {
+    public function testMungeIgnoresSourceHost()
+    {
         $this->config->set('URI.Host', 'foo.example.com');
         $this->setMunge('http://example.com/%s');
         $this->assertFiltering('http://foo.example.com/bar');

--- a/tests/HTMLPurifier/URIFilterHarness.php
+++ b/tests/HTMLPurifier/URIFilterHarness.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_URIFilterHarness extends HTMLPurifier_URIHarness
 {
 
-    protected function assertFiltering($uri, $expect_uri = true) {
+    protected function assertFiltering($uri, $expect_uri = true)
+    {
         $this->prepareURI($uri, $expect_uri);
         $this->filter->prepare($this->config, $this->context);
         $result = $this->filter->filter($uri, $this->config, $this->context);

--- a/tests/HTMLPurifier/URIHarness.php
+++ b/tests/HTMLPurifier/URIHarness.php
@@ -9,7 +9,8 @@ class HTMLPurifier_URIHarness extends HTMLPurifier_Harness
      * @param &$expect_uri Reference to string expectation URI
      * @note If $expect_uri is false, it will stay false
      */
-    protected function prepareURI(&$uri, &$expect_uri) {
+    protected function prepareURI(&$uri, &$expect_uri)
+    {
         $parser = new HTMLPurifier_URIParser();
         if ($expect_uri === true) $expect_uri = $uri;
         $uri = $parser->parse($uri);
@@ -21,7 +22,8 @@ class HTMLPurifier_URIHarness extends HTMLPurifier_Harness
     /**
      * Generates a URI object from the corresponding string
      */
-    protected function createURI($uri) {
+    protected function createURI($uri)
+    {
         $parser = new HTMLPurifier_URIParser();
         return $parser->parse($uri);
     }

--- a/tests/HTMLPurifier/URIParserTest.php
+++ b/tests/HTMLPurifier/URIParserTest.php
@@ -13,98 +13,112 @@ class HTMLPurifier_URIParserTest extends HTMLPurifier_Harness
         $this->assertEqual($result, $expect);
     }
 
-    function testPercentNormalization() {
+    public function testPercentNormalization()
+    {
         $this->assertParsing(
             '%G',
             null, null, null, null, '%25G', null, null
         );
     }
 
-    function testRegular() {
+    public function testRegular()
+    {
         $this->assertParsing(
             'http://www.example.com/webhp?q=foo#result2',
             'http', null, 'www.example.com', null, '/webhp', 'q=foo', 'result2'
         );
     }
 
-    function testPortAndUsername() {
+    public function testPortAndUsername()
+    {
         $this->assertParsing(
             'http://user@authority.part:80/now/the/path?query#fragment',
             'http', 'user', 'authority.part', 80, '/now/the/path', 'query', 'fragment'
         );
     }
 
-    function testPercentEncoding() {
+    public function testPercentEncoding()
+    {
         $this->assertParsing(
             'http://en.wikipedia.org/wiki/Clich%C3%A9',
             'http', null, 'en.wikipedia.org', null, '/wiki/Clich%C3%A9', null, null
         );
     }
 
-    function testEmptyQuery() {
+    public function testEmptyQuery()
+    {
         $this->assertParsing(
             'http://www.example.com/?#',
             'http', null, 'www.example.com', null, '/', '', null
         );
     }
 
-    function testEmptyPath() {
+    public function testEmptyPath()
+    {
         $this->assertParsing(
             'http://www.example.com',
             'http', null, 'www.example.com', null, '', null, null
         );
     }
 
-    function testOpaqueURI() {
+    public function testOpaqueURI()
+    {
         $this->assertParsing(
             'mailto:bob@example.com',
             'mailto', null, null, null, 'bob@example.com', null, null
         );
     }
 
-    function testIPv4Address() {
+    public function testIPv4Address()
+    {
         $this->assertParsing(
             'http://192.0.34.166/',
             'http', null, '192.0.34.166', null, '/', null, null
         );
     }
 
-    function testFakeIPv4Address() {
+    public function testFakeIPv4Address()
+    {
         $this->assertParsing(
             'http://333.123.32.123/',
             'http', null, '333.123.32.123', null, '/', null, null
         );
     }
 
-    function testIPv6Address() {
+    public function testIPv6Address()
+    {
         $this->assertParsing(
             'http://[2001:db8::7]/c=GB?objectClass?one',
             'http', null, '[2001:db8::7]', null, '/c=GB', 'objectClass?one', null
         );
     }
 
-    function testInternationalizedDomainName() {
+    public function testInternationalizedDomainName()
+    {
         $this->assertParsing(
             "http://t\xC5\xABdali\xC5\x86.lv",
             'http', null, "t\xC5\xABdali\xC5\x86.lv", null, '', null, null
         );
     }
 
-    function testInvalidPort() {
+    public function testInvalidPort()
+    {
         $this->assertParsing(
             'http://example.com:foobar',
             'http', null, 'example.com', null, '', null, null
         );
     }
 
-    function testPathAbsolute() {
+    public function testPathAbsolute()
+    {
         $this->assertParsing(
             'http:/this/is/path',
             'http', null, null, null, '/this/is/path', null, null
         );
     }
 
-    function testPathRootless() {
+    public function testPathRootless()
+    {
         // this should not be used but is allowed
         $this->assertParsing(
             'http:this/is/path',
@@ -112,35 +126,40 @@ class HTMLPurifier_URIParserTest extends HTMLPurifier_Harness
         );
     }
 
-    function testPathEmpty() {
+    public function testPathEmpty()
+    {
         $this->assertParsing(
             'http:',
             'http', null, null, null, '', null, null
         );
     }
 
-    function testRelativeURI() {
+    public function testRelativeURI()
+    {
         $this->assertParsing(
             '/a/b',
             null, null, null, null, '/a/b', null, null
         );
     }
 
-    function testMalformedTag() {
+    public function testMalformedTag()
+    {
         $this->assertParsing(
             'http://www.example.com/>',
             'http', null, 'www.example.com', null, '/', null, null
         );
     }
 
-    function testEmpty() {
+    public function testEmpty()
+    {
         $this->assertParsing(
             '',
             null, null, null, null, '', null, null
         );
     }
 
-    function testEmbeddedColon() {
+    public function testEmbeddedColon()
+    {
         $this->assertParsing(
             '{:test:}',
             null, null, null, null, '{:test:}', null, null

--- a/tests/HTMLPurifier/URISchemeRegistryTest.php
+++ b/tests/HTMLPurifier/URISchemeRegistryTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_URISchemeRegistryTest extends HTMLPurifier_Harness
 {
 
-    function test() {
-
+    public function test()
+    {
         generate_mock_once('HTMLPurifier_URIScheme');
 
         $config = HTMLPurifier_Config::create(array(

--- a/tests/HTMLPurifier/URISchemeTest.php
+++ b/tests/HTMLPurifier/URISchemeTest.php
@@ -8,7 +8,8 @@ class HTMLPurifier_URISchemeTest extends HTMLPurifier_URIHarness
 
     private $pngBase64;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->pngBase64 =
             'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABGdBTUEAALGP'.
             'C/xhBQAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9YGARc5KB0XV+IA'.
@@ -18,7 +19,8 @@ class HTMLPurifier_URISchemeTest extends HTMLPurifier_URIHarness
             'vr4MkhoXe0rZigAAAABJRU5ErkJggg==';
     }
 
-    protected function assertValidation($uri, $expect_uri = true) {
+    protected function assertValidation($uri, $expect_uri = true)
+    {
         $this->prepareURI($uri, $expect_uri);
         $this->config->set('URI.AllowedSchemes', array($uri->scheme));
         // convenience hack: the scheme should be explicitly specified
@@ -27,165 +29,190 @@ class HTMLPurifier_URISchemeTest extends HTMLPurifier_URIHarness
         $this->assertEitherFailOrIdentical($result, $uri, $expect_uri);
     }
 
-    function test_http_regular() {
+    public function test_http_regular()
+    {
         $this->assertValidation(
             'http://example.com/?s=q#fragment'
         );
     }
 
-    function test_http_uppercase() {
+    public function test_http_uppercase()
+    {
         $this->assertValidation(
             'http://example.com/FOO'
         );
     }
 
-    function test_http_removeDefaultPort() {
+    public function test_http_removeDefaultPort()
+    {
         $this->assertValidation(
             'http://example.com:80',
             'http://example.com'
         );
     }
 
-    function test_http_removeUserInfo() {
+    public function test_http_removeUserInfo()
+    {
         $this->assertValidation(
             'http://bob@example.com',
             'http://example.com'
         );
     }
 
-    function test_http_preserveNonDefaultPort() {
+    public function test_http_preserveNonDefaultPort()
+    {
         $this->assertValidation(
             'http://example.com:8080'
         );
     }
 
-    function test_https_regular() {
+    public function test_https_regular()
+    {
         $this->assertValidation(
             'https://user@example.com:443/?s=q#frag',
             'https://example.com/?s=q#frag'
         );
     }
 
-    function test_ftp_regular() {
+    public function test_ftp_regular()
+    {
         $this->assertValidation(
             'ftp://user@example.com/path'
         );
     }
 
-    function test_ftp_removeDefaultPort() {
+    public function test_ftp_removeDefaultPort()
+    {
         $this->assertValidation(
             'ftp://example.com:21',
             'ftp://example.com'
         );
     }
 
-    function test_ftp_removeQueryString() {
+    public function test_ftp_removeQueryString()
+    {
         $this->assertValidation(
             'ftp://example.com?s=q',
             'ftp://example.com'
         );
     }
 
-    function test_ftp_preserveValidTypecode() {
+    public function test_ftp_preserveValidTypecode()
+    {
         $this->assertValidation(
             'ftp://example.com/file.txt;type=a'
         );
     }
 
-    function test_ftp_removeInvalidTypecode() {
+    public function test_ftp_removeInvalidTypecode()
+    {
         $this->assertValidation(
             'ftp://example.com/file.txt;type=z',
             'ftp://example.com/file.txt'
         );
     }
 
-    function test_ftp_encodeExtraSemicolons() {
+    public function test_ftp_encodeExtraSemicolons()
+    {
         $this->assertValidation(
             'ftp://example.com/too;many;semicolons=1',
             'ftp://example.com/too%3Bmany%3Bsemicolons=1'
         );
     }
 
-    function test_news_regular() {
+    public function test_news_regular()
+    {
         $this->assertValidation(
             'news:gmane.science.linguistics'
         );
     }
 
-    function test_news_explicit() {
+    public function test_news_explicit()
+    {
         $this->assertValidation(
             'news:642@eagle.ATT.COM'
         );
     }
 
-    function test_news_removeNonPathComponents() {
+    public function test_news_removeNonPathComponents()
+    {
         $this->assertValidation(
             'news://user@example.com:80/rec.music?path=foo#frag',
             'news:/rec.music#frag'
         );
     }
 
-    function test_nntp_regular() {
+    public function test_nntp_regular()
+    {
         $this->assertValidation(
             'nntp://news.example.com/alt.misc/42#frag'
         );
     }
 
-    function test_nntp_removalOfRedundantOrUselessComponents() {
+    public function test_nntp_removalOfRedundantOrUselessComponents()
+    {
         $this->assertValidation(
             'nntp://user@news.example.com:119/alt.misc/42?s=q#frag',
             'nntp://news.example.com/alt.misc/42#frag'
         );
     }
 
-    function test_mailto_regular() {
+    public function test_mailto_regular()
+    {
         $this->assertValidation(
             'mailto:bob@example.com'
         );
     }
 
-    function test_mailto_removalOfRedundantOrUselessComponents() {
+    public function test_mailto_removalOfRedundantOrUselessComponents()
+    {
         $this->assertValidation(
             'mailto://user@example.com:80/bob@example.com?subject=Foo#frag',
             'mailto:/bob@example.com?subject=Foo#frag'
         );
     }
 
-    function test_data_png() {
+    public function test_data_png()
+    {
         $this->assertValidation(
             'data:image/png;base64,'.$this->pngBase64
         );
     }
 
-    function test_data_malformed() {
+    public function test_data_malformed()
+    {
         $this->assertValidation(
             'data:image/png;base64,vr4MkhoXJRU5ErkJggg==',
             false
         );
     }
 
-    function test_data_implicit() {
+    public function test_data_implicit()
+    {
         $this->assertValidation(
             'data:base64,'.$this->pngBase64,
             'data:image/png;base64,'.$this->pngBase64
         );
     }
 
-    function test_file_basic() {
+    public function test_file_basic()
+    {
         $this->assertValidation(
             'file://user@MYCOMPUTER:12/foo/bar?baz#frag',
             'file://MYCOMPUTER/foo/bar#frag'
         );
     }
 
-    function test_file_local() {
+    public function test_file_local()
+    {
         $this->assertValidation(
             'file:///foo/bar?baz#frag',
             'file:///foo/bar#frag'
         );
     }
 
-    function test_ftp_empty_host() {
+    public function test_ftp_empty_host()
+    {
         $this->assertValidation('ftp:///example.com', false);
     }
 

--- a/tests/HTMLPurifier/URITest.php
+++ b/tests/HTMLPurifier/URITest.php
@@ -3,12 +3,14 @@
 class HTMLPurifier_URITest extends HTMLPurifier_URIHarness
 {
 
-    protected function createURI($uri) {
+    protected function createURI($uri)
+    {
         $parser = new HTMLPurifier_URIParser();
         return $parser->parse($uri);
     }
 
-    function test_construct() {
+    public function test_construct()
+    {
         $uri1 = new HTMLPurifier_URI('HTTP', 'bob', 'example.com', '23', '/foo', 'bar=2', 'slash');
         $uri2 = new HTMLPurifier_URI('http', 'bob', 'example.com',  23,  '/foo', 'bar=2', 'slash');
         $this->assertIdentical($uri1, $uri2);
@@ -26,23 +28,27 @@ class HTMLPurifier_URITest extends HTMLPurifier_URIHarness
         return $registry;
     }
 
-    protected function setUpSchemeMock($name) {
+    protected function setUpSchemeMock($name)
+    {
         $registry = $this->setUpSchemeRegistryMock();
         $scheme_mock = new HTMLPurifier_URISchemeMock();
         $registry->setReturnValue('getScheme', $scheme_mock, array($name, '*', '*'));
         return $scheme_mock;
     }
 
-    protected function setUpNoValidSchemes() {
+    protected function setUpNoValidSchemes()
+    {
         $registry = $this->setUpSchemeRegistryMock();
         $registry->setReturnValue('getScheme', false, array('*', '*', '*'));
     }
 
-    protected function tearDownSchemeRegistryMock() {
+    protected function tearDownSchemeRegistryMock()
+    {
         HTMLPurifier_URISchemeRegistry::instance($this->oldRegistry);
     }
 
-    function test_getSchemeObj() {
+    public function test_getSchemeObj()
+    {
         $scheme_mock = $this->setUpSchemeMock('http');
 
         $uri = $this->createURI('http:');
@@ -52,7 +58,8 @@ class HTMLPurifier_URITest extends HTMLPurifier_URIHarness
         $this->tearDownSchemeRegistryMock();
     }
 
-    function test_getSchemeObj_invalidScheme() {
+    public function test_getSchemeObj_invalidScheme()
+    {
         $this->setUpNoValidSchemes();
 
         $uri = $this->createURI('http:');
@@ -62,7 +69,8 @@ class HTMLPurifier_URITest extends HTMLPurifier_URIHarness
         $this->tearDownSchemeRegistryMock();
     }
 
-    function test_getSchemaObj_defaultScheme() {
+    public function test_getSchemaObj_defaultScheme()
+    {
         $scheme = 'foobar';
 
         $scheme_mock = $this->setUpSchemeMock($scheme);
@@ -75,7 +83,8 @@ class HTMLPurifier_URITest extends HTMLPurifier_URIHarness
         $this->tearDownSchemeRegistryMock();
     }
 
-    function test_getSchemaObj_invalidDefaultScheme() {
+    public function test_getSchemaObj_invalidDefaultScheme()
+    {
         $this->setUpNoValidSchemes();
         $this->config->set('URI.DefaultScheme', 'foobar');
 
@@ -88,55 +97,63 @@ class HTMLPurifier_URITest extends HTMLPurifier_URIHarness
         $this->tearDownSchemeRegistryMock();
     }
 
-    protected function assertToString($expect_uri, $scheme, $userinfo, $host, $port, $path, $query, $fragment) {
+    protected function assertToString($expect_uri, $scheme, $userinfo, $host, $port, $path, $query, $fragment)
+    {
         $uri = new HTMLPurifier_URI($scheme, $userinfo, $host, $port, $path, $query, $fragment);
         $string = $uri->toString();
         $this->assertIdentical($string, $expect_uri);
     }
 
-    function test_toString_full() {
+    public function test_toString_full()
+    {
         $this->assertToString(
             'http://bob@example.com:300/foo?bar=baz#fragment',
             'http', 'bob', 'example.com', 300, '/foo', 'bar=baz', 'fragment'
         );
     }
 
-    function test_toString_scheme() {
+    public function test_toString_scheme()
+    {
         $this->assertToString(
             'http:',
             'http', null, null, null, '', null, null
         );
     }
 
-    function test_toString_authority() {
+    public function test_toString_authority()
+    {
         $this->assertToString(
             '//bob@example.com:8080',
             null, 'bob', 'example.com', 8080, '', null, null
         );
     }
 
-    function test_toString_path() {
+    public function test_toString_path()
+    {
         $this->assertToString(
             '/path/to',
             null, null, null, null, '/path/to', null, null
         );
     }
 
-    function test_toString_query() {
+    public function test_toString_query()
+    {
         $this->assertToString(
             '?q=string',
             null, null, null, null, '', 'q=string', null
         );
     }
 
-    function test_toString_fragment() {
+    public function test_toString_fragment()
+    {
         $this->assertToString(
             '#fragment',
             null, null, null, null, '', null, 'fragment'
         );
     }
 
-    protected function assertValidation($uri, $expect_uri = true) {
+    protected function assertValidation($uri, $expect_uri = true)
+    {
         if ($expect_uri === true) $expect_uri = $uri;
         $uri = $this->createURI($uri);
         $result = $uri->validate($this->config, $this->context);
@@ -148,51 +165,63 @@ class HTMLPurifier_URITest extends HTMLPurifier_URIHarness
         }
     }
 
-    function test_validate_overlongPort() {
+    public function test_validate_overlongPort()
+    {
         $this->assertValidation('http://example.com:65536', 'http://example.com');
     }
 
-    function test_validate_zeroPort() {
+    public function test_validate_zeroPort()
+    {
         $this->assertValidation('http://example.com:00', 'http://example.com');
     }
 
-    function test_validate_invalidHostThatLooksLikeIPv6() {
+    public function test_validate_invalidHostThatLooksLikeIPv6()
+    {
         $this->assertValidation('http://[2001:0db8:85z3:08d3:1319:8a2e:0370:7334]', '');
     }
 
-    function test_validate_removeRedundantScheme() {
+    public function test_validate_removeRedundantScheme()
+    {
         $this->assertValidation('http:foo:/:', 'foo%3A/:');
     }
 
-    function test_validate_username() {
+    public function test_validate_username()
+    {
         $this->assertValidation("http://user\xE3\x91\x94:@foo.com", 'http://user%E3%91%94:@foo.com');
     }
 
-    function test_validate_path_abempty() {
+    public function test_validate_path_abempty()
+    {
         $this->assertValidation("http://host/\xE3\x91\x94:", 'http://host/%E3%91%94:');
     }
 
-    function test_validate_path_absolute() {
+    public function test_validate_path_absolute()
+    {
         $this->assertValidation("/\xE3\x91\x94:", '/%E3%91%94:');
     }
 
-    function test_validate_path_rootless() {
+    public function test_validate_path_rootless()
+    {
         $this->assertValidation("mailto:\xE3\x91\x94:", 'mailto:%E3%91%94:');
     }
 
-    function test_validate_path_noscheme() {
+    public function test_validate_path_noscheme()
+    {
         $this->assertValidation("\xE3\x91\x94", '%E3%91%94');
     }
 
-    function test_validate_query() {
+    public function test_validate_query()
+    {
         $this->assertValidation("?/\xE3\x91\x94", '?/%E3%91%94');
     }
 
-    function test_validate_fragment() {
+    public function test_validate_fragment()
+    {
         $this->assertValidation("#/\xE3\x91\x94", '#/%E3%91%94');
     }
 
-    function test_validate_path_empty() {
+    public function test_validate_path_empty()
+    {
         $this->assertValidation('http://google.com');
     }
 

--- a/tests/HTMLPurifier/UnitConverterTest.php
+++ b/tests/HTMLPurifier/UnitConverterTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_UnitConverterTest extends HTMLPurifier_Harness
 {
 
-    protected function assertConversion($input, $expect, $unit = null, $test_negative = true) {
+    protected function assertConversion($input, $expect, $unit = null, $test_negative = true)
+    {
         $length = HTMLPurifier_Length::make($input);
         if ($expect !== false) $expectl = HTMLPurifier_Length::make($expect);
         else $expectl = false;
@@ -29,12 +30,14 @@ class HTMLPurifier_UnitConverterTest extends HTMLPurifier_Harness
         }
     }
 
-    function testFail() {
+    public function testFail()
+    {
         $this->assertConversion('1in', false, 'foo');
         $this->assertConversion('1foo', false, 'in');
     }
 
-    function testZero() {
+    public function testZero()
+    {
         $this->assertConversion('0', '0', 'in', false);
         $this->assertConversion('-0', '0', 'in', false);
         $this->assertConversion('0in', '0', 'in', false);
@@ -43,7 +46,8 @@ class HTMLPurifier_UnitConverterTest extends HTMLPurifier_Harness
         $this->assertConversion('-0in', '0', 'pt', false);
     }
 
-    function testEnglish() {
+    public function testEnglish()
+    {
         $this->assertConversion('1in', '6pc');
         $this->assertConversion('6pc', '1in');
 
@@ -61,20 +65,23 @@ class HTMLPurifier_UnitConverterTest extends HTMLPurifier_Harness
         $this->assertConversion('96px', '1in');
     }
 
-    function testMetric() {
+    public function testMetric()
+    {
         $this->assertConversion('1cm', '10mm');
         $this->assertConversion('10mm', '1cm');
         $this->assertConversion('1mm', '0.1cm');
         $this->assertConversion('100mm', '10cm');
     }
 
-    function testEnglishMetric() {
+    public function testEnglishMetric()
+    {
         $this->assertConversion('2.835pt', '1mm');
         $this->assertConversion('1mm', '2.835pt');
         $this->assertConversion('0.3937in', '1cm');
     }
 
-    function testRoundingMinPrecision() {
+    public function testRoundingMinPrecision()
+    {
         // One sig-fig, modified to be four, conversion rounds up
         $this->assertConversion('100pt', '1.389in');
         $this->assertConversion('1000pt', '13.89in');
@@ -83,7 +90,8 @@ class HTMLPurifier_UnitConverterTest extends HTMLPurifier_Harness
         $this->assertConversion('1000000pt', '13890in');
     }
 
-    function testRoundingUserPrecision() {
+    public function testRoundingUserPrecision()
+    {
         // Five sig-figs, conversion rounds down
         $this->assertConversion('11112000pt', '154330in');
         $this->assertConversion('1111200pt', '15433in');
@@ -94,17 +102,20 @@ class HTMLPurifier_UnitConverterTest extends HTMLPurifier_Harness
         $this->assertConversion('11.112pt', '0.15433in');
     }
 
-    function testRoundingBigNumber() {
+    public function testRoundingBigNumber()
+    {
         $this->assertConversion('444400000000000000000000in', '42660000000000000000000000px');
     }
 
-    protected function assertSigFig($n, $sigfigs) {
+    protected function assertSigFig($n, $sigfigs)
+    {
         $converter = new HTMLPurifier_UnitConverter();
         $result = $converter->getSigFigs($n);
         $this->assertIdentical($result, $sigfigs);
     }
 
-    function test_getSigFigs() {
+    public function test_getSigFigs()
+    {
         $this->assertSigFig('0', 0);
         $this->assertSigFig('1', 1);
         $this->assertSigFig('-1', 1);

--- a/tests/HTMLPurifier/VarParser/FlexibleTest.php
+++ b/tests/HTMLPurifier/VarParser/FlexibleTest.php
@@ -3,8 +3,8 @@
 class HTMLPurifier_VarParser_FlexibleTest extends HTMLPurifier_VarParserHarness
 {
 
-    function testValidate() {
-
+    public function testValidate()
+    {
         $this->assertValid('foobar', 'string');
         $this->assertValid('foobar', 'text');
         $this->assertValid('FOOBAR', 'istring', 'foobar');
@@ -51,11 +51,13 @@ class HTMLPurifier_VarParser_FlexibleTest extends HTMLPurifier_VarParserHarness
 
     }
 
-    function testValidate_withMagicNumbers() {
+    public function testValidate_withMagicNumbers()
+    {
         $this->assertValid('foobar', HTMLPurifier_VarParser::STRING);
     }
 
-    function testValidate_null() {
+    public function testValidate_null()
+    {
         $this->assertIdentical($this->parser->parse(null, 'string', true), null);
         $this->expectException('HTMLPurifier_VarParserException');
         $this->parser->parse(null, 'string', false);

--- a/tests/HTMLPurifier/VarParser/NativeTest.php
+++ b/tests/HTMLPurifier/VarParser/NativeTest.php
@@ -3,7 +3,8 @@
 class HTMLPurifier_VarParser_NativeTest extends HTMLPurifier_VarParserHarness
 {
 
-    public function testValidateSimple() {
+    public function testValidateSimple()
+    {
         $this->assertValid('"foo\\\\"', 'string', 'foo\\');
     }
 

--- a/tests/HTMLPurifier/VarParserHarness.php
+++ b/tests/HTMLPurifier/VarParserHarness.php
@@ -5,17 +5,20 @@ class HTMLPurifier_VarParserHarness extends UnitTestCase
 
     protected $parser;
 
-    public function setup() {
+    public function setup()
+    {
         $class = substr(get_class($this), 0, -4);
         $this->parser = new $class();
     }
 
-    function assertValid($var, $type, $ret = null) {
+    public function assertValid($var, $type, $ret = null)
+    {
         $ret = ($ret === null) ? $var : $ret;
         $this->assertIdentical($this->parser->parse($var, $type), $ret);
     }
 
-    function assertInvalid($var, $type, $msg = null) {
+    public function assertInvalid($var, $type, $msg = null)
+    {
         $caught = false;
         try {
             $this->parser->parse($var, $type);

--- a/tests/HTMLPurifierTest.php
+++ b/tests/HTMLPurifierTest.php
@@ -4,12 +4,13 @@ class HTMLPurifierTest extends HTMLPurifier_Harness
 {
     protected $purifier;
 
-    function testNull() {
+    public function testNull()
+    {
         $this->assertPurification("Null byte\0", "Null byte");
     }
 
-    function test_purifyArray() {
-
+    public function test_purifyArray()
+    {
         $this->assertIdentical(
             $this->purifier->purifyArray(
                 array('Good', '<b>Sketchy', 'foo' => '<script>bad</script>')
@@ -21,13 +22,15 @@ class HTMLPurifierTest extends HTMLPurifier_Harness
 
     }
 
-    function testGetInstance() {
+    public function testGetInstance()
+    {
         $purifier  = HTMLPurifier::getInstance();
         $purifier2 = HTMLPurifier::getInstance();
         $this->assertReference($purifier, $purifier2);
     }
 
-    function testMakeAbsolute() {
+    public function testMakeAbsolute()
+    {
         $this->config->set('URI.Base', 'http://example.com/bar/baz.php');
         $this->config->set('URI.MakeAbsolute', true);
         $this->assertPurification(
@@ -36,12 +39,14 @@ class HTMLPurifierTest extends HTMLPurifier_Harness
         );
     }
 
-    function testDisableResources() {
+    public function testDisableResources()
+    {
         $this->config->set('URI.DisableResources', true);
         $this->assertPurification('<img src="foo.jpg" />', '');
     }
 
-    function test_addFilter_deprecated() {
+    public function test_addFilter_deprecated()
+    {
         $this->expectError('HTMLPurifier->addFilter() is deprecated, use configuration directives in the Filter namespace or Filter.Custom');
         generate_mock_once('HTMLPurifier_Filter');
         $this->purifier->addFilter($mock = new HTMLPurifier_FilterMock());

--- a/tests/PHPT/Controller/SimpleTest.php
+++ b/tests/PHPT/Controller/SimpleTest.php
@@ -8,12 +8,14 @@ class PHPT_Controller_SimpleTest extends SimpleTestCase
 
     protected $_path;
 
-    public function __construct($path) {
+    public function __construct($path)
+    {
         $this->_path = $path;
         parent::__construct($path);
     }
 
-    public function testPhpt() {
+    public function testPhpt()
+    {
         $suite = new PHPT_Suite(array($this->_path));
         $phpt_reporter = new PHPT_Reporter_SimpleTest($this->reporter);
         $suite->run($phpt_reporter);

--- a/tests/PHPT/Reporter/SimpleTest.php
+++ b/tests/PHPT/Reporter/SimpleTest.php
@@ -10,7 +10,8 @@ class PHPT_Reporter_SimpleTest implements PHPT_Reporter
     protected $reporter;
 
     /** @param SimpleTest reporter */
-    public function __construct($reporter) {
+    public function __construct($reporter)
+    {
         $this->reporter = $reporter;
     }
 
@@ -21,42 +22,48 @@ class PHPT_Reporter_SimpleTest implements PHPT_Reporter
      * Called when the Reporter is started from a PHPT_Suite
      * @todo Figure out if Suites can be named
      */
-    public function onSuiteStart(PHPT_Suite $suite) {
+    public function onSuiteStart(PHPT_Suite $suite)
+    {
         //$this->reporter->paintGroupStart('PHPT Suite', $suite->count());
     }
 
     /**
      * Called when the Reporter is finished in a PHPT_Suite
      */
-    public function onSuiteEnd(PHPT_Suite $suite) {
+    public function onSuiteEnd(PHPT_Suite $suite)
+    {
         //$this->reporter->paintGroupEnd('PHPT Suite');
     }
 
     /**
      * Called when a Case is started
      */
-    public function onCaseStart(PHPT_Case $case) {
+    public function onCaseStart(PHPT_Case $case)
+    {
         //$this->reporter->paintCaseStart($case->name);
     }
 
     /**
      * Called when a Case ends
      */
-    public function onCaseEnd(PHPT_Case $case) {
+    public function onCaseEnd(PHPT_Case $case)
+    {
         //$this->reporter->paintCaseEnd($case->name);
     }
 
     /**
      * Called when a Case runs without Exception
      */
-    public function onCasePass(PHPT_Case $case) {
+    public function onCasePass(PHPT_Case $case)
+    {
         $this->reporter->paintPass("{$case->name} in {$case->filename}");
     }
 
     /**
      * Called when a PHPT_Case_VetoException is thrown during a Case's run()
      */
-    public function onCaseSkip(PHPT_Case $case, PHPT_Case_VetoException $veto) {
+    public function onCaseSkip(PHPT_Case $case, PHPT_Case_VetoException $veto)
+    {
         $this->reporter->paintSkip($veto->getMessage() . ' [' . $case->filename .']');
     }
 
@@ -64,11 +71,13 @@ class PHPT_Reporter_SimpleTest implements PHPT_Reporter
      * Called when any Exception other than a PHPT_Case_VetoException is encountered
      * during a Case's run()
      */
-    public function onCaseFail(PHPT_Case $case, PHPT_Case_FailureException $failure) {
+    public function onCaseFail(PHPT_Case $case, PHPT_Case_FailureException $failure)
+    {
         $this->reporter->paintFail($failure->getReason());
     }
 
-    public function onParserError(Exception $exception) {
+    public function onParserError(Exception $exception)
+    {
         $this->reporter->paintException($exception);
     }
 

--- a/tests/PHPT/Section/PRESKIPIF.php
+++ b/tests/PHPT/Section/PRESKIPIF.php
@@ -4,31 +4,31 @@ class PHPT_Section_PRESKIPIF implements PHPT_Section_RunnableBefore
 {
     private $_data = null;
     private $_runner_factory = null;
-    
+
     public function __construct($data)
     {
         $this->_data = $data;
         $this->_runner_factory = new PHPT_CodeRunner_Factory();
     }
-    
+
     public function run(PHPT_Case $case)
     {
         // @todo refactor this code into PHPT_Util class as its used in multiple places
         $filename = dirname($case->filename) . '/' . basename($case->filename, '.php') . '.skip.php';
-        
+
         // @todo refactor to PHPT_CodeRunner
         file_put_contents($filename, $this->_data);
         $runner = $this->_runner_factory->factory($case);
         $runner->ini = "";
         $response = $runner->run($filename)->output;
         unlink($filename);
-        
+
         if (preg_match('/^skip( - (.*))?/', $response, $matches)) {
             $message = !empty($matches[2]) ? $matches[2] : '';
             throw new PHPT_Case_VetoException($message);
         }
     }
-    
+
     public function getPriority()
     {
         return -2;

--- a/tests/common.php
+++ b/tests/common.php
@@ -7,7 +7,8 @@ if (!defined('HTMLPurifierTest')) {
 
 // setup our own autoload, checking for HTMLPurifier library if spl_autoload_register
 // is not allowed
-function __autoload($class) {
+function __autoload($class)
+{
     if (!function_exists('spl_autoload_register')) {
         if (HTMLPurifier_Bootstrap::autoload($class)) return true;
         if (HTMLPurifierExtras::autoload($class)) return true;
@@ -85,7 +86,8 @@ require 'path2class.func.php';
  * @param $aliases
  *
  */
-function htmlpurifier_parse_args(&$AC, $aliases) {
+function htmlpurifier_parse_args(&$AC, $aliases)
+{
     if (empty($_GET) && !empty($_SERVER['argv'])) {
         array_shift($_SERVER['argv']);
         $o = false;
@@ -143,7 +145,8 @@ function htmlpurifier_parse_args(&$AC, $aliases) {
  * @param $o Argument name
  * @param $v Argument value
  */
-function htmlpurifier_args(&$AC, $aliases, $o, $v) {
+function htmlpurifier_args(&$AC, $aliases, $o, $v)
+{
     if (isset($aliases[$o])) $o = $aliases[$o];
     if (!isset($AC[$o])) return;
     if (is_string($AC[$o])) $AC[$o] = $v;
@@ -154,7 +157,8 @@ function htmlpurifier_args(&$AC, $aliases, $o, $v) {
 /**
  * Adds a test-class; we use file extension to determine which class to use.
  */
-function htmlpurifier_add_test($test, $test_file, $only_phpt = false) {
+function htmlpurifier_add_test($test, $test_file, $only_phpt = false)
+{
     switch (strrchr($test_file, ".")) {
         case '.phpt':
             return $test->add(new PHPT_Controller_SimpleTest($test_file));
@@ -173,7 +177,8 @@ function htmlpurifier_add_test($test, $test_file, $only_phpt = false) {
 /**
  * Debugging function that prints tokens in a user-friendly manner.
  */
-function printTokens($tokens, $index = null) {
+function printTokens($tokens, $index = null)
+{
     $string = '<pre>';
     $generator = new HTMLPurifier_Generator(HTMLPurifier_Config::createDefault(), new HTMLPurifier_Context);
     foreach ($tokens as $i => $token) {
@@ -189,13 +194,16 @@ function printTokens($tokens, $index = null) {
 /**
  * Convenient "insta-fail" test-case to add if any outside things fail
  */
-class FailedTest extends UnitTestCase {
+class FailedTest extends UnitTestCase
+{
     protected $msg, $details;
-    public function __construct($msg, $details = null) {
+    public function __construct($msg, $details = null)
+    {
         $this->msg = $msg;
         $this->details = $details;
     }
-    public function test() {
+    public function test()
+    {
         $this->fail($this->msg);
         if ($this->details) $this->reporter->paintFormattedMessage($this->details);
     }
@@ -204,7 +212,8 @@ class FailedTest extends UnitTestCase {
 /**
  * Flushes all caches, and fatally errors out if there's a problem.
  */
-function htmlpurifier_flush($php, $reporter) {
+function htmlpurifier_flush($php, $reporter)
+{
     exec($php . ' ../maintenance/flush.php ' . $php . ' 2>&1', $out, $status);
     if ($status) {
         $test = new FailedTest(
@@ -219,7 +228,8 @@ function htmlpurifier_flush($php, $reporter) {
 /**
  * Dumps error queue, useful if there has been a fatal error.
  */
-function htmlpurifier_dump_error_queue() {
+function htmlpurifier_dump_error_queue()
+{
     $context = SimpleTest::getContext();
     $queue = $context->get('SimpleErrorQueue');
     while (($error = $queue->extract()) !== false) {

--- a/tests/generate_mock_once.func.php
+++ b/tests/generate_mock_once.func.php
@@ -2,7 +2,8 @@
 
 // since Mocks can't be called from within test files, we need to do
 // a little jumping through hoops to generate them
-function generate_mock_once($name) {
+function generate_mock_once($name)
+{
     $mock_name = $name . 'Mock';
     if (class_exists($mock_name, false)) return false;
     Mock::generate($name, $mock_name);

--- a/tests/index.php
+++ b/tests/index.php
@@ -29,7 +29,7 @@ error_reporting(E_ALL | E_STRICT);
 
 // Because we always want to know about errors, and because SimpleTest
 // will notify us about them, logging the errors to stderr is
-// counterproductive and in fact the wrong thing when a test case 
+// counterproductive and in fact the wrong thing when a test case
 // exercises an error condition to detect for it.
 ini_set('log_errors', false);
 

--- a/tests/path2class.func.php
+++ b/tests/path2class.func.php
@@ -1,6 +1,7 @@
 <?php
 
-function path2class($path) {
+function path2class($path)
+{
     $temp = $path;
     $temp = str_replace('./', '',  $temp); // remove leading './'
     $temp = str_replace('.\\', '',  $temp); // remove leading '.\'


### PR DESCRIPTION
This is a bit of a monster...

The PSR-2 reformatting was done with a mixture of [Sensio's php-cs-fixer](http://cs.sensiolabs.org) followed by more automated formatting and hand-editing of layout and phpdocs in PHPStorm.

With all the phpdoc changes, everything springs to life in IDEs that do static analysis, auto-completion and type checking. In a few places it took quite a bit of detective work to figure out what types things should be. Sometimes I couldn't work it out, and I've added 'fix type' todos in those places.

Ther are some very minor code changes - a couple of deleted unused local vars.

I've not attempted to address PSR-0 issues with name spacing, composer etc - there are plenty of forks that have.

There's an awful lot of code in here, and I've learned a lot by going through it such detail.

Tests are passing. Time for some sleep!
