### PR TITLE
[SafeScripting] disable autoclosing of <script /> tag

### DIFF
--- a/configdoc/usage.xml
+++ b/configdoc/usage.xml
@@ -410,7 +410,7 @@
  </directive>
  <directive id="Core.EnableIDNA">
   <file name="HTMLPurifier/AttrDef/URI/Host.php">
-   <line>105</line>
+   <line>109</line>
   </file>
  </directive>
  <directive id="Attr.DefaultTextDir">

--- a/library/HTMLPurifier/HTMLModule/SafeScripting.php
+++ b/library/HTMLPurifier/HTMLModule/SafeScripting.php
@@ -23,7 +23,7 @@ class HTMLPurifier_HTMLModule_SafeScripting extends HTMLPurifier_HTMLModule
         $script = $this->addElement(
             'script',
             'Inline',
-            'Empty',
+            'Optional:', // Not `Empty` to not allow to autoclose the <script /> tag @see https://www.w3.org/TR/html4/interact/scripts.html
             null,
             array(
                 // While technically not required by the spec, we're forcing

--- a/tests/HTMLPurifier/HTMLModule/SafeScriptingTest.php
+++ b/tests/HTMLPurifier/HTMLModule/SafeScriptingTest.php
@@ -20,7 +20,15 @@ class HTMLPurifier_HTMLModule_SafeScriptingTest extends HTMLPurifier_HTMLModuleH
     public function testGood()
     {
         $this->assertResult(
-            '<script type="text/javascript" src="http://localhost/foo.js" />'
+            '<script type="text/javascript" src="http://localhost/foo.js"></script>'
+        );
+    }
+
+    public function testGoodWithAutoclosedTag()
+    {
+        $this->assertResult(
+            '<script type="text/javascript" src="http://localhost/foo.js"/>',
+            '<script type="text/javascript" src="http://localhost/foo.js"></script>'
         );
     }
 


### PR DESCRIPTION
Hi,
the end `</script>` tag is mandatory (https://www.w3.org/TR/html4/interact/scripts.html)
and in my chrome `<script src="....js" />` does not work (the script JS does not load), that is why this PR.
