### PR TITLE
Add relative length units for CSS 3 support

### DIFF
--- a/library/HTMLPurifier/Length.php
+++ b/library/HTMLPurifier/Length.php
@@ -26,12 +26,14 @@ class HTMLPurifier_Length
     protected $isValid;
 
     /**
-     * Array Lookup array of units recognized by CSS 2.1
+     * Array Lookup array of units recognized by CSS 3
      * @type array
      */
     protected static $allowedUnits = array(
         'em' => true, 'ex' => true, 'px' => true, 'in' => true,
-        'cm' => true, 'mm' => true, 'pt' => true, 'pc' => true
+        'cm' => true, 'mm' => true, 'pt' => true, 'pc' => true,
+        'ch' => true, 'rem' => true, 'vw' => true, 'vh' => true,
+        'vmin' => true, 'vmax' => true
     );
 
     /**

--- a/tests/HTMLPurifier/AttrDef/CSSTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSSTest.php
@@ -66,6 +66,10 @@ class HTMLPurifier_AttrDef_CSSTest extends HTMLPurifier_AttrDefHarness
         $this->assertDef('min-width:50px;');
         $this->assertDef('min-width:auto;');
         $this->assertDef('min-width:-50px;', false);
+        $this->assertDef('min-width:50ch;');
+        $this->assertDef('min-width:50rem;');
+        $this->assertDef('min-width:50vw;');
+        $this->assertDef('min-width:-50vw;', false);
         $this->assertDef('text-decoration:underline;');
         $this->assertDef('font-family:sans-serif;');
         $this->assertDef("font-family:Gill, 'Times New Roman', sans-serif;");


### PR DESCRIPTION
I have seen the request in #147 and think that the reporter's request makes sense, so I had a go. From what I could grasp adding them to `HTMLPurifier_Length::$allowedUnits` should be sufficient, as it is used by `HTMLPurifier_AttrDef_CSS_Length` and the validators make use of that particular array. The tests that I added seem to support this.

I chose to add the units as displayed at https://www.w3schools.com/cssref/css_units.asp. I was also considering adding `%` as a unit, but then realised that it must have been covered elsewhere, perhaps in `HTMLPurifier_AttrDef_CSS_Percentage`.

Are there any general reasons against adding support for CSS 3? Relative units are just one step towards that, but I think they will be useful as they are increasingly used in documents.