### PR TITLE
Fix some PHP 8.2 deprecations

### DIFF
--- a/library/HTMLPurifier/AttrTransform/NameSync.php
+++ b/library/HTMLPurifier/AttrTransform/NameSync.php
@@ -8,6 +8,11 @@
 class HTMLPurifier_AttrTransform_NameSync extends HTMLPurifier_AttrTransform
 {
 
+    /**
+     * @type HTMLPurifier_AttrDef_HTML_ID
+     */
+    public $idDef;
+
     public function __construct()
     {
         $this->idDef = new HTMLPurifier_AttrDef_HTML_ID();

--- a/library/HTMLPurifier/ChildDef/List.php
+++ b/library/HTMLPurifier/ChildDef/List.php
@@ -22,6 +22,8 @@ class HTMLPurifier_ChildDef_List extends HTMLPurifier_ChildDef
     // XXX: This whole business with 'wrap' is all a bit unsatisfactory
     public $elements = array('li' => true, 'ul' => true, 'ol' => true);
 
+    public $whitespace;
+
     /**
      * @param array $children
      * @param HTMLPurifier_Config $config

--- a/library/HTMLPurifier/Injector/RemoveSpansWithoutAttributes.php
+++ b/library/HTMLPurifier/Injector/RemoveSpansWithoutAttributes.php
@@ -31,6 +31,16 @@ class HTMLPurifier_Injector_RemoveSpansWithoutAttributes extends HTMLPurifier_In
      */
     private $context;
 
+    /**
+     * @type SplObjectStorage
+     */
+    private $markForDeletion;
+
+    public function __construct()
+    {
+        $this->markForDeletion = new SplObjectStorage();
+    }
+
     public function prepare($config, $context)
     {
         $this->attrValidator = new HTMLPurifier_AttrValidator();
@@ -64,7 +74,7 @@ class HTMLPurifier_Injector_RemoveSpansWithoutAttributes extends HTMLPurifier_In
 
         if ($current instanceof HTMLPurifier_Token_End && $current->name === 'span') {
             // Mark closing span tag for deletion
-            $current->markForDeletion = true;
+            $this->markForDeletion->attach($current);
             // Delete open span tag
             $token = false;
         }
@@ -75,7 +85,8 @@ class HTMLPurifier_Injector_RemoveSpansWithoutAttributes extends HTMLPurifier_In
      */
     public function handleEnd(&$token)
     {
-        if ($token->markForDeletion) {
+        if ($this->markForDeletion->contains($token)) {
+            $this->markForDeletion->detach($token);
             $token = false;
         }
     }

--- a/library/HTMLPurifier/Lexer.php
+++ b/library/HTMLPurifier/Lexer.php
@@ -48,6 +48,11 @@ class HTMLPurifier_Lexer
      */
     public $tracksLineNumbers = false;
 
+    /**
+     * @type HTMLPurifier_EntityParser
+     */
+    private $_entity_parser;
+
     // -- STATIC ----------------------------------------------------------
 
     /**

--- a/tests/HTMLPurifier/AttrTransform/NameSyncTest.php
+++ b/tests/HTMLPurifier/AttrTransform/NameSyncTest.php
@@ -3,6 +3,11 @@
 class HTMLPurifier_AttrTransform_NameSyncTest extends HTMLPurifier_AttrTransformHarness
 {
 
+    /**
+     * @type HTMLPurifier_IDAccumulator
+     */
+    public $accumulator;
+
     public function setUp()
     {
         parent::setUp();

--- a/tests/HTMLPurifier/AttrValidator_ErrorsTest.php
+++ b/tests/HTMLPurifier/AttrValidator_ErrorsTest.php
@@ -3,6 +3,11 @@
 class HTMLPurifier_AttrValidator_ErrorsTest extends HTMLPurifier_ErrorsHarness
 {
 
+    /**
+     * @type HTMLPurifier_Language
+     */
+    public $language;
+
     public function setup()
     {
         parent::setup();

--- a/tests/HTMLPurifier/URIFilterHarness.php
+++ b/tests/HTMLPurifier/URIFilterHarness.php
@@ -3,6 +3,11 @@
 class HTMLPurifier_URIFilterHarness extends HTMLPurifier_URIHarness
 {
 
+    /**
+     * @type HTMLPurifier_URIFilter
+     */
+    public $filter;
+
     protected function assertFiltering($uri, $expect_uri = true)
     {
         $this->prepareURI($uri, $expect_uri);


### PR DESCRIPTION
PHP 8.2 deprecates the creation of dynamic properties on objects: https://wiki.php.net/rfc/deprecate_dynamic_properties. This pull request fixes some of the low-hanging fruit of properties that are dynamically created.

I've opted to use the `public` access modifier, as this most closely matches the previous behavior: Dynamically created properties are visible from everywhere. The only non-trivial – and possibly breaking – change is happening in `RemoveSpansWithoutAttributes` as that one does not add a dynamic property to itself, but to another object instead.

This pull request does not fix all deprecations, a follow up change will be required to fix the remainder.