### PR TITLE
Add escapeshellcmd for shell execution

### DIFF
--- a/tests/CliTestCase.php
+++ b/tests/CliTestCase.php
@@ -32,7 +32,7 @@ class CliTestCase
     }
     public function _invokeCommand($command, $reporter)
     {
-       $xml = shell_exec($command);
+       $xml = shell_exec(escapeshellcmd($command));
         if (! $xml) {
             if (!$this->_quiet) {
                 $reporter->paintFail('Command did not have any output [' . $command . ']');


### PR DESCRIPTION
I think it is a bit dangerous to call shell commands without proper escaping, even if it is "only" in a test. The test classes might get autoloaded and be therefore in theory accessible.
I didn't manage to get the test running, but think this change will not break anything.