### PR TITLE
PHP 7.2: Skip counting currentNesting if null in Injector

### DIFF
--- a/library/HTMLPurifier/Injector.php
+++ b/library/HTMLPurifier/Injector.php
@@ -157,11 +157,13 @@ abstract class HTMLPurifier_Injector
             return false;
         }
         // check for exclusion
-        for ($i = count($this->currentNesting) - 2; $i >= 0; $i--) {
-            $node = $this->currentNesting[$i];
-            $def  = $this->htmlDefinition->info[$node->name];
-            if (isset($def->excludes[$name])) {
-                return false;
+        if (!empty($this->currentNesting)) {
+            for ($i = count($this->currentNesting) - 2; $i >= 0; $i--) {
+                $node = $this->currentNesting[$i];
+                $def  = $this->htmlDefinition->info[$node->name];
+                if (isset($def->excludes[$name])) {
+                    return false;
+                }
             }
         }
         return true;


### PR DESCRIPTION
This is an error starting in PHP 7.2, causing a test failure:

> Unexpected PHP Error [count(): Parameter must be an array or an object that implements Countable] severity [2] in [HtmlPurifier/library/HTMLPurifier/Injector.php line 160]
> 	in testErrorRequiredElementNotAllowed
> 	in HTMLPurifier_Strategy_MakeWellFormed_InjectorTest

I used `empty` to parallel an existing test in the same method.