### PR TITLE
feat: Add allowfullscreen attr for iframe

### DIFF
--- a/library/HTMLPurifier/HTMLModule/Iframe.php
+++ b/library/HTMLPurifier/HTMLModule/Iframe.php
@@ -28,22 +28,28 @@ class HTMLPurifier_HTMLModule_Iframe extends HTMLPurifier_HTMLModule
         if ($config->get('HTML.SafeIframe')) {
             $this->safe = true;
         }
+        $attrs = array(
+            'src' => 'URI#embedded',
+            'width' => 'Length',
+            'height' => 'Length',
+            'name' => 'ID',
+            'scrolling' => 'Enum#yes,no,auto',
+            'frameborder' => 'Enum#0,1',
+            'longdesc' => 'URI',
+            'marginheight' => 'Pixels',
+            'marginwidth' => 'Pixels',
+        );
+
+        if ($config->get('HTML.Trusted')) {
+            $attrs['allowfullscreen'] = 'Bool#allowfullscreen';
+        }
+
         $this->addElement(
             'iframe',
             'Inline',
             'Flow',
             'Common',
-            array(
-                'src' => 'URI#embedded',
-                'width' => 'Length',
-                'height' => 'Length',
-                'name' => 'ID',
-                'scrolling' => 'Enum#yes,no,auto',
-                'frameborder' => 'Enum#0,1',
-                'longdesc' => 'URI',
-                'marginheight' => 'Pixels',
-                'marginwidth' => 'Pixels',
-            )
+            $attrs
         );
     }
 }

--- a/tests/HTMLPurifier/HTMLT/safe-iframe-youtube-allowfullscreen.htmlt
+++ b/tests/HTMLPurifier/HTMLT/safe-iframe-youtube-allowfullscreen.htmlt
@@ -1,0 +1,9 @@
+--INI--
+HTML.SafeIframe = true
+HTML.Trusted = true
+URI.SafeIframeRegexp = "%^http://www.youtube.com/embed/%"
+--HTML--
+<iframe title="YouTube video player" width="480" height="390" src="http://www.youtube.com/embed/RVtEQxH7PWA" frameborder="0" allowfullscreen></iframe>
+--EXPECT--
+<iframe title="YouTube video player" width="480" height="390" src="http://www.youtube.com/embed/RVtEQxH7PWA" frameborder="0" allowfullscreen="allowfullscreen"></iframe>
+--# vim: et sw=4 sts=4


### PR DESCRIPTION
(closes #409)

This PR adds support for the [allowfullscreen attribute for the iframe element](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-allowfullscreen). The attribute is only allowed when the HTML.Trusted configuration option is enabled.