### PR TITLE
Don't use PHP4-style constructors

### DIFF
--- a/benchmarks/Lexer.php
+++ b/benchmarks/Lexer.php
@@ -25,7 +25,7 @@ class RowTimer extends Benchmark_Timer
 
     public $name;
 
-    public function RowTimer($name, $auto = false)
+    public function __construct($name, $auto = false)
     {
         $this->name = htmlentities($name);
         $this->Benchmark_Timer($auto);

--- a/tests/Debugger.php
+++ b/tests/Debugger.php
@@ -76,7 +76,7 @@ class Debugger
     public $scope_nextID = 1;
     public $add_pre = true;
 
-    public function Debugger()
+    public function __construct()
     {
         $this->add_pre = !extension_loaded('xdebug');
     }

--- a/tests/HTMLPurifier/AttrDef/CSS/CompositeTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSS/CompositeTest.php
@@ -5,7 +5,7 @@ class HTMLPurifier_AttrDef_CSS_Composite_Testable extends
 {
 
     // we need to pass by ref to get the mocks in
-    public function HTMLPurifier_AttrDef_CSS_Composite_Testable(&$defs)
+    public function __construct(&$defs)
     {
         $this->defs =& $defs;
     }


### PR DESCRIPTION
Old-style constructors (using the class name as the method name) are deprecated in PHP 7, so this fixes the few instances that use them. No functional changes.