### PR TITLE
Fix typo in the 4.13.0 NEWS: PHP 6.4 never existed

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,7 +18,7 @@ NEWS ( CHANGELOG and HISTORY )                                     HTMLPurifier
   Thanks Mateusz Turcza for contributing this feature.
 ! tr@bgcolor attribute is now supported.  Thanks Kieran Brahney
   for this enhancement.
-- Further improvements to PHP 6.4 support, contributed by Witold
+- Further improvements to PHP 7.4 support, contributed by Witold
   Wasiczko and Eloy Lafuente.
 - Fix PSR-0 compatibility.  Thanks Jordi Boggiano for contributing
   part of this fix.


### PR DESCRIPTION
Corresponding PRs (#230, #242) are about PHP 7.4 and PHP 6.4 has never existed 🙂.