### PR TITLE
Fix test selection logic in tests/test_files.php

### DIFF
--- a/tests/test_files.php
+++ b/tests/test_files.php
@@ -29,6 +29,7 @@ switch ($AC['type']) {
         if ($break) break;
     case 'fstools':
         $test_dirs[] = 'FSTools';
+        if ($break) break;
     case 'htmlt':
         $htmlt_dirs[] = 'HTMLPurifier/HTMLT';
         if ($break) break;


### PR DESCRIPTION
Selecting the `fstools` tests also executed the `htmlt` tests.