### PR TITLE
fix: Ensure correct permissions on directory

### DIFF
--- a/library/HTMLPurifier/DefinitionCache/Serializer.php
+++ b/library/HTMLPurifier/DefinitionCache/Serializer.php
@@ -246,6 +246,14 @@ class HTMLPurifier_DefinitionCache_Serializer extends HTMLPurifier_DefinitionCac
                 );
                 return false;
             }
+            // Ensure the directory has the correct permissions, since mkdir() obeys the umask of the current process.
+            if (!@chmod($directory, $chmod)) {
+                trigger_error(
+                    'Could not apply permissions to directory ' . $directory,
+                    E_USER_WARNING
+                );
+                return false;
+            }
             if (!$this->_testPermissions($directory, $chmod)) {
                 return false;
             }

--- a/library/HTMLPurifier/DefinitionCache/Serializer.php
+++ b/library/HTMLPurifier/DefinitionCache/Serializer.php
@@ -239,20 +239,17 @@ class HTMLPurifier_DefinitionCache_Serializer extends HTMLPurifier_DefinitionCac
             } elseif (!$this->_testPermissions($base, $chmod)) {
                 return false;
             }
-            if (!@mkdir($directory, $chmod) && !is_dir($directory)) {
+            $created = @mkdir($directory, $chmod);
+            if (!$created && !is_dir($directory)) {
                 trigger_error(
                     'Could not create directory ' . $directory . '',
                     E_USER_WARNING
                 );
                 return false;
             }
-            // Ensure the directory has the correct permissions, since mkdir() obeys the umask of the current process.
-            if (!@chmod($directory, $chmod)) {
-                trigger_error(
-                    'Could not apply permissions to directory ' . $directory,
-                    E_USER_WARNING
-                );
-                return false;
+            if ($created) {
+                // Ensure the directory has the correct permissions, since mkdir() obeys the umask
+                @chmod($directory, $chmod);
             }
             if (!$this->_testPermissions($directory, $chmod)) {
                 return false;


### PR DESCRIPTION
Directories are created using `mkdir()` which does obey the umask.

In our case the Apache umask is set to 022 and can't be changed, with `$chmod` set to 777 (via [caxy-htmldiff](https://github.com/caxy/php-htmldiff/blob/master/lib/Caxy/HtmlDiff/AbstractDiff.php#L143)) which results in directories with permissions 755.
We'd like the perms to be set to 775 instead, however that is impossible if the umask applies.

Is it possible to call `chmod()` after directories are created to explicitly set file permissions to the `$chmod` provided?