### PR TITLE
fix: PHP 8.5 using null as an array offset is deprecated in URIScheme…

### DIFF
--- a/library/HTMLPurifier/URISchemeRegistry.php
+++ b/library/HTMLPurifier/URISchemeRegistry.php
@@ -44,6 +44,11 @@ class HTMLPurifier_URISchemeRegistry
             $config = HTMLPurifier_Config::createDefault();
         }
 
+        // Scheme cannot be null
+        if ($scheme === null) {
+            return;
+        }
+
         // important, otherwise attacker could include arbitrary file
         $allowed_schemes = $config->get('URI.AllowedSchemes');
         if (!$config->get('URI.OverrideAllowedSchemes') &&


### PR DESCRIPTION
…Registry.php