### PR TITLE
Small typos in comments

### DIFF
--- a/library/HTMLPurifier/Lexer/PH5P.php
+++ b/library/HTMLPurifier/Lexer/PH5P.php
@@ -1507,7 +1507,7 @@ class HTML5
                 $entity = $this->character($start, $this->char);
                 $cond = strlen($e_name) > 0;
 
-                // The rest of the parsing happens bellow.
+                // The rest of the parsing happens below.
                 break;
 
             // Anything else
@@ -1535,7 +1535,7 @@ class HTML5
                 }
 
                 $cond = isset($entity);
-                // The rest of the parsing happens bellow.
+                // The rest of the parsing happens below.
                 break;
         }
 

--- a/maintenance/PH5P.php
+++ b/maintenance/PH5P.php
@@ -1080,7 +1080,7 @@ class HTML5
                 $entity = $this->character($start, $this->char);
                 $cond = strlen($e_name) > 0;
 
-                // The rest of the parsing happens bellow.
+                // The rest of the parsing happens below.
             break;
 
             // Anything else
@@ -1102,7 +1102,7 @@ class HTML5
                 }
 
                 $cond = isset($entity);
-                // The rest of the parsing happens bellow.
+                // The rest of the parsing happens below.
             break;
         }
 


### PR DESCRIPTION
Hi, I'm a developer to TikiWiki and we use your htmlpurifier. Following our philosophy, I fixed some typos we found upstream, i.e., in your code. 

Thanks!