### PR TITLE
Fix autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "php": ">=5.2"
     },
     "autoload": {
-        "psr-0": { "HTMLPurifier": "library/" },
+        "psr-0": { "HTMLPurifier_": "library/" },
         "files": ["library/HTMLPurifier.composer.php"]
     }
 }


### PR DESCRIPTION
Hi,

The new DebugClassLoader used by symfony (https://github.com/symfony/Debug/blob/master/DebugClassLoader.php)
seems disagree with your autoload definition.

> The autoloader expected class "HTMLPurifier\Bootstrap" to be defined in file "/My/Home/Project/vendor/ezyang/htmlpurifier/library/HTMLPurifier/Bootstrap.php". The file was found but the class was not in it, the class name or namespace probably has a typo.

Here is the fix.