### PR TITLE
avoid exif_imagetype exception with small files/corrupt data URI

### DIFF
--- a/library/HTMLPurifier/URIScheme/data.php
+++ b/library/HTMLPurifier/URIScheme/data.php
@@ -79,6 +79,11 @@ class HTMLPurifier_URIScheme_data extends HTMLPurifier_URIScheme
         } else {
             $raw_data = $data;
         }
+        if ( strlen($raw_data) < 12 ) {
+            // error; exif_imagetype throws exception with small files,
+            // and this likely indicates a corrupt URI/failed parse anyway
+            return false;
+        }
         // XXX probably want to refactor this into a general mechanism
         // for filtering arbitrary content types
         if (function_exists('sys_get_temp_dir')) {


### PR DESCRIPTION
Ran into an issue with bad data URIs causing an exception to be thrown in exif_imagetype because the parsing had failed and small data is not allowed. This fixes it by failed the validation if the data is too small.