### PR TITLE
Docblock update

### DIFF
--- a/library/HTMLPurifier.php
+++ b/library/HTMLPurifier.php
@@ -104,7 +104,7 @@ class HTMLPurifier
     /**
      * Initializes the purifier.
      *
-     * @param HTMLPurifier_Config $config Optional HTMLPurifier_Config object
+     * @param HTMLPurifier_Config|mixed $config Optional HTMLPurifier_Config object
      *                for all instances of the purifier, if omitted, a default
      *                configuration is supplied (which can be overridden on a
      *                per-use basis).


### PR DESCRIPTION
I've updated the docblock of `HTMLPurifier::__construct` since it is not valid and results in Scrutinizer notices.

The argument passed to the constructor of the `HTMLPurifier` class can be anything that `HTMLPurifier_Config::create()` accepts which is `mixed` to be exact.

```php
    /**
     * Convenience constructor that creates a config object based on a mixed var
     * @param mixed $config Variable that defines the state of the config
     *                      object. Can be: a HTMLPurifier_Config() object,
     *                      an array of directives based on loadArray(),
     *                      or a string filename of an ini file.
     * @param HTMLPurifier_ConfigSchema $schema Schema object
     * @return HTMLPurifier_Config Configured object
     */
    public static function create($config, $schema = null)
```