### PR TITLE
Fix creation of dynamic property

### DIFF
--- a/tests/HTMLPurifier/Strategy/MakeWellFormed/EndRewindInjector.php
+++ b/tests/HTMLPurifier/Strategy/MakeWellFormed/EndRewindInjector.php
@@ -4,10 +4,13 @@ class HTMLPurifier_Strategy_MakeWellFormed_EndRewindInjector extends HTMLPurifie
 {
     public $name = 'EndRewindInjector';
     public $needed = array('span');
+    public $deleteElement = false;
+
     public function handleElement(&$token)
     {
-        if (isset($token->_InjectorTest_EndRewindInjector_delete)) {
+        if ($this->deleteElement) {
             $token = false;
+            $this->deleteElement = false;
         }
     }
     public function handleText(&$token)
@@ -23,7 +26,7 @@ class HTMLPurifier_Strategy_MakeWellFormed_EndRewindInjector extends HTMLPurifie
             $prev->name == 'span'
         ) {
             $token = false;
-            $prev->_InjectorTest_EndRewindInjector_delete = true;
+            $this->deleteElement = true;
             $this->rewindOffset(1);
         }
     }

--- a/tests/HTMLPurifier/Strategy/MakeWellFormed/EndRewindInjector.php
+++ b/tests/HTMLPurifier/Strategy/MakeWellFormed/EndRewindInjector.php
@@ -4,7 +4,7 @@ class HTMLPurifier_Strategy_MakeWellFormed_EndRewindInjector extends HTMLPurifie
 {
     public $name = 'EndRewindInjector';
     public $needed = array('span');
-    public $deleteElement = false;
+    private $deleteElement = false;
 
     public function handleElement(&$token)
     {


### PR DESCRIPTION
```
# php tests/index.php 
All HTML Purifier tests on PHP 8.2.0RC1
Exception 1!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_Token_Start::$_InjectorTest_EndRewindInjector_delete is deprecated] severity [8192] in [/v/tests/HTMLPurifier/Strategy/MakeWellFormed/EndRewindInjector.php line 26]
        in testFunction
        in HTMLPurifier_Strategy_MakeWellFormed_EndRewindInjectorTest
Exception 2!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_Token_Start::$_InjectorTest_EndRewindInjector_delete is deprecated] severity [8192] in [/v/tests/HTMLPurifier/Strategy/MakeWellFormed/EndRewindInjector.php line 26]
        in testPadded
        in HTMLPurifier_Strategy_MakeWellFormed_EndRewindInjectorTest
Exception 3!
Unexpected PHP Error [Creation of dynamic property HTMLPurifier_Token_Start::$_InjectorTest_EndRewindInjector_delete is deprecated] severity [8192] in [/v/tests/HTMLPurifier/Strategy/MakeWellFormed/EndRewindInjector.php line 26]
        in testDoubled
        in HTMLPurifier_Strategy_MakeWellFormed_EndRewindInjectorTest
FAILURES!!!
Test cases run: 221/221, Passes: 2795, Failures: 0, Exceptions: 3

```