### PR TITLE
fix: Support for locales using decimal separators other than . (dot)

### DIFF
--- a/library/HTMLPurifier/UnitConverter.php
+++ b/library/HTMLPurifier/UnitConverter.php
@@ -46,12 +46,6 @@ class HTMLPurifier_UnitConverter
      * @type int
      */
     protected $internalPrecision;
-    
-    /**
-     * Currently used decimal separator based on locale.
-     * @type string
-     */
-    protected $decimalSeparator;
 
     /**
      * Whether or not BCMath is available.
@@ -63,7 +57,6 @@ class HTMLPurifier_UnitConverter
     {
         $this->outputPrecision = $output_precision;
         $this->internalPrecision = $internal_precision;
-        $this->decimalSeparator = localeconv()['decimal_point'];
         $this->bcmath = !$force_no_bcmath && function_exists('bcmul');
     }
 
@@ -262,13 +255,13 @@ class HTMLPurifier_UnitConverter
     /**
      * Rounds a number according to the number of sigfigs it should have,
      * using arbitrary precision when available.
-     * @param string $n
+     * @param float $n
      * @param int $sigfigs
      * @return string
      */
     private function round($n, $sigfigs)
     {
-        $new_log = (int)floor(log(abs(floatval($n)), 10)); // Number of digits left of decimal - 1
+        $new_log = (int)floor(log(abs((float)$n), 10)); // Number of digits left of decimal - 1
         $rp = $sigfigs - $new_log - 1; // Number of decimal places needed
         $neg = $n < 0 ? '-' : ''; // Negative sign
         if ($this->bcmath) {
@@ -283,7 +276,7 @@ class HTMLPurifier_UnitConverter
             }
             return $n;
         } else {
-            return $this->scale(round(floatval($n), $sigfigs - $new_log - 1), $rp + 1);
+            return $this->scale(round((float)$n, $sigfigs - $new_log - 1), $rp + 1);
         }
     }
 
@@ -307,7 +300,7 @@ class HTMLPurifier_UnitConverter
             // Now we return it, truncating the zero that was rounded off.
             return substr($precise, 0, -1) . str_repeat('0', -$scale + 1);
         }
-        return str_replace($this->decimalSeparator, '.', sprintf('%.' . $scale . 'f', (float)$r));
+        return number_format((float)$r, $scale, '.', '');
     }
 }
 

--- a/library/HTMLPurifier/UnitConverter.php
+++ b/library/HTMLPurifier/UnitConverter.php
@@ -46,6 +46,12 @@ class HTMLPurifier_UnitConverter
      * @type int
      */
     protected $internalPrecision;
