### PR TITLE
fix: undefined array key warning

### DIFF
--- a/library/HTMLPurifier/EntityParser.php
+++ b/library/HTMLPurifier/EntityParser.php
@@ -116,8 +116,8 @@ class HTMLPurifier_EntityParser
     protected function entityCallback($matches)
     {
         $entity = $matches[0];
-        $hex_part = @$matches[1];
-        $dec_part = @$matches[2];
+        $hex_part = isset($matches[1]) ? $matches[1] : null;
+        $dec_part = isset($matches[2]) ? $matches[2] : null;
         $named_part = empty($matches[3]) ? (empty($matches[4]) ? "" : $matches[4]) : $matches[3];
         if ($hex_part !== NULL && $hex_part !== "") {
             return HTMLPurifier_Encoder::unichr(hexdec($hex_part));


### PR DESCRIPTION
Hello :wave: 

The following code causes the warning “Undefined array key 2”

```php
$html = "/<style>{src:'<style/onload=this.onload=confirm(1)>'/</style>';";

$purifier = new \HTMLPurifier();

$purifier->purify($html);
```

This also solves the problem reported here https://github.com/ezyang/htmlpurifier/issues/413