### PR TITLE
Fix PHP 5.4 and 5.5 builds on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: php
 php:
-    - '5.4'
-    - '5.5'
     - '5.6'
     - '7.0'
     - '7.1'
     - '7.2'
     - '7.3'
+matrix:
+    include:
+        - php: '5.4'
+          dist: trusty
+        - php: '5.5'
+          dist: trusty
 before_script:
     - git clone --depth=50 https://github.com/ezyang/simpletest.git
     - cp test-settings.travis.php test-settings.php


### PR DESCRIPTION
PHP 5.4 and 5.5 builds on Travis CI are currently failing with the following error:

```
$ phpenv global 5.4 2>/dev/null
5.4 is not pre-installed; installing
Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/php/binaries/ubuntu/16.04/x86_64/php-5.4.tar.bz2
0.12s$ curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /
bzip2: (stdin) is not a bzip2 file.
tar: Child returned status 2
tar: Error is not recoverable: exiting now
0.00s0.02s$ phpenv global 5.4
rbenv: version `5.4' not installed
The command "phpenv global 5.4" failed and exited with 1 during .
Your build has been stopped.
```