### PR TITLE
chore: use simpletest ^1.3 instead of dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "cerdic/css-tidy": "^1.7 || ^2.0",
-        "simpletest/simpletest": "v1.3"
+        "simpletest/simpletest": "^1.3"
     },
     "autoload": {
         "psr-0": { "HTMLPurifier": "library/" },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "cerdic/css-tidy": "^1.7 || ^2.0",
-        "simpletest/simpletest": "dev-master"
+        "simpletest/simpletest": "v1.3"
     },
     "autoload": {
         "psr-0": { "HTMLPurifier": "library/" },


### PR DESCRIPTION
possible solution for simpletest errors with PHP 8.5, as dev-master is behind v1.3.0