### PR TITLE
fix: Fixed missing return value

### DIFF
--- a/library/HTMLPurifier/HTMLModule/Tidy.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy.php
@@ -221,6 +221,7 @@ class HTMLPurifier_HTMLModule_Tidy extends HTMLPurifier_HTMLModule
      */
     public function makeFixes()
     {
+        return array();
     }
 }
 


### PR DESCRIPTION
Fixes:
`222  Method HTMLPurifier_HTMLModule_Tidy::makeFixes() should return array but return statement is missing.`