### PR TITLE
Exclude language classes from autoloader optimization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
     },
     "autoload": {
         "psr-0": { "HTMLPurifier": "library/" },
-        "files": ["library/HTMLPurifier.composer.php"]
+        "files": ["library/HTMLPurifier.composer.php"],
+        "exclude-from-classmap": [
+            "/library/HTMLPurifier/Language/"
+        ]
     }
 }


### PR DESCRIPTION
These classes are autoloaded by a custom autoloader. The classes don't follow PSR-0 and as such will trigger a warning when dumping an optimized autoloader in composer 1.10+