### PR TITLE
fix: Remove unnecessary disablement of autoload in `class_exists` usage

### DIFF
--- a/library/HTMLPurifier/DefinitionCacheFactory.php
+++ b/library/HTMLPurifier/DefinitionCacheFactory.php
@@ -71,7 +71,7 @@ class HTMLPurifier_DefinitionCacheFactory
             return $this->caches[$method][$type];
         }
         if (isset($this->implementations[$method]) &&
-            class_exists($class = $this->implementations[$method], false)) {
+            class_exists($class = $this->implementations[$method])) {
             $cache = new $class($type);
         } else {
             if ($method != 'Serializer') {

--- a/library/HTMLPurifier/LanguageFactory.php
+++ b/library/HTMLPurifier/LanguageFactory.php
@@ -109,7 +109,7 @@ class HTMLPurifier_LanguageFactory
         } else {
             $class = 'HTMLPurifier_Language_' . $pcode;
             $file  = $this->dir . '/Language/classes/' . $code . '.php';
-            if (file_exists($file) || class_exists($class, false)) {
+            if (file_exists($file) || class_exists($class)) {
                 $lang = new $class($config, $context);
             } else {
                 // Go fallback

--- a/library/HTMLPurifier/Lexer.php
+++ b/library/HTMLPurifier/Lexer.php
@@ -101,7 +101,7 @@ class HTMLPurifier_Lexer
                         break;
                     }
 
-                    if (class_exists('DOMDocument', false) &&
+                    if (class_exists('DOMDocument') &&
                         method_exists('DOMDocument', 'loadHTML') &&
                         !extension_loaded('domxml')
                     ) {


### PR DESCRIPTION
This PR removes the usage of the secondary argument in `class_exists()` checks in HTML Purifier. This secondary argument is being used to disable autoloading the class if it has not yet been autoloaded.

The current implementation breaks composer based projects where a class may not have been included or required yet via composers autoloader, but has been registered as a definition cache:

```php
$cache = \App\Purifier\RemoteFilesystemDefinition::class;

HTMLPurifier_DefinitionCacheFactory::instance()->register($cache, $cache);

$htmlConfig = HTMLPurifier_Config::create($config);

$htmlConfig->set('Cache.DefinitionImpl', $cache);
```

Upon usage:

```
ErrorException : Unrecognized DefinitionCache App\Purifier\RemoteFilesystemDefinition, using Serializer instead
```

This exception can be resolved by `require`'ing or `include`'ing the class manually, or via a `spl_autoload_call($cache)`:

```php
$cache = \App\Purifier\RemoteFilesystemDefinition::class;

spl_autoload_call($cache);

HTMLPurifier_DefinitionCacheFactory::instance()->register($cache, $cache);
```

However, this should not be necessary in todays PHP, as class strings are frequently used as a way to dynamically register implementations of things, and removing the secondary argument in `class_exists()` results in the definition cache being properly registered and used.