### PR TITLE
fix: Avoid a deprecated error when the attribute name is numeric and DirectLex is used

### DIFF
--- a/library/HTMLPurifier/Token/Tag.php
+++ b/library/HTMLPurifier/Token/Tag.php
@@ -44,7 +44,7 @@ abstract class HTMLPurifier_Token_Tag extends HTMLPurifier_Token
         $this->name = ctype_lower($name) ? $name : strtolower($name);
         foreach ($attr as $key => $value) {
             // normalization only necessary when key is not lowercase
-            if (!ctype_lower($key)) {
+            if (!ctype_lower((string)$key)) {
                 $new_key = strtolower($key);
                 if (!isset($attr[$new_key])) {
                     $attr[$new_key] = $attr[$key];

--- a/tests/HTMLPurifier/HTMLDefinitionTest.php
+++ b/tests/HTMLPurifier/HTMLDefinitionTest.php
@@ -222,6 +222,17 @@ a[href|title]
         $this->assertPurification_AllowedAttributes_local_p_style();
     }
 
+    public function test_AllowedAttributes_invalidAttributeDueToConsistingOfNumbers_UsingDirectLex()
+    {
+        $this->config->set('HTML.AllowedElements', array('a'));
+        $this->config->set('HTML.AllowedAttributes', 'href');
+        $this->config->set('Core.LexerImpl', 'DirectLex');
+        $this->assertPurification(
+            '<a href="https://example.com/" 10="hoge">Test</a>',
+            '<a href="https://example.com/">Test</a>'
+        );
+    }
+
     public function test_ForbiddenElements()
     {
         $this->config->set('HTML.ForbiddenElements', 'b');


### PR DESCRIPTION
I have created a pull request for #393.
Issue #393 had shown a case where a deprecated error occurs using PHP 8.1 or later.
This PR avoids that error.


[Example]
Contents of "test-393.php"
```
<?php
require_once './htmlpurifier/library/HTMLPurifier.auto.php';
$config = HTMLPurifier_Config::createDefault();
$purifier = new HTMLPurifier($config);
$config->set('HTML.AllowedElements', ['a']);
$config->set('HTML.AllowedAttributes', ['href']);
$config->set('Core.LexerImpl', 'DirectLex');
$clean_html = $purifier->purify('<a href="https://example.com/" 10="hoge">Test</a>');
echo $clean_html . "\n";
```

```
% /opt/homebrew/opt/php@8.0/bin/php -v | head -n 1
PHP 8.0.30 (cli) (built: Jun  6 2024 19:16:32) ( NTS )
% /opt/homebrew/opt/php@8.0/bin/php test-393.php
<a href="https://example.com/">Test</a>
```

```
% /opt/homebrew/opt/php@8.1/bin/php -v | head -n 1
PHP 8.1.29 (cli) (built: Jun  5 2024 05:51:57) (NTS)
% /opt/homebrew/opt/php@8.1/bin/php test-393.php
PHP Deprecated:  ctype_lower(): Argument of type int will be interpreted as string in the future in /Users/(snip)/htmlpurifier/library/HTMLPurifier/Token/Tag.php on line 47

Deprecated: ctype_lower(): Argument of type int will be interpreted as string in the future in /Users/(snip)/htmlpurifier/library/HTMLPurifier/Token/Tag.php on line 47
<a href="https://example.com/">Test</a>
```


Thank you.