### PR TITLE
Fix PHP 8.2 deprecated utf8_encode & utf8_decode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
 
+      - name: Composer dependencies
+        run: composer update
+
       - name: Clone simpletest
         run: git clone --depth=50 https://github.com/ezyang/simpletest.git
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         }
     ],
     "require": {
-        "php": ">=5.2"
+        "php": ">=5.3.3",
+        "symfony/polyfill-php72": "^1.0"
     },
     "autoload": {
         "psr-0": { "HTMLPurifier": "library/" },

--- a/library/HTMLPurifier/Encoder.php
+++ b/library/HTMLPurifier/Encoder.php
@@ -396,13 +396,12 @@ class HTMLPurifier_Encoder
             // If the string is bjorked by Shift_JIS or a similar encoding
             // that doesn't support all of ASCII, convert the naughty
             // characters to their true byte-wise ASCII/UTF-8 equivalents.
-            $str = strtr($str, self::testEncodingSupportsASCII($encoding));
-            return $str;
-        } elseif ($encoding === 'iso-8859-1') {
-            $str = utf8_encode($str);
-            return $str;
+            return strtr($str, self::testEncodingSupportsASCII($encoding));
         }
-        $bug = HTMLPurifier_Encoder::testIconvTruncateBug();
+        if ($encoding === 'iso-8859-1') {
+            return self::utf8Encode($str);
+        }
+        $bug = self::testIconvTruncateBug();
         if ($bug == self::ICONV_OK) {
             trigger_error('Encoding not supported, please install iconv', E_USER_ERROR);
         } else {
@@ -448,11 +447,10 @@ class HTMLPurifier_Encoder
             }
             $str = strtr($str, array_flip($ascii_fix));
             // Normal stuff
-            $str = self::iconv('utf-8', $encoding . '//IGNORE', $str);
-            return $str;
-        } elseif ($encoding === 'iso-8859-1') {
-            $str = utf8_decode($str);
-            return $str;
+            return self::iconv('utf-8', $encoding . '//IGNORE', $str);
+        }
+        if ($encoding === 'iso-8859-1') {
+            return self::utf8Decode($str);
         }
         trigger_error('Encoding not supported', E_USER_ERROR);
         // You might be tempted to assume that the ASCII representation
@@ -611,6 +609,26 @@ class HTMLPurifier_Encoder
         }
         $encodings[$encoding] = $ret;
         return $ret;
+    }
+
+    /**
+     * @param string $str
+     *
+     * @return string
+     */
+    public static function utf8Encode($str)
+    {
+        return (string) \Symfony\Polyfill\Php72\Php72::utf8_encode($str);
+    }
+
+    /**
+     * @param string $str
+     *
+     * @return string
+     */
+    public static function utf8Decode($str)
+    {
+        return (string) \Symfony\Polyfill\Php72\Php72::utf8_decode($str);
     }
 }
 

--- a/tests/index.php
+++ b/tests/index.php
@@ -41,6 +41,8 @@ define('HTMLPurifierTest', 1);
 define('HTMLPURIFIER_SCHEMA_STRICT', true); // validate schemas
 chdir(dirname(__FILE__));
 
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
 $php = 'php'; // for safety
 ini_set('memory_limit', '64M');
 


### PR DESCRIPTION
Removed usages of deprecated functions `utf8_decode` & `utf8_encode`

This definitely isn't the way to solve the issue in the long run, but would at least keep backwards compatibility with minimal changes apart from dropping PHP 5.2 support. Removing `utf8_encode` and `utf8_decode` completely would require quite a bit of changes to related tests and would also break backwards compatibility.