### PR TITLE
Fix some more PHP 8.2 deprecations

### DIFF
--- a/library/HTMLPurifier/AttrTransform/SafeParam.php
+++ b/library/HTMLPurifier/AttrTransform/SafeParam.php
@@ -24,6 +24,11 @@ class HTMLPurifier_AttrTransform_SafeParam extends HTMLPurifier_AttrTransform
      */
     private $uri;
 
+    /**
+     * @type HTMLPurifier_AttrDef_Enum
+     */
+    public $wmode;
+
     public function __construct()
     {
         $this->uri = new HTMLPurifier_AttrDef_URI(true); // embedded

--- a/tests/HTMLPurifier/DefinitionCache/DecoratorHarness.php
+++ b/tests/HTMLPurifier/DefinitionCache/DecoratorHarness.php
@@ -5,6 +5,8 @@ generate_mock_once('HTMLPurifier_DefinitionCache');
 class HTMLPurifier_DefinitionCache_DecoratorHarness extends HTMLPurifier_DefinitionCacheHarness
 {
 
+    public $cache;
+
     public function setup()
     {
         $this->mock     = new HTMLPurifier_DefinitionCacheMock();

--- a/tests/HTMLPurifier/DefinitionCache/DecoratorHarness.php
+++ b/tests/HTMLPurifier/DefinitionCache/DecoratorHarness.php
@@ -7,6 +7,8 @@ class HTMLPurifier_DefinitionCache_DecoratorHarness extends HTMLPurifier_Definit
 
     public $cache;
 
+    public $mock;
+
     public function setup()
     {
         $this->mock     = new HTMLPurifier_DefinitionCacheMock();

--- a/tests/HTMLPurifier/DefinitionCache/DecoratorHarness.php
+++ b/tests/HTMLPurifier/DefinitionCache/DecoratorHarness.php
@@ -9,6 +9,8 @@ class HTMLPurifier_DefinitionCache_DecoratorHarness extends HTMLPurifier_Definit
 
     public $mock;
 
+    public $def;
+
     public function setup()
     {
         $this->mock     = new HTMLPurifier_DefinitionCacheMock();

--- a/tests/HTMLPurifier/EntityParserTest.php
+++ b/tests/HTMLPurifier/EntityParserTest.php
@@ -5,6 +5,8 @@ class HTMLPurifier_EntityParserTest extends HTMLPurifier_Harness
 
     protected $EntityParser;
 
+    protected $_entity_lookup;
+
     public function setUp()
     {
         $this->EntityParser = new HTMLPurifier_EntityParser();


### PR DESCRIPTION
Read the description in #319 for more details.

-------------------------

At this point fixing more issues gets painful, because some of the errors are in simpletest and not obvious to fix to me. Unfortunately simpletest's own tests already fail even with PHP 7.4 making it even harder to make the necessary changes.

It might make sense to migrate HTMLPurifier's tests to another maintained testing framework (e.g. PHPUnit) to future proof it for upcoming PHP versions (I specifically can imagine PHP 9 being painful once it appears). Unfortunately I don't have the time resources that are necessary to make this happen.