### PR TITLE
feat: Allow universal CSS values for all properties

### DIFF
--- a/library/HTMLPurifier/AttrDef/CSS.php
+++ b/library/HTMLPurifier/AttrDef/CSS.php
@@ -27,6 +27,13 @@ class HTMLPurifier_AttrDef_CSS extends HTMLPurifier_AttrDef
         $definition = $config->getCSSDefinition();
         $allow_duplicates = $config->get("CSS.AllowDuplicates");
 
+        $universal_attrdef = new HTMLPurifier_AttrDef_Enum(
+            array(
+                'initial',
+                'inherit',
+                'unset',
+            )
+        );
 
         // According to the CSS2.1 spec, the places where a
         // non-delimiting semicolon can appear are in strings
@@ -96,16 +103,13 @@ class HTMLPurifier_AttrDef_CSS extends HTMLPurifier_AttrDef
             if (!$ok) {
                 continue;
             }
-            // inefficient call, since the validator will do this again
-            if (strtolower(trim($value)) !== 'inherit') {
-                // inherit works for everything (but only on the base property)
+            $result = $universal_attrdef->validate($value, $config, $context);
+            if ($result === false) {
                 $result = $definition->info[$property]->validate(
                     $value,
                     $config,
                     $context
                 );
-            } else {
-                $result = 'inherit';
             }
             if ($result === false) {
                 continue;

--- a/library/HTMLPurifier/CSSDefinition.php
+++ b/library/HTMLPurifier/CSSDefinition.php
@@ -116,8 +116,6 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
                         'auto',
                         'cover',
                         'contain',
-                        'initial',
-                        'inherit',
                     ]
                 ),
                 new HTMLPurifier_AttrDef_CSS_Percentage(),
@@ -236,21 +234,20 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
             [
                 new HTMLPurifier_AttrDef_CSS_Length('0'),
                 new HTMLPurifier_AttrDef_CSS_Percentage(true),
-                new HTMLPurifier_AttrDef_Enum(['auto', 'initial', 'inherit'])
+                new HTMLPurifier_AttrDef_Enum(['auto'])
             ]
         );
         $trusted_min_wh = new HTMLPurifier_AttrDef_CSS_Composite(
             [
                 new HTMLPurifier_AttrDef_CSS_Length('0'),
                 new HTMLPurifier_AttrDef_CSS_Percentage(true),
-                new HTMLPurifier_AttrDef_Enum(['initial', 'inherit'])
             ]
         );
         $trusted_max_wh = new HTMLPurifier_AttrDef_CSS_Composite(
             [
                 new HTMLPurifier_AttrDef_CSS_Length('0'),
                 new HTMLPurifier_AttrDef_CSS_Percentage(true),
-                new HTMLPurifier_AttrDef_Enum(['none', 'initial', 'inherit'])
+                new HTMLPurifier_AttrDef_Enum(['none'])
             ]
         );
         $max = $config->get('CSS.MaxImgLength');
@@ -278,12 +275,7 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
                 new HTMLPurifier_AttrDef_Switch(
                     'img',
                     // For img tags:
-                    new HTMLPurifier_AttrDef_CSS_Composite(
-                        [
-                            new HTMLPurifier_AttrDef_CSS_Length('0', $max),
-                            new HTMLPurifier_AttrDef_Enum(['initial', 'inherit'])
-                        ]
-                    ),
+                    new HTMLPurifier_AttrDef_CSS_Length('0', $max),
                     // For everyone else:
                     $trusted_min_wh
                 );
@@ -297,7 +289,7 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
                     new HTMLPurifier_AttrDef_CSS_Composite(
                         [
                             new HTMLPurifier_AttrDef_CSS_Length('0', $max),
-                            new HTMLPurifier_AttrDef_Enum(['none', 'initial', 'inherit'])
+                            new HTMLPurifier_AttrDef_Enum(['none'])
                         ]
                     ),
                     // For everyone else:
@@ -315,11 +307,11 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
         $this->info['text-decoration'] = new HTMLPurifier_AttrDef_CSS_TextDecoration();
 
         $this->info['text-decoration-line'] = new HTMLPurifier_AttrDef_Enum(
-            ['none', 'underline', 'overline', 'line-through', 'initial', 'inherit']
+            ['none', 'underline', 'overline', 'line-through']
         );
 
         $this->info['text-decoration-style'] = new HTMLPurifier_AttrDef_Enum(
-            ['solid', 'double', 'dotted', 'dashed', 'wavy', 'initial', 'inherit']
+            ['solid', 'double', 'dotted', 'dashed', 'wavy']
         );
 
         $this->info['text-decoration-color'] = new HTMLPurifier_AttrDef_CSS_Color();
