### PR TITLE
Fix DOM Lexer for PHP versions older than 5.4

### DIFF
--- a/library/HTMLPurifier/Lexer/DOMLex.php
+++ b/library/HTMLPurifier/Lexer/DOMLex.php
@@ -74,7 +74,12 @@ class HTMLPurifier_Lexer_DOMLex extends HTMLPurifier_Lexer
         }
 
         set_error_handler(array($this, 'muteErrorHandler'));
-        $doc->loadHTML($html, $options);
+        // loadHTML() fails on PHP 5.3 when second parameter is given
+        if ($options) {
+            $doc->loadHTML($html, $options);
+        } else {
+            $doc->loadHTML($html);
+        }
         restore_error_handler();
 
         $body = $doc->getElementsByTagName('html')->item(0)-> // <html>


### PR DESCRIPTION
Hi @ezyang,
I'd like to ask what's the current policy on supporting prehistoric PHP versions? The minimum PHP version in [`composer.json`](https://github.com/ezyang/htmlpurifier/blob/master/composer.json#L16) is set at 5.2, which is the reason I submit this PR.

The DOM Lexer (default lexer implementation) in version 4.11.0 does not work on PHP 5.3 because of [this line](https://github.com/ezyang/htmlpurifier/blob/master/library/HTMLPurifier/Lexer/DOMLex.php#L77).

Loading HTML document in PHP 5.3 fails with:

```
Fatal error: Call to a member function getElementsByTagName() on a non-object
```

After disabling (for the investigation purposes) `muteErrorHandler` we see the culprit:

```
Warning: DOMDocument::loadHTML() expects exactly 1 parameter, 2 given
```

According to the [docs](https://www.php.net/manual/en/domdocument.loadhtml.php), second parameter to `loadHTML` requires at least PHP 5.4.
