### PR TITLE
changed chmod behaviour in Serializer

### DIFF
--- a/library/HTMLPurifier/DefinitionCache/Serializer.php
+++ b/library/HTMLPurifier/DefinitionCache/Serializer.php
@@ -198,10 +198,7 @@ class HTMLPurifier_DefinitionCache_Serializer extends HTMLPurifier_DefinitionCac
         if ($result !== false) {
             // set permissions of the new file (no execute)
             $chmod = $config->get('Cache.SerializerPermissions');
-            if ($chmod === null) {
-                // don't do anything
-            } else {
-                $chmod = $chmod & 0666;
+            if ($chmod !== null) {
                 chmod($file, $chmod);
             }
         }
@@ -227,14 +224,6 @@ class HTMLPurifier_DefinitionCache_Serializer extends HTMLPurifier_DefinitionCac
                 );
                 return false;
             } elseif (!$this->_testPermissions($base, $chmod)) {
-                return false;
-            }
-            if ($chmod === null) {
-                trigger_error(
-                    'Base directory ' . $base . ' does not exist,
-                    please create or change using %Cache.SerializerPath',
-                    E_USER_WARNING
-                );
                 return false;
             }
             if ($chmod !== null) {

--- a/library/HTMLPurifier/DefinitionCache/Serializer.php
+++ b/library/HTMLPurifier/DefinitionCache/Serializer.php
@@ -199,7 +199,7 @@ class HTMLPurifier_DefinitionCache_Serializer extends HTMLPurifier_DefinitionCac
             // set permissions of the new file (no execute)
             $chmod = $config->get('Cache.SerializerPermissions');
             if ($chmod !== null) {
-                chmod($file, $chmod);
+                chmod($file, $chmod & 0666);
             }
         }
         return $result;

--- a/tests/HTMLPurifier/DefinitionCache/SerializerTest.php
+++ b/tests/HTMLPurifier/DefinitionCache/SerializerTest.php
@@ -23,7 +23,6 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
             $rel_file = HTMLPURIFIER_PREFIX . '/HTMLPurifier/DefinitionCache/Serializer/Test/' .
             $config_md5 . '.ser'
         );
-        
         if($file && file_exists($file)) unlink($file); // prevent previous failures from causing problems
 
         $this->assertIdentical($config_md5, $cache->generateKey($config));
@@ -216,12 +215,10 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
 
         $def_original = $this->generateDefinition();
         $cache->add($def_original, $config);
+        $this->assertFileExist($dir . '/Test/1.0.0,serial,1.ser');
 
-        $file_path = $dir . '/Test/1.0.0,serial,1.ser';
-        $this->assertFileExist($file_path);
-
-        $file_permissions = substr(sprintf("%o",fileperms($file_path)),-4);;
-        $this->assertEqual("0700", $file_permissions);
+        $this->assertEqual(0600, 0777 & fileperms($dir . '/Test/1.0.0,serial,1.ser'));
+        $this->assertEqual(0700, 0777 & fileperms($dir . '/Test'));
 
         unlink($dir . '/Test/1.0.0,serial,1.ser');
         rmdir( $dir . '/Test');

--- a/tests/HTMLPurifier/DefinitionCache/SerializerTest.php
+++ b/tests/HTMLPurifier/DefinitionCache/SerializerTest.php
@@ -23,6 +23,7 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
             $rel_file = HTMLPURIFIER_PREFIX . '/HTMLPurifier/DefinitionCache/Serializer/Test/' .
             $config_md5 . '.ser'
         );
+        
         if($file && file_exists($file)) unlink($file); // prevent previous failures from causing problems
 
         $this->assertIdentical($config_md5, $cache->generateKey($config));
@@ -215,10 +216,12 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
 
         $def_original = $this->generateDefinition();
         $cache->add($def_original, $config);
-        $this->assertFileExist($dir . '/Test/1.0.0,serial,1.ser');
 
-        $this->assertEqual(0600, 0777 & fileperms($dir . '/Test/1.0.0,serial,1.ser'));
-        $this->assertEqual(0700, 0777 & fileperms($dir . '/Test'));
+        $file_path = $dir . '/Test/1.0.0,serial,1.ser';
+        $this->assertFileExist($file_path);
+
+        $file_permissions = substr(sprintf("%o",fileperms($file_path)),-4);;
+        $this->assertEqual("0700", $file_permissions);
 
         unlink($dir . '/Test/1.0.0,serial,1.ser');
         rmdir( $dir . '/Test');


### PR DESCRIPTION
# Actions taken:

The previous chmod behaviour was unclear and didn't agree with the documentation, and was causing a few unwanted side effects.

i.e., http://htmlpurifier.org/live/configdoc/plain.html#Cache.SerializerPermissions

First I removed the bitwise & that was happening when custom permissions were applied to the file. The & was making it impossible to actually set the permissions that were set in the config. E.g., if the permissions were set to 0777 then the actual value would come out as 1000 or something.

I also removed a block of code from the _prepareDir method that was erroneously throwing an error when the custom chmod value in the configuration was set to null.

I updated the unit test to be a) more easy to read and understand, and b) just test the permission of the file, since the permissions that were being tested for the directory seemed arbitrary.

# Rationale

My team is currently working on a large scale web application and we wanted to include HtmlPurifier for our sanitization. However, when installed using Composer HTMLPurifier will try to write its cache files to the vendor director, which we do not want writable. This behaviour can be changed using the config to write to a different directory, but the default permissions that HTMLPurifier uses to create the cache file are such that Jenkins (our CI) can't delete the cache files when it pushes a new version.

This behaviour can also be changed using configuration, but the permissions weren't being written properly, which led to all sorts of havok in our staging server.

