### PR TITLE
Fix creation of dynamic property notices on PHP 8.2

### DIFF
--- a/tests/HTMLPurifier/DefinitionTestable.php
+++ b/tests/HTMLPurifier/DefinitionTestable.php
@@ -1,7 +1,14 @@
 <?php
 
+abstract class HTMLPurifier_TestDefinition extends HTMLPurifier_Definition
+{
+    public $info;
+    public $info_candles;
+    public $info_random;
+}
+
 Mock::generatePartial(
-        'HTMLPurifier_Definition',
+        'HTMLPurifier_TestDefinition',
         'HTMLPurifier_DefinitionTestable',
         array('doSetup'));
 


### PR DESCRIPTION
Not really sure that this is the best way to handle it, but it does the trick :shrug: 

```
# php tests/index.php 
All HTML Purifier tests on PHP 8.2.0RC1
Exception 1!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info_random is deprecated] severity [8192] in [/v/tests/HTMLPurifier/DefinitionCache/SerializerTest.php line 41]
        in test
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 2!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info_random is deprecated] severity [8192] in [/v/library/HTMLPurifier/DefinitionCache/Serializer.php line 73]
        in test
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 3!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info_random is deprecated] severity [8192] in [/v/library/HTMLPurifier/DefinitionCache/Serializer.php line 73]
        in test
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 4!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info_random is deprecated] severity [8192] in [/v/library/HTMLPurifier/DefinitionCache/Serializer.php line 73]
        in test
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 5!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info_candles is deprecated] severity [8192] in [/v/tests/HTMLPurifier/DefinitionCacheHarness.php line 29]
        in test_flush
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 6!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info_candles is deprecated] severity [8192] in [/v/tests/HTMLPurifier/DefinitionCacheHarness.php line 29]
        in test_flush
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 7!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info_candles is deprecated] severity [8192] in [/v/tests/HTMLPurifier/DefinitionCacheHarness.php line 29]
        in test_flush
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 8!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info_candles is deprecated] severity [8192] in [/v/library/HTMLPurifier/DefinitionCache/Serializer.php line 73]
        in test_flush
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 9!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info_candles is deprecated] severity [8192] in [/v/library/HTMLPurifier/DefinitionCache/Serializer.php line 73]
        in test_flush
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 10!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info_candles is deprecated] severity [8192] in [/v/library/HTMLPurifier/DefinitionCache/Serializer.php line 73]
        in test_flush
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 11!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info is deprecated] severity [8192] in [/v/tests/HTMLPurifier/DefinitionCacheHarness.php line 29]
        in testCleanup
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 12!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info is deprecated] severity [8192] in [/v/tests/HTMLPurifier/DefinitionCacheHarness.php line 29]
        in testCleanup
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 13!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info is deprecated] severity [8192] in [/v/library/HTMLPurifier/DefinitionCache/Serializer.php line 73]
        in testCleanup
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 14!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info is deprecated] severity [8192] in [/v/tests/HTMLPurifier/DefinitionCacheHarness.php line 29]
        in testCleanupOnlySameID
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 15!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info is deprecated] severity [8192] in [/v/tests/HTMLPurifier/DefinitionCacheHarness.php line 29]
        in testCleanupOnlySameID
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 16!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info is deprecated] severity [8192] in [/v/library/HTMLPurifier/DefinitionCache/Serializer.php line 73]
        in testCleanupOnlySameID
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 17!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info is deprecated] severity [8192] in [/v/library/HTMLPurifier/DefinitionCache/Serializer.php line 73]
        in testCleanupOnlySameID
        in HTMLPurifier_DefinitionCache_SerializerTest
Exception 18!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_DefinitionTestable::$info is deprecated] severity [8192] in [/v/library/HTMLPurifier/DefinitionCache/Serializer.php line 73]
        in testCleanupOnlySameID
        in HTMLPurifier_DefinitionCache_SerializerTest
FAILURES!!!
Test cases run: 221/221, Passes: 2794, Failures: 0, Exceptions: 18
```