### PR TITLE
feat(Tests) inform if SimpleTest library cannot be found

### DIFF
--- a/tests/common.php
+++ b/tests/common.php
@@ -40,6 +40,10 @@ else {
     throw new Exception('Please create a test-settings.php file by copying test-settings.sample.php and configuring accordingly');
 }
 
+if (!is_dir($simpletest_location) or !file_exists($simpletest_location . 'unit_tester.php')) {
+    echo "Could not find SimpleTest, please configure SimpleTest directory variable: \$simpletest_location\n";
+    throw new Exception('Could not find SimpleTest, please configure SimpleTest directory variable: $simpletest_location');
+}
 // load SimpleTest
 require_once $simpletest_location . 'unit_tester.php';
 require_once $simpletest_location . 'reporter.php';


### PR DESCRIPTION
While setting up testing it took me a while to find where the simpletest library has to be wrt the configuration variable because I was getting no error on the failing require in common.
This PR simply adds a message and exception to make this case more explicit.

HTH