@@ -327,7 +319,7 @@ class HTMLPurifier_CSSDefinition extends HTMLPurifier_Definition
         $this->info['text-decoration-thickness'] = new HTMLPurifier_AttrDef_CSS_Composite([
             new HTMLPurifier_AttrDef_CSS_Length(),
             new HTMLPurifier_AttrDef_CSS_Percentage(),
-            new HTMLPurifier_AttrDef_Enum(['auto', 'from-font', 'initial', 'inherit'])
+            new HTMLPurifier_AttrDef_Enum(['auto', 'from-font'])
         ]);
 
         $this->info['font-family'] = new HTMLPurifier_AttrDef_CSS_FontFamily();

--- a/library/HTMLPurifier/Filter/ExtractStyleBlocks.php
+++ b/library/HTMLPurifier/Filter/ExtractStyleBlocks.php
@@ -54,6 +54,11 @@ class HTMLPurifier_Filter_ExtractStyleBlocks extends HTMLPurifier_Filter
      */
     private $_enum_attrdef;
 
+    /**
+     * @type HTMLPurifier_AttrDef_Enum
+     */
+    private $_universal_attrdef;
+
     public function __construct()
     {
         $this->_tidy = new csstidy();
@@ -68,6 +73,13 @@ class HTMLPurifier_Filter_ExtractStyleBlocks extends HTMLPurifier_Filter
                 'active',
                 'hover',
                 'focus'
+            )
+        );
+        $this->_universal_attrdef = new HTMLPurifier_AttrDef_Enum(
+            array(
+                'initial',
+                'inherit',
+                'unset',
             )
         );
     }
@@ -305,6 +317,11 @@ class HTMLPurifier_Filter_ExtractStyleBlocks extends HTMLPurifier_Filter
                     foreach ($style as $name => $value) {
                         if (!isset($css_definition->info[$name])) {
                             unset($style[$name]);
+                            continue;
+                        }
+                        $uni_ret = $this->_universal_attrdef->validate($value, $config, $context);
+                        if ($uni_ret !== false) {
+                            $style[$name] = $uni_ret;
                             continue;
                         }
                         $def = $css_definition->info[$name];

--- a/tests/HTMLPurifier/AttrDef/CSSTest.php
+++ b/tests/HTMLPurifier/AttrDef/CSSTest.php
@@ -120,8 +120,10 @@ class HTMLPurifier_AttrDef_CSSTest extends HTMLPurifier_AttrDefHarness
         $this->assertDef('text-transform:capitalize;destroy:it;',
                          'text-transform:capitalize;');
 
-        // inherit works for everything
+        // universal values work for everything
         $this->assertDef('text-align:inherit;');
+        $this->assertDef('text-align:initial;');
+        $this->assertDef('text-align:unset;');
 
         // bad props
         $this->assertDef('nodice:foobar;', false);

--- a/tests/HTMLPurifier/Filter/ExtractStyleBlocksTest.php
+++ b/tests/HTMLPurifier/Filter/ExtractStyleBlocksTest.php
@@ -88,6 +88,13 @@ class HTMLPurifier_Filter_ExtractStyleBlocksTest extends HTMLPurifier_Harness
         $this->assertCleanCSS("a .foo #id div.cl#foo {\nfont-weight:700\n}");
     }
 
+    public function test_cleanCSS_universals()
+    {
+        $this->assertCleanCSS("a {\nfont-weight:inherit\n}");
+        $this->assertCleanCSS("a {\nfont-weight:initial\n}");
+        $this->assertCleanCSS("a {\nfont-weight:unset\n}");
+    }
+
     public function test_cleanCSS_angledBrackets()
     {
         // [Content] No longer can smuggle in angled brackets using


### PR DESCRIPTION
Support for the universal or "CSS-wide" property values (`initial`, `inherit`, and `unset`, see https://www.w3.org/TR/css-values/#common-keywords) is mixed at the moment.

Several properties manually are defined to allow `initial` and `inherit`, currently:
- background-size
- width
- height
- max-width
- max-height
- min-width
- min-height
- text-decoration-line
- text-decoration-style
- text-decoration-thickness

Separately, `inherit` is allowed for _every_ property, but only in the `style` attribute, not in an extracted style block (the code that does this is only in the CSS AttrDef).

This PR removes the special case in AttrDef_CSS and the explicit enum definitions in the CSSDefinition, and replaces both with checks in AttrDef_CSS and Filter_ExtractStyleBlocks against an enum of `initial`, `inherit`, and `unset`, making all three values allowed for all defined properties in both the attribute and block contexts.

`unset`, which hasn't previously been allowed here, is comparable to `initial` and `inherit`: for properties that inherit by default, it acts as `inherit`, for those that don't, it acts as `initial`. 