### PR TITLE
speed(Bootstrap) static cache to getPath to decrease time to response

### DIFF
--- a/library/HTMLPurifier/Bootstrap.php
+++ b/library/HTMLPurifier/Bootstrap.php
@@ -57,7 +57,10 @@ class HTMLPurifier_Bootstrap
      */
     public static function getPath($class)
     {
+        static $_mypath_cache = array();
+        if (isset($_mypath_cache[$class])) return $_mypath_cache[$class];
         if (strncmp('HTMLPurifier', $class, 12) !== 0) {
+            $_mypath_cache[$class] = false;
             return false;
         }
         // Custom implementations
@@ -68,8 +71,10 @@ class HTMLPurifier_Bootstrap
             $file = str_replace('_', '/', $class) . '.php';
         }
         if (!file_exists(HTMLPURIFIER_PREFIX . '/' . $file)) {
+            $_mypath_cache[$class] = false;
             return false;
         }
+        $_mypath_cache[$class] = $file;
         return $file;
     }
 


### PR DESCRIPTION
While profiling a part of coreBOS I saw that getPath() function was called 67 times for a total of 5.50

![htmlpurifier_getpath_nocache](https://cloud.githubusercontent.com/assets/1237191/14191391/f35fb7ce-f797-11e5-80d9-cb18ad2679a2.png)

I had a look at the function and saw that it could benefit from a local cache array, so I added that and the the time fell significantly.

![htmlpurifier_getpath_cache](https://cloud.githubusercontent.com/assets/1237191/14191422/1bfb04c2-f798-11e5-9610-dfa82265dfc5.png)

![htmlpurifier_getpath_cache2](https://cloud.githubusercontent.com/assets/1237191/14191428/21189820-f798-11e5-8aea-86fcb085025e.png)

I ran the tests and all past correctly.
