### PR TITLE
Use IDNA2008 for converting domains to ASCII

### DIFF
--- a/library/HTMLPurifier/AttrDef/URI/Host.php
+++ b/library/HTMLPurifier/AttrDef/URI/Host.php
@@ -97,7 +97,7 @@ class HTMLPurifier_AttrDef_URI_Host extends HTMLPurifier_AttrDef
 
         // PHP 5.3 and later support this functionality natively
         if (function_exists('idn_to_ascii')) {
-            $string = idn_to_ascii($string);
+            $string = idn_to_ascii($string, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
 
         // If we have Net_IDNA2 support, we can support IRIs by
         // punycoding them. (This is the most portable thing to do,

--- a/tests/HTMLPurifier/AttrDef/URI/HostTest.php
+++ b/tests/HTMLPurifier/AttrDef/URI/HostTest.php
@@ -49,6 +49,7 @@ class HTMLPurifier_AttrDef_URI_HostTest extends HTMLPurifier_AttrDefHarness
         }
         $this->config->set('Core.EnableIDNA', true);
         $this->assertDef("\xE4\xB8\xAD\xE6\x96\x87.com.cn", "xn--fiq228c.com.cn");
+        $this->assertDef("faß.de", "xn--fa-hia.de");
         $this->assertDef("\xe2\x80\x85.com", false); // rejected
     }
 


### PR DESCRIPTION
idn_to_ascii($string) shows deprecation notice in PHP 7.2 , see
https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003

and even in earlier PHP versions it is incorrect in some cases, for example it converts "faß.de" into "fass.de"
see http://www.unicode.org/reports/tr46/