### PR TITLE
fix: semantic release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,0 @@
-# [4.16.0](https://github.com/ezyang/htmlpurifier/compare/v4.15.0...v4.16.0) (2022-09-18)
-
-
-### Features
-
-* add semantic release ([#307](https://github.com/ezyang/htmlpurifier/issues/307)) ([db31243](https://github.com/ezyang/htmlpurifier/commit/db312435cb9d8d73395f75f9642a43ba6de5e903)), closes [#322](https://github.com/ezyang/htmlpurifier/issues/322) [#323](https://github.com/ezyang/htmlpurifier/issues/323) [#326](https://github.com/ezyang/htmlpurifier/issues/326) [#327](https://github.com/ezyang/htmlpurifier/issues/327) [#328](https://github.com/ezyang/htmlpurifier/issues/328) [#329](https://github.com/ezyang/htmlpurifier/issues/329) [#330](https://github.com/ezyang/htmlpurifier/issues/330) [#331](https://github.com/ezyang/htmlpurifier/issues/331) [#332](https://github.com/ezyang/htmlpurifier/issues/332) [#333](https://github.com/ezyang/htmlpurifier/issues/333) [#337](https://github.com/ezyang/htmlpurifier/issues/337) [#335](https://github.com/ezyang/htmlpurifier/issues/335) [ezyang/htmlpurifier#334](https://github.com/ezyang/htmlpurifier/issues/334) [#336](https://github.com/ezyang/htmlpurifier/issues/336) [#338](https://github.com/ezyang/htmlpurifier/issues/338)

--- a/release.config.js
+++ b/release.config.js
@@ -4,26 +4,30 @@ module.exports = {
   plugins: [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',
-    ['@semantic-release/changelog', {'changelogFile': 'NEWS'}],
-    '@semantic-release/exec',
-    ['@semantic-release/git', {
-      'assets': ['VERSION', 'NEWS', 'Doxyfile', 'library/HTMLPurifier.php', 'library/HTMLPurifier/Config.php', 'library/HTMLPurifier.includes.php'],
-    }],
-    '@semantic-release/github'
+    [
+      '@semantic-release/changelog',
+      {
+        'changelogFile': 'NEWS'
+      }
+    ],
+    [
+      '@semantic-release/exec',
+      {
+        'prepareCmd': 'php update-for-release ${nextRelease.version}'
+      }
+    ],
+    [
+      '@semantic-release/git',
+      {
+        'assets': [
+          'VERSION',
+          'NEWS',
+          'Doxyfile',
+          'library/HTMLPurifier.php',
+          'library/HTMLPurifier/Config.php',
+          'library/HTMLPurifier.includes.php'
+        ],
+      }
+    ]
   ],
-  verifyConditions: [
-    '@semantic-release/changelog',
-    '@semantic-release/github',
-  ],
-  prepare: [
-    {
-      path: '@semantic-release/exec',
-      cmd: 'php update-for-release ${nextRelease.version}'
-    },
-    '@semantic-release/changelog',
-    '@semantic-release/git',
-  ],
-  publish: [
-    '@semantic-release/github',
-  ]
 }

--- a/release.config.js
+++ b/release.config.js
@@ -23,11 +23,11 @@ module.exports = {
           'VERSION',
           'NEWS',
           'Doxyfile',
-          'library/HTMLPurifier.php',
-          'library/HTMLPurifier/Config.php',
-          'library/HTMLPurifier.includes.php'
+          'library/**/*',
+          'configdoc/**/*',
         ],
       }
-    ]
+    ],
+    '@semantic-release/github'
   ],
 }


### PR DESCRIPTION
I noticed that https://github.com/ezyang/htmlpurifier/commit/523407fb06eb9e5f3d59889b3978d5bfe94299c8 didn't update all the files:
```
'VERSION',
'NEWS',
'Doxyfile',
'library/HTMLPurifier.php',
'library/HTMLPurifier/Config.php',
'library/HTMLPurifier.includes.php'
```

