### PR TITLE
fix: Fix typos

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -99,7 +99,7 @@ Autoload compatibility
 
     HTML Purifier attempts to be as smart as possible when registering an
     autoloader, but there are some cases where you will need to change
-    your own code to accomodate HTML Purifier. These are those cases:
+    your own code to accommodate HTML Purifier. These are those cases:
 
     AN __autoload FUNCTION IS DECLARED AFTER OUR AUTOLOADER IS REGISTERED
         spl_autoload_register() has the curious behavior of disabling

--- a/NEWS
+++ b/NEWS
@@ -439,7 +439,7 @@ real release we decided to skip this version number.
 
 3.3.0, released 2009-02-16
 ! Implement CSS property 'overflow' when %CSS.AllowTricky is true.
-! Implement generic property list classess
+! Implement generic property list classes
 - Fix bug with testEncodingSupportsASCII() algorithm when iconv() implementation
   does not do the "right thing" with characters not supported in the output
   set.
@@ -479,7 +479,7 @@ real release we decided to skip this version number.
 ! %Core.AggressivelyFixLt is on by default. This causes more sensible
   processing of left angled brackets in smileys and other whatnot.
 ! Test scripts now have a 'type' parameter, which lets you say 'htmlpurifier',
-  'phpt', 'vtest', etc. in order to only execute those tests. This supercedes
+  'phpt', 'vtest', etc. in order to only execute those tests. This supersedes
   the --only-phpt parameter, although for backwards-compatibility the flag
   will still work.
 ! AutoParagraph auto-formatter will now preserve double-newlines upon output.
@@ -530,7 +530,7 @@ real release we decided to skip this version number.
 . Added --quick option to multitest.php, which tests only the most recent
   release for each series.
 . Added --distro option to multitest.php, which accepts either 'normal' or
-  'standalone'. This supercedes --exclude-normal and --exclude-standalone
+  'standalone'. This supersedes --exclude-normal and --exclude-standalone
 
 3.1.1, released 2008-06-19
 # %URI.Munge now, by default, does not munge resources (for example, <img src="">)
@@ -680,7 +680,7 @@ real release we decided to skip this version number.
 # HTMLPurifier->addFilter is deprecated; built-in filters can now be
   enabled using %Filter.$filter_name or by setting your own filters using
   %Filter.Custom
-# Directive-level safety properties superceded in favor of module-level
+# Directive-level safety properties superseded in favor of module-level
   safety. Internal method HTMLModule->addElement() has changed, although
   the externally visible HTMLDefinition->addElement has *not* changed.
 ! Extra utility classes for testing and non-library operations can
@@ -726,7 +726,7 @@ real release we decided to skip this version number.
 . A couple of new historical maintenance scripts were added.
 . HTMLPurifier/HTMLModule/Tidy/XHTMLAndHTML4.php split into two files
 . tests/index.php can now be run from any directory.
