### PR TITLE
Cache: handle group permission (mkdir flaw)

### DIFF
--- a/library/HTMLPurifier/DefinitionCache/Serializer.php
+++ b/library/HTMLPurifier/DefinitionCache/Serializer.php
@@ -264,7 +264,7 @@ class HTMLPurifier_DefinitionCache_Serializer extends HTMLPurifier_DefinitionCac
     private function _testPermissions($dir, $chmod)
     {
         // early abort, if it is writable, everything is hunky-dory
-        if (is_writable($dir)) {
+        if ($chmod === (0777 & fileperms($dir))) {
             return true;
         }
         if (!is_dir($dir)) {

--- a/tests/HTMLPurifier/DefinitionCache/SerializerTest.php
+++ b/tests/HTMLPurifier/DefinitionCache/SerializerTest.php
@@ -225,6 +225,28 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
 
     }
 
+    public function testAlternateGroupPermissions()
+    {
+        $cache = new HTMLPurifier_DefinitionCache_Serializer('Test');
+        $config = $this->generateConfigMock('serial');
+        $config->version = '1.0.0';
+        $config->returns('get', 1, array('Test.DefinitionRev'));
+        $dir = dirname(__FILE__) . '/SerializerTest';
+        $config->returns('get', $dir, array('Cache.SerializerPath'));
+        $config->returns('get', 0770, array('Cache.SerializerPermissions'));
+
+        $def_original = $this->generateDefinition();
+        $cache->add($def_original, $config);
+        $this->assertFileExist($dir . '/Test/1.0.0,serial,1.ser');
+
+        $this->assertEqual(0660, 0777 & fileperms($dir . '/Test/1.0.0,serial,1.ser'));
+        $this->assertEqual(0770, 0777 & fileperms($dir . '/Test'));
+
+        unlink($dir . '/Test/1.0.0,serial,1.ser');
+        rmdir( $dir . '/Test');
+
+    }
+
     public function testNoInfiniteLoop()
     {
         $cache = new HTMLPurifier_DefinitionCache_Serializer('Test');


### PR DESCRIPTION
For some reason, I don't know why, `mkdir` doesn't handle well the `0770` permission:

https://3v4l.org/pKu4U

So we need to test the complete permission set for a correct handle of mkdir result.