I believe this PR fixes that. Here's an example I ran locally - the important bit being `Update /v/NEWS` and `Found 6 file(s) to commit`:
```bash
$ npx semantic-release --no-ci
[6:41:28 PM] [semantic-release] › ℹ  Running semantic-release version 19.0.5
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/changelog"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/exec"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/git"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/exec"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "verifyRelease" from "@semantic-release/exec"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "generateNotes" from "@semantic-release/release-notes-generator"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "generateNotes" from "@semantic-release/exec"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/changelog"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/exec"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "prepare" from "@semantic-release/git"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/exec"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "addChannel" from "@semantic-release/exec"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "success" from "@semantic-release/exec"
[6:41:28 PM] [semantic-release] › ✔  Loaded plugin "fail" from "@semantic-release/exec"
[6:41:30 PM] [semantic-release] › ✔  Run automated release from branch master on repository https://github.com/bytestream/htmlpurifier
[6:41:31 PM] [semantic-release] › ✔  Allowed to push to the Git repository
[6:41:31 PM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/changelog"
[6:41:31 PM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/changelog"
[6:41:31 PM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/exec"
[6:41:31 PM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/exec"
[6:41:31 PM] [semantic-release] › ℹ  Start step "verifyConditions" of plugin "@semantic-release/git"
[6:41:31 PM] [semantic-release] › ✔  Completed step "verifyConditions" of plugin "@semantic-release/git"
[6:41:31 PM] [semantic-release] › ℹ  Found git tag v4.16.0 associated with version 4.16.0 on branch master
[6:41:31 PM] [semantic-release] › ℹ  Found 1 commits since last release
[6:41:31 PM] [semantic-release] › ℹ  Start step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
[6:41:31 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analyzing commit: fix: foobar
[6:41:31 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  The release type for the commit is patch
[6:41:31 PM] [semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analysis of 1 commits complete: patch release
[6:41:31 PM] [semantic-release] › ✔  Completed step "analyzeCommits" of plugin "@semantic-release/commit-analyzer"
[6:41:31 PM] [semantic-release] › ℹ  Start step "analyzeCommits" of plugin "@semantic-release/exec"
[6:41:31 PM] [semantic-release] › ✔  Completed step "analyzeCommits" of plugin "@semantic-release/exec"
[6:41:31 PM] [semantic-release] › ℹ  The next release version is 4.16.1
[6:41:31 PM] [semantic-release] › ℹ  Start step "verifyRelease" of plugin "@semantic-release/exec"
[6:41:31 PM] [semantic-release] › ✔  Completed step "verifyRelease" of plugin "@semantic-release/exec"
[6:41:31 PM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[6:41:31 PM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[6:41:31 PM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/exec"
[6:41:31 PM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/exec"
[6:41:31 PM] [semantic-release] › ℹ  Start step "prepare" of plugin "@semantic-release/changelog"
[6:41:31 PM] [semantic-release] [@semantic-release/changelog] › ℹ  Update /v/NEWS
[6:41:31 PM] [semantic-release] › ✔  Completed step "prepare" of plugin "@semantic-release/changelog"
[6:41:31 PM] [semantic-release] › ℹ  Start step "prepare" of plugin "@semantic-release/exec"
[6:41:31 PM] [semantic-release] [@semantic-release/exec] › ℹ  Call script php update-for-release 4.16.1
+++ dirname maintenance/flush.sh
++ cd maintenance
++ pwd
+ DIR=/v/maintenance
+ php /v/maintenance/generate-includes.php
Scanning for files... done!
Writing HTMLPurifier.includes.php... done!
Writing HTMLPurifier.safe-includes.php... done!
+ php /v/maintenance/generate-schema-cache.php
Saving schema... done!
+ php /v/maintenance/flush-definition-cache.php
Flushing cache... 
 - Flushing HTML
 - Flushing CSS
 - Flushing URI
 - Flushing Test
Cache flushed successfully.
+ php /v/maintenance/generate-standalone.php
Generating includes file... done!
Creating full file... done!
Creating standalone directory... done!
+ php /v/maintenance/config-scanner.php
PHP Fatal error:  Uncaught Error: Class 'XMLWriter' not found in /v/maintenance/config-scanner.php:132
Stack trace:
#0 {main}
  thrown in /v/maintenance/config-scanner.php on line 132

136/139 instances of $config or $this->config found in source code.
Generating XML... Review changes, and then commit with log 'Release 4.16.1.'
[6:41:32 PM] [semantic-release] › ✔  Completed step "prepare" of plugin "@semantic-release/exec"
[6:41:32 PM] [semantic-release] › ℹ  Start step "prepare" of plugin "@semantic-release/git"
[6:41:32 PM] [semantic-release] [@semantic-release/git] › ℹ  Found 6 file(s) to commit
[6:41:34 PM] [semantic-release] [@semantic-release/git] › ℹ  Prepared Git release: v4.16.1
[6:41:34 PM] [semantic-release] › ✔  Completed step "prepare" of plugin "@semantic-release/git"
[6:41:34 PM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[6:41:34 PM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[6:41:34 PM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/exec"
[6:41:34 PM] [semantic-release] › ✔  Completed step "generateNotes" of plugin "@semantic-release/exec"
[6:41:36 PM] [semantic-release] › ✔  Created tag v4.16.1
[6:41:36 PM] [semantic-release] › ℹ  Start step "publish" of plugin "@semantic-release/exec"
[6:41:36 PM] [semantic-release] › ✔  Completed step "publish" of plugin "@semantic-release/exec"
[6:41:36 PM] [semantic-release] › ℹ  Start step "success" of plugin "@semantic-release/exec"
[6:41:36 PM] [semantic-release] › ✔  Completed step "success" of plugin "@semantic-release/exec"
[6:41:36 PM] [semantic-release] › ✔  Published release 4.16.1 on default channel
```