### PR TITLE
Remove unnecessary reference assigment

### DIFF
--- a/library/HTMLPurifier/HTMLModule/Tidy.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy.php
@@ -146,7 +146,7 @@ class HTMLPurifier_HTMLModule_Tidy extends HTMLPurifier_HTMLModule
                         $type = "info_$type";
                         $e = $this;
                     }
-                    {$e->$type}[$attr] = $fix;
+                    $e->{$type}[$attr] = $fix;
                     break;
                 case 'tag_transform':
                     $this->info_tag_transform[$params['element']] = $fix;

--- a/library/HTMLPurifier/HTMLModule/Tidy.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy.php
@@ -146,10 +146,7 @@ class HTMLPurifier_HTMLModule_Tidy extends HTMLPurifier_HTMLModule
                         $type = "info_$type";
                         $e = $this;
                     }
-                    // PHP does some weird parsing when I do
-                    // $e->$type[$attr], so I have to assign a ref.
-                    $f =& $e->$type;
-                    $f[$attr] = $fix;
+                    {$e->$type}[$attr] = $fix;
                     break;
                 case 'tag_transform':
                     $this->info_tag_transform[$params['element']] = $fix;


### PR DESCRIPTION
Proposed code is PHP5 and PHP7 compatible. PHP5 interpreted `$e->$type[$attr]` as `$e->{$type[$attr]}`, but the expected behavior based on workaround is consistent with PHP7 interpretation: `($e->$type)[$attr]`. By using curly braces `{$e->$type}[$attr]` there is a forced interpretation order working for both versions.
Details can be found on https://www.php.net/manual/en/migration70.incompatible.php (section "Changes to the handling of indirect variables, properties, and methods")