### PR TITLE
Add PHP 7.2 to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
     - '5.6'
     - '7.0'
     - '7.1'
+    - '7.2'
 before_script:
     - git clone --depth=50 https://github.com/ezyang/simpletest.git
     - cp test-settings.travis.php test-settings.php


### PR DESCRIPTION
Updates .travis.yml to add PHP 7.2 to the test matrix.

With the issues around #158 understood, there should be nothing in the way of 7.2 running and passing in the CI. I won't close #158 because I think it's still a documentation issue at least that makes it slightly difficult for contributors to know which simpletest must be used.

An autoloader warning is emitted, but before the tests are run and it doesn't affect the tests themselves.