### PR TITLE
Check PHP version before checking magic quotes

### DIFF
--- a/library/HTMLPurifier/Config.php
+++ b/library/HTMLPurifier/Config.php
@@ -803,7 +803,7 @@ class HTMLPurifier_Config
         if ($index !== false) {
             $array = (isset($array[$index]) && is_array($array[$index])) ? $array[$index] : array();
         }
-        $mq = $mq_fix && function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc();
+        $mq = $mq_fix && version_compare(PHP_VERSION, '7.4.0', '<') && function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc();
 
         $allowed = HTMLPurifier_Config::getAllowedDirectivesForForm($allowed, $schema);
         $ret = array();


### PR DESCRIPTION
This function has been DEPRECATED as of PHP 7.4.0. Relying on this function is highly discouraged. It is basically useless as of PHP 5.4 because it will always return false, so for modern applications it can be safely removed. But as this library still supports PHP 5.2 — according to the constraints in composer.json — I added a version check to prevent this method from being called (and trigger a notice) on PHP >=7.4. Fixes #272.

See: https://www.php.net/manual/en/function.get-magic-quotes-gpc.php