### PR TITLE
fix: handle definition cache delete races safely

### DIFF
--- a/library/HTMLPurifier/DefinitionCache/Serializer.php
+++ b/library/HTMLPurifier/DefinitionCache/Serializer.php
@@ -83,7 +83,7 @@ class HTMLPurifier_DefinitionCache_Serializer extends HTMLPurifier_DefinitionCac
         if (!file_exists($file)) {
             return false;
         }
-        return unlink($file);
+        return $this->safeUnlink($file);
     }
 
     /**
@@ -110,7 +110,7 @@ class HTMLPurifier_DefinitionCache_Serializer extends HTMLPurifier_DefinitionCac
             if ($filename[0] === '.') {
                 continue;
             }
-            unlink($dir . '/' . $filename);
+            $this->safeUnlink($dir . '/' . $filename);
         }
         closedir($dh);
         return true;
@@ -141,7 +141,7 @@ class HTMLPurifier_DefinitionCache_Serializer extends HTMLPurifier_DefinitionCac
             $key = substr($filename, 0, strlen($filename) - 4);
             $file = $dir . '/' . $filename;
             if ($this->isOld($key, $config) && file_exists($file)) {
-                unlink($file);
+                $this->safeUnlink($file);
             }
         }
         closedir($dh);
@@ -186,6 +186,31 @@ class HTMLPurifier_DefinitionCache_Serializer extends HTMLPurifier_DefinitionCac
         $base = $config->get('Cache.SerializerPath');
         $base = is_null($base) ? HTMLPURIFIER_PREFIX . '/HTMLPurifier/DefinitionCache/Serializer' : $base;
         return $base;
+    }
+
+    /**
+     * Silently handles files already deleted by another process,
+     * but still emits a warning when the file remains after unlink.
+     * @param string $file
+     * @return bool
+     */
+    private function safeUnlink($file)
+    {
+        if (!file_exists($file)) {
+            return true;
+        }
+        if (@unlink($file)) {
+            return true;
+        }
+        clearstatcache(true, $file);
+        if (!file_exists($file)) {
+            return true;
+        }
+        trigger_error(
+            'Could not delete definition cache file ' . $file,
+            E_USER_WARNING
+        );
+        return false;
     }
 
     /**

--- a/tests/HTMLPurifier/DefinitionCache/SerializerTest.php
+++ b/tests/HTMLPurifier/DefinitionCache/SerializerTest.php
@@ -167,6 +167,31 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
         $cache->flush($config1);
     }
 
+    public function testSafeUnlinkTreatsMissingFileAsSuccess()
+    {
+        $cache = new HTMLPurifier_DefinitionCache_Serializer('Test');
+
+        $this->assertTrue(
+            $this->invokeSafeUnlink(
+                $cache,
+                dirname(__FILE__) . '/SerializerTest/missing-file-' . uniqid('', true)
+            )
+        );
+    }
+
+    public function testSafeUnlinkWarnsWhenTargetStillExists()
+    {
+        $cache = new HTMLPurifier_DefinitionCache_Serializer('Test');
+
+        $dir = dirname(__FILE__) . '/SerializerTestDir-' . uniqid('', true);
+        mkdir($dir);
+
+        $this->expectError('Could not delete definition cache file ' . $dir);
+        $this->assertFalse($this->invokeSafeUnlink($cache, $dir));
+
+        rmdir($dir);
+    }
+
     /**
      * Asserts that a file exists, ignoring the stat cache
      */
@@ -237,6 +262,13 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
         $config->returns('get', 0400, array('Cache.SerializerPermissions'));
 
         $cache->cleanup($config);
+    }
+
+    private function invokeSafeUnlink($cache, $file)
+    {
+        $method = new ReflectionMethod('HTMLPurifier_DefinitionCache_Serializer', 'safeUnlink');
+        $method->setAccessible(true);
+        return $method->invoke($cache, $file);
     }
 }
 

--- a/tests/HTMLPurifier/DefinitionCache/SerializerTest.php
+++ b/tests/HTMLPurifier/DefinitionCache/SerializerTest.php
@@ -266,9 +266,11 @@ class HTMLPurifier_DefinitionCache_SerializerTest extends HTMLPurifier_Definitio
 
     private function invokeSafeUnlink($cache, $file)
     {
-        $method = new ReflectionMethod('HTMLPurifier_DefinitionCache_Serializer', 'safeUnlink');
-        $method->setAccessible(true);
-        return $method->invoke($cache, $file);
+        $callable = Closure::bind(function ($file) {
+            return $this->safeUnlink($file);
+        }, $cache, 'HTMLPurifier_DefinitionCache_Serializer');
+
+        return $callable($file);
     }
 }
 


### PR DESCRIPTION
## Summary
- route `remove()`, `flush()`, and `cleanup()` through a shared `safeUnlink()` helper
- treat files already deleted by another process as a successful cleanup
- keep emitting a warning when the file still exists after `unlink()` fails

## Background
Fixes #442.

`cleanup()` already checks `file_exists()` before calling `unlink()`, but that still leaves a small TOCTOU window when multiple processes clean the same serializer cache directory at the same time. `remove()` and `flush()` still call `unlink()` directly as well.

This change keeps the existing warning signal for real delete failures while avoiding noisy warnings when another process has already removed the cache file.

## Tests
- `php tests/index.php --file=HTMLPurifier/DefinitionCache/SerializerTest.php --txt`