-. HTMLPurifier_Token subclasses split into seperate files
+. HTMLPurifier_Token subclasses split into separate files
 . HTMLPURIFIER_PREFIX now is defined in Bootstrap.php, NOT HTMLPurifier.php
 . HTMLPURIFIER_PREFIX can now be defined outside of HTML Purifier
 . New --php=php flag added, allows PHP executable to be specified (command
@@ -792,7 +792,7 @@ real release we decided to skip this version number.
 - Fix warning emitted when a non-supported URI scheme is passed to the
   MakeAbsolute URIFilter, thanks NykO18 (again)
 - Further refine AutoParagraph injector. Behavior inside of elements
-  allowing paragraph tags clarified: only inline content delimeted by
+  allowing paragraph tags clarified: only inline content delimited by
   double newlines (not block elements) are paragraphed.
 - Buggy treatment of end tags of elements that have required attributes
   fixed (does not manifest on default tag-set)
@@ -838,7 +838,7 @@ real release we decided to skip this version number.
 ! CSS property border-spacing implemented
 - Fix non-visible parsing error in DirectLex with empty tags that have
   slashes inside attribute values.
-- Fix typo in CSS definition: border-collapse:seperate; was incorrectly
+- Fix typo in CSS definition: border-collapse:separate; was incorrectly
   accepted as valid CSS. Usually non-visible, because this styling is the
   default for tables in most browsers. Thanks Brett Zamir for pointing
   this out.
@@ -889,7 +889,7 @@ real release we decided to skip this version number.
 . HTMLPurifier_Config->getSerial() implemented, this is extremely useful
   for output cache invalidation
 . ConfigForm printer now can retrieve CSS and JS files as strings, in
-  case HTML Purifier's directory is not publically accessible
+  case HTML Purifier's directory is not publicly accessible
 . Introduce new text/itext configuration directive values: these represent
   longer strings that would be more appropriately edited with a textarea
 . Allow newlines to act as separators for lists, hashes, lookups and

--- a/TODO
+++ b/TODO
@@ -41,7 +41,7 @@ FUTURE VERSIONS
  - Config: Add examples to everything (make built-in which also automatically
    gives output)
  - Add "register" field to config schemas to eliminate dependence on
-   naming conventions (try to remember why we ultimately decided on tihs)
+   naming conventions (try to remember why we ultimately decided on this)
 
 5.0 release [HTML 5]
  # Swap out code to use html5lib tokenizer and tree-builder
@@ -112,7 +112,7 @@ Neat feature related
    Also, enable disabling of directionality
  ? Externalize inline CSS to promote clean HTML, proposed by Sander Tekelenburg
  ? Remove redundant tags, ex. <u><u>Underlined</u></u>. Implementation notes:
-    1. Analyzing which tags to remove duplicants
+    1. Analyzing which tags to remove duplicates
     2. Ensure attributes are merged into the parent tag
     3. Extend the tag exclusion system to specify whether or not the
     contents should be dropped or not (currently, there's code that could do

--- a/benchmarks/samples/Lexer/4.html
+++ b/benchmarks/samples/Lexer/4.html
@@ -392,7 +392,7 @@ Women practicing non-martial T'ai Chi in <a href="/wiki/Chinatown_%28Manhattan%2
 <li><a href="http://www.scheele.org/lee/tcclinks.html" class="external text" title="http://www.scheele.org/lee/tcclinks.html">Lee Scheele's Links to T'ai Chi Ch'uan Web Sites</a></li>
 <li><a href="http://news.bbc.co.uk/1/hi/health/3543907.stm" class="external text" title="http://news.bbc.co.uk/1/hi/health/3543907.stm">BBC article</a></li>
 <li><a href="http://www.acupuncturetoday.com/archives2004/jul/07taichi.html" class="external text" title="http://www.acupuncturetoday.com/archives2004/jul/07taichi.html">Tai Chi: Good for the Mind, Good for the Body</a></li>
-<li><a href="http://www.taichiunion.com/" class="external text" title="http://www.taichiunion.com/">Tai Chi Chuan Union for Great Britian: The largest collective of independent Tai Chi Chuan Instructors in the British Isles</a></li>
+<li><a href="http://www.taichiunion.com/" class="external text" title="http://www.taichiunion.com/">Tai Chi Chuan Union for Great Britain: The largest collective of independent Tai Chi Chuan Instructors in the British Isles</a></li>
 </ul>
 
 

--- a/docs/dev-config-naming.txt
+++ b/docs/dev-config-naming.txt
@@ -49,7 +49,7 @@ the properties:
     AllowedFrameTargets -> heavily <a> specific, but also used by <area>
         and <form>. Transitional DTD %FrameTarget, not present in strict,
         HTML5 calls them "browsing contexts"
-    Default*Image* -> as a default parameter, is almost entirely exlcusive
+    Default*Image* -> as a default parameter, is almost entirely exclusive
         to <img>
     EnableID -> global attribute
     Name.UseCDATA -> heavily <a> specific, but has heavy other usage by

--- a/docs/dev-progress.html
+++ b/docs/dev-progress.html
@@ -122,7 +122,7 @@ thead th {text-align:left;padding:0.1em;background-color:#EEE;}
 
 <tbody>
 <tr><th colspan="2">Table</th></tr>
-<tr class="impl-yes"><td>border-collapse</td><td>ENUM(collapse, seperate)</td></tr>
+<tr class="impl-yes"><td>border-collapse</td><td>ENUM(collapse, separate)</td></tr>
 <tr class="impl-yes"><td>border-space</td><td>MULTIPLE</td></tr>
 <tr class="impl-yes"><td>caption-side</td><td>ENUM(top, bottom)</td></tr>
 <tr class="feature"><td>empty-cells</td><td>ENUM(show, hide), No IE support makes this useless,

--- a/docs/enduser-tidy.html
+++ b/docs/enduser-tidy.html
@@ -163,7 +163,7 @@ smoketest</a>.</p>
 
 <p>So you want HTML Purifier to clean up your HTML, but you're not
 so happy about the br@clear implementation. That's perfectly fine!
-HTML Purifier will make accomodations:</p>
+HTML Purifier will make accommodations:</p>
 
 <pre>$config-&gt;set('HTML.Doctype', 'XHTML 1.0 Transitional');
 $config-&gt;set('HTML.TidyLevel', 'heavy'); // all changes, minus...

--- a/docs/proposal-filter-levels.txt
+++ b/docs/proposal-filter-levels.txt
@@ -60,7 +60,7 @@ These are special use tags, they should be enabled on a blanket basis.
 Lists - dd, dl, dt, li, ol, ul ~ menu, dir
 Tables - caption, table, td, th, tr / col, colgroup, tbody, tfoot, thead
 
-Forms - fieldset, form, input, lable, legend, optgroup, option, select, textarea
+Forms - fieldset, form, input, label, legend, optgroup, option, select, textarea
 XSS - noscript, object, script ~ applet
 Meta - base, basefont, body, head, html, link, meta, style, title
 Frames - frame, frameset, iframe
@@ -91,7 +91,7 @@ attribute and put URI filtering higher up on the priority list.
 
 == Attribute Risk Analysis ==
 
-We actually have a suprisingly small assortment of allowed attributes (the
+We actually have a surprisingly small assortment of allowed attributes (the
 rest are deprecated in strict, and thus we opted not to allow them, even
 though our output is XHTML Transitional by default.)
 

--- a/docs/proposal-plists.txt
+++ b/docs/proposal-plists.txt
@@ -70,7 +70,7 @@ Backfills/Data integrity:
 Type systems:
     - Flags: ReadOnly, Permanent, DontEnum
     - Typed properties isn't that useful [It's also Not-PHP]
-    - Seperate meta-list of directive properties IS useful
+    - Separate meta-list of directive properties IS useful
     - Duck typing is useful for systems designed fully around properties pattern
 
 Trade-off:

--- a/library/HTMLPurifier/AttrDef/CSS/FontFamily.php
+++ b/library/HTMLPurifier/AttrDef/CSS/FontFamily.php
@@ -195,7 +195,7 @@ class HTMLPurifier_AttrDef_CSS_FontFamily extends HTMLPurifier_AttrDef
             // transforms don't pose a security risk (as \\ and \"
             // might--these escapes are not supported by most browsers).
             // We could try to be clever and use single-quote wrapping
-            // when there is a double quote present, but I have choosen
+            // when there is a double quote present, but I have chosen
             // not to implement that.  (NOTE: you can reduce the amount
             // of escapes by one depending on what quoting style you use)
             // $font = str_replace('\\', '\\5C ', $font);

--- a/library/HTMLPurifier/AttrDef/URI/IPv6.php
+++ b/library/HTMLPurifier/AttrDef/URI/IPv6.php
@@ -37,7 +37,7 @@ class HTMLPurifier_AttrDef_URI_IPv6 extends HTMLPurifier_AttrDef_URI_IPv4
             }
         }
 
-        //      IPv4-compatiblity check
+        //      IPv4-compatibility check
         if (preg_match('#(?<=:' . ')' . $this->ip4 . '$#s', $aIP, $find)) {
             $aIP = substr($aIP, 0, 0 - strlen($find[0]));
             $ip = explode('.', $find[0]);

--- a/library/HTMLPurifier/AttrTransform/BdoDir.php
+++ b/library/HTMLPurifier/AttrTransform/BdoDir.php
@@ -3,7 +3,7 @@
 // this MUST be placed in post, as it assumes that any value in dir is valid
 
 /**
- * Post-trasnform that ensures that bdo tags have the dir attribute set.
+ * Post-transform that ensures that bdo tags have the dir attribute set.
  */
 class HTMLPurifier_AttrTransform_BdoDir extends HTMLPurifier_AttrTransform
 {

--- a/library/HTMLPurifier/AttrValidator.php
+++ b/library/HTMLPurifier/AttrValidator.php
@@ -135,7 +135,7 @@ class HTMLPurifier_AttrValidator
             // we'd also want slightly more complicated substitution
             // involving an array as the return value,
             // although we're not sure how colliding attributes would
-            // resolve (certain ones would be completely overriden,
+            // resolve (certain ones would be completely overridden,
             // others would prepend themselves).
         }
 

--- a/library/HTMLPurifier/Bootstrap.php
+++ b/library/HTMLPurifier/Bootstrap.php
@@ -5,7 +5,7 @@ if (!defined('HTMLPURIFIER_PREFIX')) {
     define('HTMLPURIFIER_PREFIX', realpath(dirname(__FILE__) . '/..'));
 }
 
-// accomodations for versions earlier than 5.0.2
+// accommodations for versions earlier than 5.0.2
 // borrowed from PHP_Compat, LGPL licensed, by Aidan Lister <aidan@php.net>
 if (!defined('PHP_EOL')) {
     switch (strtoupper(substr(PHP_OS, 0, 3))) {

--- a/library/HTMLPurifier/ConfigSchema/Interchange/Directive.php
+++ b/library/HTMLPurifier/ConfigSchema/Interchange/Directive.php
@@ -66,7 +66,7 @@ class HTMLPurifier_ConfigSchema_Interchange_Directive
     public $version;
 
     /**
-     * ID of directive that supercedes this old directive.
+     * ID of directive that supersedes this old directive.
      * Null if not deprecated.
      * @type HTMLPurifier_ConfigSchema_Interchange_Id
      */

--- a/library/HTMLPurifier/ConfigSchema/schema/Attr.IDPrefixLocal.txt
+++ b/library/HTMLPurifier/ConfigSchema/schema/Attr.IDPrefixLocal.txt
@@ -5,10 +5,10 @@ DEFAULT: ''
 --DESCRIPTION--
 Temporary prefix for IDs used in conjunction with %Attr.IDPrefix.  If you
 need to allow multiple sets of user content on web page, you may need to
-have a seperate prefix that changes with each iteration.  This way,
-seperately submitted user content displayed on the same page doesn't
+have a separate prefix that changes with each iteration.  This way,
+separately submitted user content displayed on the same page doesn't
 clobber each other. Ideal values are unique identifiers for the content it
 represents (i.e. the id of the row in the database). Be sure to add a
-seperator (like an underscore) at the end.  Warning: this directive will
+separator (like an underscore) at the end.  Warning: this directive will
 not work unless %Attr.IDPrefix is set to a non-empty value!
 --# vim: et sw=4 sts=4

--- a/library/HTMLPurifier/ConfigSchema/schema/Core.EscapeNonASCIICharacters.txt
+++ b/library/HTMLPurifier/ConfigSchema/schema/Core.EscapeNonASCIICharacters.txt
@@ -8,6 +8,6 @@ converting all non-ASCII characters into decimal numeric entities before
 converting it to its native encoding. This means that even characters that
 can be expressed in the non-UTF-8 encoding will be entity-ized, which can
 be a real downer for encodings like Big5. It also assumes that the ASCII
-repetoire is available, although this is the case for almost all encodings.
+repertoire is available, although this is the case for almost all encodings.
 Anyway, use UTF-8!
 --# vim: et sw=4 sts=4

--- a/library/HTMLPurifier/ConfigSchema/schema/Core.LexerImpl.txt
+++ b/library/HTMLPurifier/ConfigSchema/schema/Core.LexerImpl.txt
@@ -16,7 +16,7 @@ DEFAULT: NULL
   </dd>
   <dt><em>string</em> lexer identifier</dt>
   <dd>
-    This is a slim way of manually overridding the implementation.
+    This is a slim way of manually overriding the implementation.
     Currently recognized values are: DOMLex (the default PHP5
 implementation)
     and DirectLex (the default PHP4 implementation). Only use this if

--- a/library/HTMLPurifier/ConfigSchema/schema/Filter.ExtractStyleBlocks.txt
+++ b/library/HTMLPurifier/ConfigSchema/schema/Filter.ExtractStyleBlocks.txt
@@ -54,7 +54,7 @@ EXTERNAL: CSSTidy
   <div>
     <?php echo $html; ?>
   </div>
-</b]]><![CDATA[ody>
+</b]]><![CDATA[body>
 </html>
 ]]></pre>
 <p>

--- a/library/HTMLPurifier/EntityParser.php
+++ b/library/HTMLPurifier/EntityParser.php
@@ -5,7 +5,7 @@
 // $config or $context to the callback functions.
 
 /**
- * Handles referencing and derefencing character entities
+ * Handles referencing and dereferencing character entities
  */
 class HTMLPurifier_EntityParser
 {

--- a/library/HTMLPurifier/Filter.php
+++ b/library/HTMLPurifier/Filter.php
@@ -4,7 +4,7 @@
  * Represents a pre or post processing filter on HTML Purifier's output
  *
  * Sometimes, a little ad-hoc fixing of HTML has to be done before
- * it gets sent through HTML Purifier: you can use filters to acheive
+ * it gets sent through HTML Purifier: you can use filters to achieve
  * this effect. For instance, YouTube videos can be preserved using
  * this manner. You could have used a decorator for this task, but
  * PHP's support for them is not terribly robust, so we're going

--- a/library/HTMLPurifier/Generator.php
+++ b/library/HTMLPurifier/Generator.php
@@ -244,7 +244,7 @@ class HTMLPurifier_Generator
             // whitespace (in fact, most don't, at least for attributes
             // like alt, but an extra space at the end is barely
             // noticeable).  Still, we have a configuration knob for
-            // this, since this transformation is not necesary if you
+            // this, since this transformation is not necessary if you
             // don't process user input with innerHTML or you don't plan
             // on supporting Internet Explorer.
             if ($this->_innerHTMLFix) {

--- a/library/HTMLPurifier/HTMLModule/Edit.php
+++ b/library/HTMLPurifier/HTMLModule/Edit.php
@@ -28,7 +28,7 @@ class HTMLPurifier_HTMLModule_Edit extends HTMLPurifier_HTMLModule
 
     // HTML 4.01 specifies that ins/del must not contain block
     // elements when used in an inline context, chameleon is
-    // a complicated workaround to acheive this effect
+    // a complicated workaround to achieve this effect
 
     // Inline context ! Block context (exclamation mark is
     // separator, see getChildDef for parsing)

--- a/library/HTMLPurifier/HTMLModule/Ruby.php
+++ b/library/HTMLPurifier/HTMLModule/Ruby.php
@@ -2,7 +2,7 @@
 
 /**
  * XHTML 1.1 Ruby Annotation Module, defines elements that indicate
- * short runs of text alongside base text for annotation or pronounciation.
+ * short runs of text alongside base text for annotation or pronunciation.
  */
 class HTMLPurifier_HTMLModule_Ruby extends HTMLPurifier_HTMLModule
 {

--- a/library/HTMLPurifier/HTMLModule/Tidy/Name.php
+++ b/library/HTMLPurifier/HTMLModule/Tidy/Name.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Name is deprecated, but allowed in strict doctypes, so onl
+ * Name is deprecated, but allowed in strict doctypes, so only
  */
 class HTMLPurifier_HTMLModule_Tidy_Name extends HTMLPurifier_HTMLModule_Tidy
 {

--- a/library/HTMLPurifier/Lexer/PH5P.php
+++ b/library/HTMLPurifier/Lexer/PH5P.php
@@ -463,7 +463,7 @@ class HTML5
         $this->data = $data;
         $this->char = -1;
         $this->EOF = strlen($data);
-        $this->tree = new HTML5TreeConstructer;
+        $this->tree = new HTML5TreeConstructor;
         $this->content_model = self::PCDATA;
 
         $this->state = 'data';
@@ -1223,7 +1223,7 @@ class HTML5
                 'type' => self::COMMENT
             );
 
-            /* Otherwise if the next seven chacacters are a case-insensitive match
+            /* Otherwise if the next seven characters are a case-insensitive match
             for the word "DOCTYPE", then consume those characters and switch to the
             DOCTYPE state. */
         } elseif (strtolower($this->character($this->char + 1, 7)) === 'doctype') {
@@ -1574,7 +1574,7 @@ class HTML5
     }
 }
 
-class HTML5TreeConstructer
+class HTML5TreeConstructor
 {
     public $stack = array();
 
@@ -1674,6 +1674,8 @@ class HTML5TreeConstructer
     const END_PHASE = 3;
 
     // The different insertion modes for the main phase.
+    const BEFORE_HEAD = 0;
+    // For backward compatibility.
     const BEFOR_HEAD = 0;
     const IN_HEAD = 1;
     const AFTER_HEAD = 2;
@@ -1700,7 +1702,7 @@ class HTML5TreeConstructer
     public function __construct()
     {
         $this->phase = self::INIT_PHASE;
-        $this->mode = self::BEFOR_HEAD;
+        $this->mode = self::BEFORE_HEAD;
         $this->dom = new DOMDocument;
 
         $this->dom->encoding = 'UTF-8';
@@ -1865,7 +1867,7 @@ class HTML5TreeConstructer
         } else {
             /* Depends on the insertion mode: */
             switch ($this->mode) {
-                case self::BEFOR_HEAD:
+                case self::BEFORE_HEAD:
                     return $this->beforeHead($token);
                     break;
                 case self::IN_HEAD:
@@ -4749,7 +4751,7 @@ class HTML5TreeConstructer
                 case, abort these steps. (innerHTML case) */
             } elseif ($node->nodeName === 'html') {
                 $this->mode = ($this->head_pointer === null)
-                    ? self::BEFOR_HEAD
+                    ? self::BEFORE_HEAD
                     : self::AFTER_HEAD;
 
                 break;

--- a/library/HTMLPurifier/Lexer/PH5P.php
+++ b/library/HTMLPurifier/Lexer/PH5P.php
@@ -1574,7 +1574,15 @@ class HTML5
     }
 }
 
-class HTML5TreeConstructor
+class HTML5TreeConstructor extends HTML5TreeConstructer
+{}
+
+/**
+ * @deprecated Use HTML5TreeConstructor instead
+ *
+ * @todo Remove with version 5
+ */
+class HTML5TreeConstructer
 {
     public $stack = array();
 

--- a/library/HTMLPurifier/Strategy/FixNesting.php
+++ b/library/HTMLPurifier/Strategy/FixNesting.php
@@ -20,7 +20,7 @@
  * The second objective is to ensure that explicitly excluded elements of
  * an element do not appear in its children.  Code that accomplishes this
  * task is pervasive through the strategy, though the two are distinct tasks
- * and could, theoretically, be seperated (although it's not recommended).
+ * and could, theoretically, be separated (although it's not recommended).
  *
  * @note Whether or not unrecognized children are silently dropped or
  *       translated into text depends on the child definitions.

--- a/library/HTMLPurifier/Strategy/MakeWellFormed.php
+++ b/library/HTMLPurifier/Strategy/MakeWellFormed.php
@@ -641,7 +641,7 @@ class HTMLPurifier_Strategy_MakeWellFormed extends HTMLPurifier_Strategy
 //    Needless to say, we need to UN-skip the token so it gets
 //    reprocessed.
 //
-//  - Suppose that you successfuly process a token, replace it with
+//  - Suppose that you successfully process a token, replace it with
 //    one with your skip mark, but now another injector wants to
 //    process the skipped token with another token.  Should you continue
 //    to skip that new token, or reprocess it?  If you reprocess,

--- a/library/HTMLPurifier/URIFilter/Munge.php
+++ b/library/HTMLPurifier/URIFilter/Munge.php
@@ -71,7 +71,7 @@ class HTMLPurifier_URIFilter_Munge extends HTMLPurifier_URIFilter
         } // ignore unknown schemes, maybe another postfilter did it
         if (!$scheme_obj->browsable) {
             return true;
-        } // ignore non-browseable schemes, since we can't munge those in a reasonable way
+        } // ignore non-browsable schemes, since we can't munge those in a reasonable way
         if ($uri->isBenign($config, $context)) {
             return true;
         } // don't redirect if a benign URL

--- a/library/HTMLPurifier/URIParser.php
+++ b/library/HTMLPurifier/URIParser.php
@@ -29,7 +29,7 @@ class HTMLPurifier_URIParser
 
         // Regexp is as per Appendix B.
         // Note that ["<>] are an addition to the RFC's recommended
-        // characters, because they represent external delimeters.
+        // characters, because they represent external delimiters.
         $r_URI = '!'.
             '(([a-zA-Z0-9\.\+\-]+):)?'. // 2. Scheme
             '(//([^/?#"<>]*))?'. // 4. Authority
@@ -43,7 +43,7 @@ class HTMLPurifier_URIParser
 
         if (!$result) return false; // *really* invalid URI
 
-        // seperate out parts
+        // separate out parts
         $scheme     = !empty($matches[1]) ? $matches[2] : null;
         $authority  = !empty($matches[3]) ? $matches[4] : null;
         $path       = $matches[5]; // always present, can be empty

--- a/maintenance/PH5P.php
+++ b/maintenance/PH5P.php
@@ -72,7 +72,7 @@ class HTML5
         $this->data = $data;
         $this->char = -1;
         $this->EOF  = strlen($data);
-        $this->tree = new HTML5TreeConstructer;
+        $this->tree = new HTML5TreeConstructor;
         $this->content_model = self::PCDATA;
 
         $this->state = 'data';
@@ -800,7 +800,7 @@ class HTML5
                 'type' => self::COMMENT
             );
 
-        /* Otherwise if the next seven chacacters are a case-insensitive match
+        /* Otherwise if the next seven characters are a case-insensitive match
         for the word "DOCTYPE", then consume those characters and switch to the
         DOCTYPE state. */
         } elseif(strtolower($this->character($this->char + 1, 7)) === 'doctype') {
@@ -1139,7 +1139,7 @@ class HTML5
     }
 }
 
-class HTML5TreeConstructer
+class HTML5TreeConstructor
 {
     public $stack = array();
 
@@ -1169,20 +1169,21 @@ class HTML5TreeConstructer
     const END_PHASE  = 3;
 
     // The different insertion modes for the main phase.
-    const BEFOR_HEAD = 0;
-    const IN_HEAD    = 1;
-    const AFTER_HEAD = 2;
-    const IN_BODY    = 3;
-    const IN_TABLE   = 4;
-    const IN_CAPTION = 5;
-    const IN_CGROUP  = 6;
-    const IN_TBODY   = 7;
-    const IN_ROW     = 8;
-    const IN_CELL    = 9;
-    const IN_SELECT  = 10;
-    const AFTER_BODY = 11;
-    const IN_FRAME   = 12;
-    const AFTR_FRAME = 13;
+    const BEFORE_HEAD = 0;
+    const BEFOR_HEAD  = 0;
+    const IN_HEAD     = 1;
+    const AFTER_HEAD  = 2;
+    const IN_BODY     = 3;
+    const IN_TABLE    = 4;
+    const IN_CAPTION  = 5;
+    const IN_CGROUP   = 6;
+    const IN_TBODY    = 7;
+    const IN_ROW      = 8;
+    const IN_CELL     = 9;
+    const IN_SELECT   = 10;
+    const AFTER_BODY  = 11;
+    const IN_FRAME    = 12;
+    const AFTR_FRAME  = 13;
 
     // The different types of elements.
     const SPECIAL    = 0;
@@ -1195,7 +1196,7 @@ class HTML5TreeConstructer
     public function __construct()
     {
         $this->phase = self::INIT_PHASE;
-        $this->mode = self::BEFOR_HEAD;
+        $this->mode = self::BEFORE_HEAD;
         $this->dom = new DOMDocument;
 
         $this->dom->encoding = 'UTF-8';
@@ -1346,7 +1347,7 @@ class HTML5TreeConstructer
         } else {
             /* Depends on the insertion mode: */
             switch($this->mode) {
-                case self::BEFOR_HEAD: return $this->beforeHead($token); break;
+                case self::BEFORE_HEAD: return $this->beforeHead($token); break;
                 case self::IN_HEAD:    return $this->inHead($token); break;
                 case self::AFTER_HEAD: return $this->afterHead($token); break;
                 case self::IN_BODY:    return $this->inBody($token); break;
@@ -3852,7 +3853,7 @@ class HTML5TreeConstructer
             case, abort these steps. (innerHTML case) */
             } elseif($node->nodeName === 'html') {
                 $this->mode = ($this->head_pointer === null)
-                    ? self::BEFOR_HEAD
+                    ? self::BEFORE_HEAD
                     : self::AFTER_HEAD;
 
                 break;

--- a/maintenance/PH5P.php
+++ b/maintenance/PH5P.php
@@ -1139,7 +1139,14 @@ class HTML5
     }
 }
 
-class HTML5TreeConstructor
+class HTML5TreeConstructor extends HTML5TreeConstructer
+{}
+
+/**
+ * @deprecated Use HTML5TreeConstructor instead
+ * @todo Remove with version 5
+ */
+class HTML5TreeConstructer
 {
     public $stack = array();
 

--- a/plugins/phorum/settings.php
+++ b/plugins/phorum/settings.php
@@ -14,7 +14,7 @@ if(!defined("PHORUM_ADMIN")) exit;
 // error reporting is good!
 error_reporting(E_ALL ^ E_NOTICE);
 
-// load library and other paraphenalia
+// load library and other paraphernalia
 require_once './include/admin/PhorumInputForm.php';
 require_once (dirname(__FILE__) . '/htmlpurifier/HTMLPurifier.auto.php');
 require_once (dirname(__FILE__) . '/init-config.php');

--- a/smoketests/xssAttacks.php
+++ b/smoketests/xssAttacks.php
@@ -36,7 +36,7 @@ function formatCode($string)
 <p>XSS attacks are from
 <a href="http://ha.ckers.org/xss.html">http://ha.ckers.org/xss.html</a>.</p>
 <p><strong>Caveats:</strong>
-<tt>Google.com</tt> has been programatically disallowed, but as you can
+<tt>Google.com</tt> has been programmatically disallowed, but as you can
 see, there are ways of getting around that, so coverage in this area
 is not complete. Most XSS broadcasts its presence by spawning an alert dialogue.
 The displayed code is not strictly correct, as linebreaks have been forced for
@@ -50,7 +50,7 @@ if (version_compare(PHP_VERSION, '5', '<')) exit('<p>Requires PHP 5.</p>');
 
 $xml = simplexml_load_file('xssAttacks.xml');
 
-// programatically disallow google.com for URI evasion tests
+// programmatically disallow google.com for URI evasion tests
 // not complete
 $config = HTMLPurifier_Config::createDefault();
 $config->set('URI.HostBlacklist', array('google.com'));

--- a/smoketests/xssAttacks.xml
+++ b/smoketests/xssAttacks.xml
@@ -864,7 +864,7 @@ As a side note, this was also effective against a real world XSS filter I came a
 	<attack>
 		<name>Extraneous Open Brackets</name>
 		<code>&lt;&lt;SCRIPT&gt;alert(&quot;XSS&quot;);//&lt;&lt;/SCRIPT&gt;</code>
-		<desc>(Submitted by Franz Sedlmaier http://www.pilorz.net/).  This XSS vector could defeat certain detection engines that work by first using matching pairs of open and close angle brackets and then by doing a comparison of the tag inside, instead of a more efficient algorythm like Boyer-Moore (http://www.cs.utexas.edu/users/moore/best-ideas/string-searching/) that looks for entire string matches of the open angle bracket and associated tag (post de-obfuscation, of course).  The double slash comments out the ending extraneous bracket to supress a JavaScript error.</desc>
+		<desc>(Submitted by Franz Sedlmaier http://www.pilorz.net/).  This XSS vector could defeat certain detection engines that work by first using matching pairs of open and close angle brackets and then by doing a comparison of the tag inside, instead of a more efficient algorithm like Boyer-Moore (http://www.cs.utexas.edu/users/moore/best-ideas/string-searching/) that looks for entire string matches of the open angle bracket and associated tag (post de-obfuscation, of course).  The double slash comments out the ending extraneous bracket to suppress a JavaScript error.</desc>
 
 		<label>Embedded Character Attacks</label>
 		<browser>Browser support: [&lt;span class=&quot;s&quot;&gt;IE6.0&lt;/span&gt;|&lt;span class=&quot;s&quot;&gt;NS8.1-IE&lt;/span&gt;] [&lt;span class=&quot;s&quot;&gt;NS8.1-G&lt;/span&gt;|&lt;span class=&quot;s&quot;&gt;FF1.5&lt;/span&gt;] [&lt;span class=&quot;s&quot;&gt;O8.54&lt;/span&gt;]</browser>
@@ -940,7 +940,7 @@ alert(a.source)&lt;/SCRIPT&gt;</code>
 
 -onCut() (user needs to copy something or it can be exploited using the execCommand(&quot;Cut&quot;) command)
 
--onDataAvailible() (user would need to change data in an element, or attacker could perform the same function)
+-onDataAvailable() (user would need to change data in an element, or attacker could perform the same function)
 
 -onDataSetChanged() (fires when the data set exposed by a data source object changes)
 

--- a/tests/HTMLPurifier/AttrCollectionsTest.php
+++ b/tests/HTMLPurifier/AttrCollectionsTest.php
@@ -34,12 +34,12 @@ class HTMLPurifier_AttrCollectionsTest extends HTMLPurifier_Harness
         $modules['Module2'] = new HTMLPurifier_HTMLModule();
         $modules['Module2']->attr_collections = array(
             'Core' => array(
-                0 => array('Brocolli')
+                0 => array('Broccoli')
             ),
             'Soup' => array(
                 'attribute-3' => 'Type3'
             ),
-            'Brocolli' => array()
+            'Broccoli' => array()
         );
 
         $collections->doConstruct($types, $modules);
@@ -48,14 +48,14 @@ class HTMLPurifier_AttrCollectionsTest extends HTMLPurifier_Harness
             $collections->info,
             array(
                 'Core' => array(
-                    0 => array('Soup', 'Undefined', 'Brocolli'),
+                    0 => array('Soup', 'Undefined', 'Broccoli'),
                     'attribute' => 'Type',
                     'attribute-2' => 'Type2'
                 ),
                 'Soup' => array(
                     'attribute-3' => 'Type3'
                 ),
-                'Brocolli' => array()
+                'Broccoli' => array()
             )
         );
 

--- a/tests/HTMLPurifier/ChildDef/StrictBlockquoteTest.php
+++ b/tests/HTMLPurifier/ChildDef/StrictBlockquoteTest.php
@@ -59,7 +59,7 @@ extends HTMLPurifier_ChildDefHarness
         );
     }
 
-    public function testWrapComplicatedSring()
+    public function testWrapComplicatedString()
     {
         $this->assertResult(
             $var = 'He said<br />perhaps<br />we should <b>nuke</b> them.',

--- a/tests/HTMLPurifier/ConfigTest.php
+++ b/tests/HTMLPurifier/ConfigTest.php
@@ -184,7 +184,7 @@ class HTMLPurifier_ConfigTest extends HTMLPurifier_Harness
             )
         );
 
-        // grab a non-existant namespace
+        // grab a non-existent namespace
         $this->expectError('Cannot retrieve undefined namespace Constants');
         $config->getBatch('Constants');
 

--- a/tests/HTMLPurifier/Injector/AutoParagraphTest.php
+++ b/tests/HTMLPurifier/Injector/AutoParagraphTest.php
@@ -331,7 +331,7 @@ Par1
         );
     }
 
-    public function testBlockNodeTextDelimeterInBlockNode()
+    public function testBlockNodeTextDelimiterInBlockNode()
     {
         $this->assertResult(
 '<div>Par1
@@ -343,7 +343,7 @@ Par1
         );
     }
 
-    public function testBlockNodeTextDelimeterWithoutDoublespaceInBlockNode()
+    public function testBlockNodeTextDelimiterWithoutDoublespaceInBlockNode()
     {
         $this->assertResult(
 '<div>Par1
@@ -351,7 +351,7 @@ Par1
         );
     }
 
-    public function testBlockNodeTextDelimeterWithoutDoublespace()
+    public function testBlockNodeTextDelimiterWithoutDoublespace()
     {
         $this->assertResult(
 'Par1

--- a/tests/HTMLPurifier/Injector/PurifierLinkifyTest.php
+++ b/tests/HTMLPurifier/Injector/PurifierLinkifyTest.php
@@ -10,7 +10,7 @@ class HTMLPurifier_Injector_PurifierLinkifyTest extends HTMLPurifier_InjectorHar
         $this->config->set('AutoFormat.PurifierLinkify.DocURL', '#%s');
     }
 
-    public function testNoTriggerCharacer()
+    public function testNoTriggerCharacter()
     {
         $this->assertResult('Foobar');
     }

--- a/tests/HTMLPurifier/LexerTest.php
+++ b/tests/HTMLPurifier/LexerTest.php
@@ -651,7 +651,7 @@ class HTMLPurifier_LexerTest extends HTMLPurifier_Harness
             return;
         } elseif (LIBXML_VERSION < 20628) {
             // libxml's behavior is wrong prior to this version, so make
-            // appropriate accomodations
+            // appropriate accommodations
             $extra['DOMLex'] = $extra['DirectLex'];
         }
         $this->assertTokenization(

--- a/tests/HTMLPurifier/PercentEncoderTest.php
+++ b/tests/HTMLPurifier/PercentEncoderTest.php
@@ -29,7 +29,7 @@ class HTMLPurifier_PercentEncoderTest extends HTMLPurifier_Harness
         $this->assertDecode('%2B2B%3A3A'); // extra text
         $this->assertDecode('%2b2B%4141', '%2B2BA41'); // extra text, with normalization
         $this->assertDecode('%', '%25'); // normalize stray percent sign
-        $this->assertDecode('%5%25', '%255%25'); // permaturely terminated encoding
+        $this->assertDecode('%5%25', '%255%25'); // prematurely terminated encoding
         $this->assertDecode('%GJ', '%25GJ'); // invalid hexadecimal chars
 
         // contested behavior, if this changes, we'll also have to have

--- a/tests/HTMLPurifier/Strategy/MakeWellFormedTest.php
+++ b/tests/HTMLPurifier/Strategy/MakeWellFormedTest.php
@@ -157,7 +157,7 @@ class HTMLPurifier_Strategy_MakeWellFormedTest extends HTMLPurifier_StrategyHarn
         );
     }
 
-    public function testNoAutocloseIfNoParentsCanAccomodateTag()
+    public function testNoAutocloseIfNoParentsCanAccommodateTag()
     {
         $this->assertResult(
             '<table><tr><td><li>foo</li></td></tr></table>',

--- a/tests/HTMLPurifier/TagTransformTest.php
+++ b/tests/HTMLPurifier/TagTransformTest.php
@@ -1,6 +1,6 @@
 <?php
 
-// needs to be seperated into files
+// needs to be separated into files
 class HTMLPurifier_TagTransformTest extends HTMLPurifier_Harness
 {
 

--- a/tests/index.php
+++ b/tests/index.php
@@ -101,7 +101,7 @@ if (!SimpleReporter::inCli()) {
 }
 
 // initialize and load HTML Purifier
-// use ?standalone to load the alterative standalone stub
+// use ?standalone to load the alternative standalone stub
 if ($AC['standalone']) {
     require '../library/HTMLPurifier.standalone.php';
 } else {


### PR DESCRIPTION
Found some misspellings.

The `HTML5TreeConstructer` class has been renamed.
