### PR TITLE
Suggest stable Composer installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ Package available on [Composer](https://packagist.org/packages/ezyang/htmlpurifi
 
 If you're using Composer to manage dependencies, you can use
 
-    $ composer require "ezyang/htmlpurifier":"dev-master"
+    $ composer require ezyang/htmlpurifier


### PR DESCRIPTION
Normally people should not use the latest master but the latest stable release instead.