### PR TITLE
fix: catastrophic backtracking in Core.AggressivelyFixLt

### DIFF
--- a/tests/HTMLPurifier/Lexer/DomLexTest.php
+++ b/tests/HTMLPurifier/Lexer/DomLexTest.php
@@ -1,0 +1,40 @@
+<?php
+
+class HTMLPurifier_Lexer_DomLexTest extends HTMLPurifier_Harness
+{
+
+    protected $domLex;
+
+    public function setUp()
+    {
+        $this->domLex = new HTMLPurifier_Lexer_DOMLex();
+    }
+
+    public function testCoreAggressivelyFixLtEmojis()
+    {
+        $context = new HTMLPurifier_Context();
+        $config  = HTMLPurifier_Config::createDefault();
+        $output = $this->domLex->tokenizeHTML('<b><3</b>', $config, $context);
+
+        $this->assertIdentical($output, array(
+            new HTMLPurifier_Token_Start('b'),
+            new HTMLPurifier_Token_Text('<3'),
+            new HTMLPurifier_Token_End('b')
+        ));
+    }
+
+    public function testCoreAggressivelyFixLtComments()
+    {
+        $context = new HTMLPurifier_Context();
+        $config  = HTMLPurifier_Config::createDefault();
+        $output = $this->domLex->tokenizeHTML('<!-- Nested <!-- Not to be included --> comment -->', $config, $context);
+
+        $this->assertIdentical($output, array(
+            new HTMLPurifier_Token_Comment(' Nested <!-- Not to be included '),
+            new HTMLPurifier_Token_Text(' comment -->')
+        ));
+    }
+
+}
+
+// vim: et sw=4 sts=4


### PR DESCRIPTION
When provided with a large HTML document (over a million characters) the `Core.AggressivelyFixLt` regex results in catastrophic backtracking and `$html = null` being returned. TLDR; HTMLPurifier gives you back a `null` document...

I tried many times to produce a regex which did not suffer from catastrophic backtracking but I think it ultimately comes back to the argument of why you should not use regex to parse HTML. The only solutions I could come up with were to either:
* Increase `pcre.backtrack_limit` to a higher value
* Disable `Core.AggressivelyFixLt` but that's sub-optimal given the approach seems to work on documents of a reasonable size...
* Handle the `null` return value from `preg_replace_callback` and return `$html` (disable armor logic if a regex error occurs)

The solution in this PR uses a little algorithm which employs only standard string manipulation functions so it works incredibly fast. The algorithm searches for HTML comments and allows a callback to be ran on them.

I've not messed with the signatures of the `callbackUndoCommentSubst` and `callbackArmorCommentEntities` functions because they're `public` and might be used by other libraries.