### PR TITLE
Update to `actions/checkout@v3`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This does not introduce any functional difference and is intended as a
future-proofing change.

see https://github.com/actions/checkout/releases/tag/v3.0.0