### PR TITLE
Added tr@bgcolor to tidy

### DIFF
--- a/library/HTMLPurifier/HTMLModule/Tidy/XHTMLAndHTML4.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy/XHTMLAndHTML4.php
@@ -96,6 +96,7 @@ class HTMLPurifier_HTMLModule_Tidy_XHTMLAndHTML4 extends HTMLPurifier_HTMLModule
 
         // @bgcolor for table, tr, td, th ---------------------------------
         $r['table@bgcolor'] =
+        $r['tr@bgcolor'] =
         $r['td@bgcolor'] =
         $r['th@bgcolor'] =
             new HTMLPurifier_AttrTransform_BgColor();


### PR DESCRIPTION
I've been using xemlock/htmlpurifier-html5 and realised that it's removing the `bgcolor` attribute from `<tr>` elements. I tried to add `"HTML.TidyAdd" => ["tr@bgcolor"],` but it didn't do anything.

I think this is a long standing bug, given the comment says `@bgcolor for tr` but there's never been any commit that added / removed it?

With this addition `"HTML.TidyAdd" => ["tr@bgcolor"],` now works and so does `"HTML.TidyLevel" => "heavy"`