### PR TITLE
Use a more explicit URL regex in Linkify to allow commas in a URL

### DIFF
--- a/library/HTMLPurifier/Injector/Linkify.php
+++ b/library/HTMLPurifier/Injector/Linkify.php
@@ -33,7 +33,8 @@ class HTMLPurifier_Injector_Linkify extends HTMLPurifier_Injector
 
         // there is/are URL(s). Let's split the string:
         // Note: this regex is extremely permissive
-        $bits = preg_split('#((?:https?|ftp)://[^\s\'",<>()]+)#Su', $token->data, -1, PREG_SPLIT_DELIM_CAPTURE);
+        // $bits = preg_split('#((?:https?|ftp)://[^\s\'",<>()]+)#Su', $token->data, -1, PREG_SPLIT_DELIM_CAPTURE);
+        $bits = preg_split('#((?:https?|ftp)://\S+(?!(?<=[,\'")}>\]])\s?))#Su', $token->data, -1, PREG_SPLIT_DELIM_CAPTURE);
 
 
         $token = array();


### PR DESCRIPTION
I'm using an altered regex for parsing URLs in the Linkify injector. It's quite common for commas to come across unencoded in copy and paste actions from browsers. My experience writing regex look-arounds is limited so this regex could use some review but it works in all my use cases.

reference:
http://htmlpurifier.org/phorum/read.php?5,6970,6970

TESTS

normal:
http://www.google.com/

url with a comma:
https://www.google.com/maps/place/Googleplex/@37.422,-122.084058,17z/data=!3m1!4b1!4m2!3m1!1s0x808fba02425dad8f:0x6c296c66619367e0

url wrapped by bracket:
[http://www.google.com/]

url wrapped by parenthesis:
(http://www.google.com/)

url wrapped by quote:
'http://www.google.com/'

url wrapped by double quote:
"http://www.google.com/"

list separated by comma and space:
http://www.google.com/, http://facebook.com, http://twitter.com

list separated by bracket, comma and space:
[http://www.google.com/], [http://facebook.com], [http://twitter.com]

list separated by bracket and space:
[http://www.google.com/] [http://facebook.com] [http://twitter.com]

list separated by comma and no space (bad form, will result in single url):
http://www.google.com/,http://facebook.com,http://twitter.com

list separated by bracket and no space (bad form, will result in single url):
[http://www.google.com/][http://facebook.com][http://twitter.com]
