### PR TITLE
fix: remove docker files on install

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,8 @@
 /benchmarks export-ignore
 /configdoc export-ignore
 /configdoc/usage.xml -crlf
+/docker-compose.yaml export-ignore
+/Dockerfile export-ignore
 /docs export-ignore
 /Doxyfile export-ignore
 /extras export-ignore


### PR DESCRIPTION
When installing, we probably don't want to have docker related files as these are really only a development time thing, hence one we might want to add to the gitattribute file (off the back of #424).

(would probably be noticed before the next release but why not get it done sooner rather than later)