### PR TITLE
Fix GH workflow conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: ci
 
 on:
   push:
-    branches:
-      - "master"
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
 
     name: PHP ${{ matrix.php }}
 


### PR DESCRIPTION
I asked GitHub why actions were not running on PRs, and their response was:
> This happened because the pull request was from a fork. The workflow file was configured to run only when triggered on push from the master branch.

This partially reverts https://github.com/ezyang/htmlpurifier/pull/297 due to the test suite not being compatible with PHP 8.