### PR TITLE
fix: Fixed missing return statement

### DIFF
--- a/library/HTMLPurifier/VarParser.php
+++ b/library/HTMLPurifier/VarParser.php
@@ -125,6 +125,7 @@ class HTMLPurifier_VarParser
                 $this->errorInconsistent(get_class($this), $type);
         }
         $this->errorGeneric($var, $type);
+        return null;
     }
 
     /**


### PR DESCRIPTION
Fixes:
`127 Method HTMLPurifier_VarParser::parse() should return string but return statement is missing`