### PR TITLE
Fix contenteditable attribute definition

### DIFF
--- a/library/HTMLPurifier/HTMLModule/CommonAttributes.php
+++ b/library/HTMLPurifier/HTMLModule/CommonAttributes.php
@@ -17,6 +17,7 @@ class HTMLPurifier_HTMLModule_CommonAttributes extends HTMLPurifier_HTMLModule
             'class' => 'Class',
             'id' => 'ID',
             'title' => 'CDATA',
+            'contenteditable' => 'ContentEditable',
         ),
         'Lang' => array(),
         'I18N' => array(

--- a/tests/HTMLPurifier/Strategy/ValidateAttributesTest.php
+++ b/tests/HTMLPurifier/Strategy/ValidateAttributesTest.php
@@ -258,6 +258,13 @@ class HTMLPurifier_Strategy_ValidateAttributesTest extends
         );
     }
 
+    public function testContentEditableAttribute()
+    {
+        $this->assertResult(
+            '<div contenteditable="false"></div>',
+            '<div contenteditable="false"></div>'
+        );
+    }
 }
 
 // vim: et sw=4 sts=4


### PR DESCRIPTION
I forgot to add the attribute to a collection in https://github.com/ezyang/htmlpurifier/pull/332 so the attribute was never actually being validated.