+    
+    /**
+     * Currently used decimal separator based on locale.
+     * @type string
+     */
+    protected $decimalSeparator;
 
     /**
      * Whether or not BCMath is available.
@@ -57,6 +63,7 @@ class HTMLPurifier_UnitConverter
     {
         $this->outputPrecision = $output_precision;
         $this->internalPrecision = $internal_precision;
+        $this->decimalSeparator = localeconv()['decimal_point'];
         $this->bcmath = !$force_no_bcmath && function_exists('bcmul');
     }
 
@@ -276,32 +283,9 @@ class HTMLPurifier_UnitConverter
             }
             return $n;
         } else {
-            return $this->scale(round($n, $sigfigs - $new_log - 1), $rp + 1);
+            return $this->scale(round(floatval($n), $sigfigs - $new_log - 1), $rp + 1);
         }
     }
-    
-    /**
-     * Converts a float to a string like strval() but without using the
-     * exponential notation (x.yE+z)
-     * @param float $n
-     * @return string
-     */
-    /*private function floatToStringNonExponential($n) {
-      $n_str = strval($n);
-      $exp_pos = strpos($n_str, 'E');
-      if($exp_pos === false){
-        return $n_str;
-      } else {
-        $exp = intval(substr($n_str, $exp_pos + 1));
-        $digits_to_add = $exp;
-        $dot_pos = strpos($n_str, '.');
-        if($dot_pos !== false){
-          $decimals = strlen(substr($n_str, $dot_pos + 1, $exp_pos));
-          $digits_to_add -= $decimals;
-        }
-        return str_pad(str_replace('.', '', substr($n_str, 0, $exp_pos)), $digits_to_add, '0');
-      }
-    }*/
 
     /**
      * Scales a float to $scale digits right of decimal point, like BCMath.
@@ -323,7 +307,7 @@ class HTMLPurifier_UnitConverter
             // Now we return it, truncating the zero that was rounded off.
             return substr($precise, 0, -1) . str_repeat('0', -$scale + 1);
         }
-        return sprintf('%.' . $scale . 'f', (float)$r);
+        return str_replace($this->decimalSeparator, '.', sprintf('%.' . $scale . 'f', (float)$r));
     }
 }
 

--- a/library/HTMLPurifier/UnitConverter.php
+++ b/library/HTMLPurifier/UnitConverter.php
@@ -175,7 +175,7 @@ class HTMLPurifier_UnitConverter
         //echo "<pre>n";
         //echo "$n\nsigfigs = $sigfigs\nnew_log = $new_log\nlog = $log\nrp = $rp\n</pre>\n";
 
-        $n = $this->round($n, $sigfigs);
+        $n = $this->round(floatval($n), $sigfigs);
         if (strpos($n, '.') !== false) {
             $n = rtrim($n, '0');
         }

--- a/library/HTMLPurifier/UnitConverter.php
+++ b/library/HTMLPurifier/UnitConverter.php
@@ -175,7 +175,7 @@ class HTMLPurifier_UnitConverter
         //echo "<pre>n";
         //echo "$n\nsigfigs = $sigfigs\nnew_log = $new_log\nlog = $log\nrp = $rp\n</pre>\n";
 
-        $n = $this->round(floatval($n), $sigfigs);
+        $n = $this->round($n, $sigfigs);
         if (strpos($n, '.') !== false) {
             $n = rtrim($n, '0');
         }
@@ -255,13 +255,13 @@ class HTMLPurifier_UnitConverter
     /**
      * Rounds a number according to the number of sigfigs it should have,
      * using arbitrary precision when available.
-     * @param float $n
+     * @param string $n
      * @param int $sigfigs
      * @return string
      */
     private function round($n, $sigfigs)
     {
-        $new_log = (int)floor(log(abs($n), 10)); // Number of digits left of decimal - 1
+        $new_log = (int)floor(log(abs(floatval($n)), 10)); // Number of digits left of decimal - 1
         $rp = $sigfigs - $new_log - 1; // Number of decimal places needed
         $neg = $n < 0 ? '-' : ''; // Negative sign
         if ($this->bcmath) {
@@ -279,6 +279,29 @@ class HTMLPurifier_UnitConverter
             return $this->scale(round($n, $sigfigs - $new_log - 1), $rp + 1);
         }
     }
+    
+    /**
+     * Converts a float to a string like strval() but without using the
+     * exponential notation (x.yE+z)
+     * @param float $n
+     * @return string
+     */
+    /*private function floatToStringNonExponential($n) {
+      $n_str = strval($n);
+      $exp_pos = strpos($n_str, 'E');
+      if($exp_pos === false){
+        return $n_str;
+      } else {
+        $exp = intval(substr($n_str, $exp_pos + 1));
+        $digits_to_add = $exp;
+        $dot_pos = strpos($n_str, '.');
+        if($dot_pos !== false){
+          $decimals = strlen(substr($n_str, $dot_pos + 1, $exp_pos));
+          $digits_to_add -= $decimals;
+        }
+        return str_pad(str_replace('.', '', substr($n_str, 0, $exp_pos)), $digits_to_add, '0');
+      }
+    }*/
 
     /**
      * Scales a float to $scale digits right of decimal point, like BCMath.

--- a/tests/HTMLPurifier/UnitConverterTest.php
+++ b/tests/HTMLPurifier/UnitConverterTest.php
@@ -101,6 +101,13 @@ class HTMLPurifier_UnitConverterTest extends HTMLPurifier_Harness
         $this->assertConversion('111.12pt', '1.5433in');
         $this->assertConversion('11.112pt', '0.15433in');
     }
+    
+    public function testDecimalSeparatorComma()
+    {
+        setlocale(LC_ALL, 'de_DE@euro', 'de_DE', 'deu_deu');
+        $this->assertConversion('11.11px', '0.294cm');
+        setlocale(LC_ALL, '');
+    }
 
     public function testRoundingBigNumber()
     {


### PR DESCRIPTION
When using somtehing like `setlocale(LC_ALL, 'de_DE');` the function `sprintf('%.1f, ...)'` will use a comma for decimal separation. The function `is_numeric()` will output `false` for strings containing a comma. Thereby I had to replace the decimal separator of the used locale with a dot.