### PR TITLE
.htaccess support apache 2.4+

### DIFF
--- a/benchmarks/.htaccess
+++ b/benchmarks/.htaccess
@@ -1,1 +1,7 @@
-Deny from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+<IfModule !mod_authz_core.c>
+    Deny from all
+</ifModule>

--- a/maintenance/.htaccess
+++ b/maintenance/.htaccess
@@ -1,1 +1,7 @@
-Deny from all
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+<IfModule !mod_authz_core.c>
+    Deny from all
+</ifModule>


### PR DESCRIPTION
```
Deny from all
```
is depricated by [apache 2.4](https://httpd.apache.org/docs/2.4/upgrading.html).
The new directive is:
```
Require all denied
```
I changed the files to support <2.4 and >2.4 as suggested in https://github.com/nextcloud/news/issues/340
There is a mod for backward [compatibility](https://httpd.apache.org/docs/2.4/mod/mod_access_compat.html) but I think it's better to support both.