### PR TITLE
Fix phpdoc params in HTMLModule::addElement() and Bool attr

### DIFF
--- a/library/HTMLPurifier/AttrDef/HTML/Bool.php
+++ b/library/HTMLPurifier/AttrDef/HTML/Bool.php
@@ -7,7 +7,7 @@ class HTMLPurifier_AttrDef_HTML_Bool extends HTMLPurifier_AttrDef
 {
 
     /**
-     * @type bool
+     * @type string
      */
     protected $name;
 
@@ -17,7 +17,7 @@ class HTMLPurifier_AttrDef_HTML_Bool extends HTMLPurifier_AttrDef
     public $minimized = true;
 
     /**
-     * @param bool $name
+     * @param bool|string $name
      */
     public function __construct($name = false)
     {

--- a/library/HTMLPurifier/HTMLModule.php
+++ b/library/HTMLPurifier/HTMLModule.php
@@ -132,9 +132,9 @@ class HTMLPurifier_HTMLModule
      * @param string $element Name of element to add
      * @param string|bool $type What content set should element be registered to?
      *              Set as false to skip this step.
-     * @param string $contents Allowed children in form of:
+     * @param string|HTMLPurifier_ChildDef $contents Allowed children in form of:
      *              "$content_model_type: $content_model"
-     * @param array $attr_includes What attribute collections to register to
+     * @param array|string $attr_includes What attribute collections to register to
      *              element?
      * @param array $attr What unique attributes does the element define?
      * @see HTMLPurifier_ElementDef:: for in-depth descriptions of these parameters.


### PR DESCRIPTION
This PR fixes a few errors in phpdoc params:

- `$attr_includes` param in `HTMLModule::addElement()` can be a string, and this is how it's mostly used in the codebase (e.g. [here](https://github.com/ezyang/htmlpurifier/blob/master/library/HTMLPurifier/HTMLModule/Text.php#L35)).

- The `$contents` param in `HTMLModule::addElement()` can be an instance of `HTMLPurifier_ChildDef` (as noted [here](https://github.com/ezyang/htmlpurifier/blob/master/library/HTMLPurifier/HTMLModule.php#L161)), and this should also be reflected in phpdoc.

Additionally there is a minor fix to phpdoc of `AttrDef_HTML_Bool`, as the name of a boolean attribute is a `string`, not a `bool` (example usage [here](https://github.com/ezyang/htmlpurifier/blob/master/library/HTMLPurifier/HTMLModule/Forms.php#L76)).
