### PR TITLE
Update reference to the valid types when adding HTMLPurifier_ConfigSchema

### DIFF
--- a/library/HTMLPurifier/ConfigSchema.php
+++ b/library/HTMLPurifier/ConfigSchema.php
@@ -100,7 +100,7 @@ class HTMLPurifier_ConfigSchema
      * @param string $key Name of directive
      * @param mixed $default Default value of directive
      * @param string $type Allowed type of the directive. See
-     *      HTMLPurifier_DirectiveDef::$type for allowed values
+     *      HTMLPurifier_VarParser::$types for allowed values
      * @param bool $allow_null Whether or not to allow null values
      */
     public function add($key, $default, $type, $allow_null)


### PR DESCRIPTION
I was adding a custom ConfigSchema and was trying to look for the types and couldn't find HTMLPurifier_DirectiveDef but did find the types under HTMLPurifier_VarParser.