### PR TITLE
Fix #322 - PHP 8.1 deprecation notice in HostBlacklist URIFilter

### DIFF
--- a/library/HTMLPurifier/URIFilter/HostBlacklist.php
+++ b/library/HTMLPurifier/URIFilter/HostBlacklist.php
@@ -35,7 +35,7 @@ class HTMLPurifier_URIFilter_HostBlacklist extends HTMLPurifier_URIFilter
     public function filter(&$uri, $config, $context)
     {
         foreach ($this->blacklist as $blacklisted_host_fragment) {
-            if (strpos($uri->host, $blacklisted_host_fragment) !== false) {
+            if ($uri->host !== null && strpos($uri->host, $blacklisted_host_fragment) !== false) {
                 return false;
             }
         }

--- a/tests/HTMLPurifier/URIFilter/HostBlacklistTest.php
+++ b/tests/HTMLPurifier/URIFilter/HostBlacklistTest.php
@@ -28,6 +28,12 @@ class HTMLPurifier_URIFilter_HostBlacklistTest extends HTMLPurifier_URIFilterHar
         $this->assertFiltering('http://google.com');
     }
 
+    public function testFragment()
+    {
+        $this->config->set('URI.HostBlacklist', 'example.com');
+        $this->assertFiltering('#foo');
+    }
+
 }
 
 // vim: et sw=4 sts=4


### PR DESCRIPTION
`$uri->host` can be `null`:
```
object(HTMLPurifier_URI)#14528 (7) {
  ["scheme"]=>
  NULL
  ["userinfo"]=>
  NULL
  ["host"]=>
  NULL
  ["port"]=>
  NULL
  ["path"]=>
  string(0) ""
  ["query"]=>
  NULL
  ["fragment"]=>
  string(3) "foo"
}
```

Closes #322 