### PR TITLE
Fix "Parameter must be an array or an object that implements Countable"

### DIFF
--- a/library/HTMLPurifier/Injector/Linkify.php
+++ b/library/HTMLPurifier/Injector/Linkify.php
@@ -40,6 +40,9 @@ class HTMLPurifier_Injector_Linkify extends HTMLPurifier_Injector
             '/\\b((?:[a-z][\\w\\-]+:(?:\\/{1,3}|[a-z0-9%])|www\\d{0,3}[.]|[a-z0-9.\\-]+[.][a-z]{2,4}\\/)(?:[^\\s()<>]|\\((?:[^\\s()<>]|(?:\\([^\\s()<>]+\\)))*\\))+(?:\\((?:[^\\s()<>]|(?:\\([^\\s()<>]+\\)))*\\)|[^\\s`!()\\[\\]{};:\'".,<>?\x{00ab}\x{00bb}\x{201c}\x{201d}\x{2018}\x{2019}]))/iu',
             $token->data, -1, PREG_SPLIT_DELIM_CAPTURE);
 
+        if ($bits === false) {
+            return;
+        }
 
         $token = array();
 


### PR DESCRIPTION
[`preg_split()`](https://www.php.net/manual/en/function.preg-split.php) returns `string[]|false`

In PHP 7.2 `count()` generates a warning if the given argument is not countable:
> Warning: count(): Parameter must be an array or an object that implements Countable

https://3v4l.org/daRFo

Unfortunately I cannot add a test as I'm not sure what data causes the issue. That being said, the issue seems fairly obvious based on the return type of `preg_split`.