### PR TITLE
Remove /maintenance export-ignore from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,7 +6,6 @@
 /configdoc/ export-ignore
 /configdoc/usage.xml -crlf
 /docs/ export-ignore
-/maintenance/ export-ignore
 /phpdoc.ini
 /smoketests/ export-ignore
 /tests/ export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,5 @@
 /docs/ export-ignore
 /phpdoc.ini
 /smoketests/ export-ignore
-/tests/ export-ignore
+/tests/* export-ignore
+/tests/path2class.func.php -export-ignore


### PR DESCRIPTION
4.7.0 release is not shipping with the maintenance scripts any more, and those scripts could be used in continuously integrated environments (e.g. `generate-standalone.php`).