### PR TITLE
fix: Invalid scheme check in Attr.TargetBlank

### DIFF
--- a/library/HTMLPurifier/AttrTransform/TargetBlank.php
+++ b/library/HTMLPurifier/AttrTransform/TargetBlank.php
@@ -33,7 +33,11 @@ class HTMLPurifier_AttrTransform_TargetBlank extends HTMLPurifier_AttrTransform
 
         // XXX Kind of inefficient
         $url = $this->parser->parse($attr['href']);
-        $scheme = $url->getSchemeObj($config, $context);
+        
+        // Ignore invalid schemes (e.g. `javascript:`)
+        if (!($scheme = $url->getSchemeObj($config, $context))) {
+            return $attr;
+        }
 
         if ($scheme->browsable && !$url->isBenign($config, $context)) {
             $attr['target'] = '_blank';


### PR DESCRIPTION
When `Attr.TargetBlank` is enabled, a PHP warning is logged if an `href` attribute contains an invalid URI scheme.

Normally an `href` like `javascript:void(0)` or `itms-apps://itunes.apple.com/developer/id1234567890` would be removed by the default `HTMLPurifier_Config` configuration.

However, it's possible to insert a URL with an unknown context from a trusted source after filtering. For instance, an `HTMLPurifier_URIFilter` extension.

This patch doesn't change any functionality or permit anything new, it simply adds error checking around `$url->getSchemeObj()` which returns `HTMLPurifier_URIScheme|false`.

The `false` case is currently not handled, resulting in error log entries under PHP 8.x like the following:

~~~
Attempt to read property "browsable" on bool /PATH/TO/APP/vendor/ezyang/htmlpurifier/library/HTMLPurifier/AttrTransform/TargetBlank.php:L38
~~~